### PR TITLE
fix(tpl-toolkit): remove preinstall/prepare scripts for npm consumers

### DIFF
--- a/packages/tpl-toolkit/package.json
+++ b/packages/tpl-toolkit/package.json
@@ -6,9 +6,7 @@
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
-    "dist",
-    "README.md",
-    "LICENSE"
+    "dist"
   ],
   "publishConfig": {
     "access": "public"
@@ -45,16 +43,13 @@
     "test": "pnpm run vitest:run",
     "vitest:run": "vitest --passWithNoTests --run",
     "vitest:ui": "vitest --passWithNoTests --ui",
-    "commit": "pnpm exec cz",
-    "prepare": "pnpm exec husky",
-    "preinstall": "pnpm exec only-allow pnpm"
+    "commit": "pnpm exec cz"
   },
   "keywords": [],
   "author": "Roy Chuang",
   "license": "ISC",
   "engines": {
-    "node": ">=18",
-    "pnpm": ">=10.24.0 <11.0.0"
+    "node": ">=18"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.7.1",
@@ -70,7 +65,6 @@
     "eslint-config-prettier": "^10.0.1",
     "husky": "^9.1.7",
     "lint-staged": "^15.4.3",
-    "only-allow": "^1.2.2",
     "prettier": "^3.5.1",
     "rimraf": "^6.0.1",
     "ts-node": "^10.9.2",


### PR DESCRIPTION
These scripts would run during installation, blocking consumers who don't use pnpm. Keep engines.node only for maximum compatibility.