### PR TITLE
fix(ci): add ^build dependency to test task in turbo.json

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -36,6 +36,7 @@
     },
     "test": {
       "dependsOn": [
+        "^build",
         "^test"
       ]
     },


### PR DESCRIPTION
orm-app test fails because vitest coverage scans all src/ files which import @rfjs/orm-* libs, but their dist/ dirs are not built. Adding ^build ensures dependent packages are built before testing.