### PR TITLE
fix(ci): add vitest aliases for ORM libs in orm-app

### DIFF
--- a/apps/orm-app/vitest.config.mts
+++ b/apps/orm-app/vitest.config.mts
@@ -5,6 +5,10 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),
+      '@rfjs/orm-drizzle': path.resolve(__dirname, '../../libs/orm-drizzle/src/index.ts'),
+      '@rfjs/orm-kysely': path.resolve(__dirname, '../../libs/orm-kysely/src/index.ts'),
+      '@rfjs/orm-prisma': path.resolve(__dirname, '../../libs/orm-prisma/src/index.ts'),
+      '@rfjs/orm-typeorm': path.resolve(__dirname, '../../libs/orm-typeorm/src/index.ts'),
     },
   },
   test: {


### PR DESCRIPTION
Vitest coverage scans all src/ files including those importing @rfjs/orm-* libs. Since these libs point to dist/ in package.json main, coverage fails when dist/ is not built. Adding resolve aliases to point directly to lib src/ entries fixes this.