### PR TITLE
fix(ci): make main mirror-only so GitLab trigger stops 400-ing

### DIFF
--- a/.github/workflows/trigger-gitlab-pipeline.yml
+++ b/.github/workflows/trigger-gitlab-pipeline.yml
@@ -8,12 +8,20 @@ on:
       - deploy/*
       - publish/*
 
+# One in-flight run per branch so two pushes don't race the same GitLab branch
+# (force_push keeps the GitLab branch identical to GitHub).
+concurrency:
+  group: gitlab-sync-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # full history for a faithful mirror push
 
       - name: Sync to GitLab
         id: sync
@@ -24,6 +32,12 @@ jobs:
           gitlab_project_id: 5
           gitlab_ref: ${{ github.ref_name }}
           deploy_env: royfw-dev
+          # main is the mirror / single source of truth — it has no matching jobs
+          # in .gitlab-ci.yml (jobs run on release/*, publish/npmjs, deploy/*), so
+          # triggering a pipeline on main returns 400 "No stages / jobs for this
+          # pipeline". Mirror only on main; trigger + wait on the work branches.
+          trigger_pipeline: ${{ github.ref_name != 'main' }}
+          wait_for_pipeline: ${{ github.ref_name != 'main' }}
           gitlab_push_token: ${{ secrets.GITLAB_API_TOKEN }}
           gitlab_trigger_token: ${{ secrets.GITLAB_TRIGGER_TOKEN }}
           gitlab_api_token: ${{ secrets.GITLAB_API_TOKEN }}

--- a/GITLAB_CI.md
+++ b/GITLAB_CI.md
@@ -27,11 +27,14 @@ GitHub repo (royfw/rfjs)
      push to: main / release/* / deploy/* / publish/*
      └─ royfw/gitlab-sync-action@v1
           鏡像分支 → GitLab project royfw/apps/rfjs (id 5)
-          └─ 在 GitLab 跑 .gitlab-ci.yml(version / docker_build / deploy_trigger / publish)
+          ├─ main          → 只鏡像,不觸發 pipeline(mirror-only)
+          └─ 其餘工作分支  → 鏡像 + 觸發 + 等待 .gitlab-ci.yml
+                            (version / docker_build / deploy_trigger / publish)
 ```
 
 - **單一事實來源是 GitLab**。先前重複的 GitHub-native CD workflow(`cd-version-release*`、`cd-publish-npmjs`、`cd-npm-release`、`cd-deploy-dev`)已移除,避免「同一個 PR 同時被 GitHub 與 GitLab 各跑一次版本/發佈」造成雙重 commit / 雙重 publish。
 - GitHub 端只保留 `trigger-gitlab-pipeline.yml` 作為橋接。
+- **`main` 是鏡像-only**:`.gitlab-ci.yml` 的 job 只在 `release/*`、`publish/npmjs`、`deploy/*` 命中,`main` 上沒有任何 job。若對 `main` 觸發 pipeline,GitLab 會回 `400 "No stages / jobs for this pipeline"`,讓 GitHub Action 紅燈。因此 workflow 以 `trigger_pipeline: ${{ github.ref_name != 'main' }}` 對 `main` 改走 push-only,實際工作交給 release/publish/deploy 分支。
 
 ---
 


### PR DESCRIPTION
After consolidating CD onto GitLab, removing the echo job left main with no matching jobs in .gitlab-ci.yml (jobs run only on release/*, publish/npmjs, deploy/*). The sync action still POSTed /trigger/pipeline for main, so GitLab returned 400 "No stages / jobs for this pipeline" and the GitHub Action went red on every main push.

- Gate trigger_pipeline + wait_for_pipeline on `github.ref_name != 'main'` so main is mirror-only (push-only mode); work branches still trigger + wait.
- Add concurrency group + fetch-depth: 0 (canonical gitlab-sync-action wiring).
- GITLAB_CI.md: document main = mirror-only and why.