### PR TITLE
chore(ci): move changeset versioning to GitHub Actions, GitLab keeps …

### DIFF
--- a/.github/workflows/cd-version-release-prerelease.yml
+++ b/.github/workflows/cd-version-release-prerelease.yml
@@ -1,0 +1,34 @@
+name: Version (prerelease branches)
+
+on:
+  pull_request_target:
+    branches:
+      - release/alpha
+      - release/beta
+      - release/rc
+    types: [closed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  resolve:
+    runs-on: ubuntu-latest
+    outputs:
+      channel: ${{ steps.ch.outputs.channel }}
+    if: github.event.pull_request.merged == true
+    steps:
+      - id: ch
+        run: |
+          REF="${{ github.event.pull_request.base.ref }}"
+          echo "channel=${REF#release/}" >> "$GITHUB_OUTPUT"
+
+  version:
+    needs: resolve
+    uses: royfw/rf-devops/.github/workflows/_changesets-version-channel-turbo.yml@main
+    secrets:
+      GIT_TOKEN: ${{ secrets.GIT_TOKEN }}
+    with:
+      ref: ${{ github.event.pull_request.base.ref }}
+      channel: ${{ needs.resolve.outputs.channel }}

--- a/.github/workflows/cd-version-release.yml
+++ b/.github/workflows/cd-version-release.yml
@@ -1,0 +1,20 @@
+name: Version (release/stable)
+
+on:
+  pull_request_target:
+    branches: [release/stable]
+    types: [closed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  version:
+    if: github.event.pull_request.merged == true
+    uses: royfw/rf-devops/.github/workflows/_changesets-version-channel-turbo.yml@main
+    secrets:
+      GIT_TOKEN: ${{ secrets.GIT_TOKEN }}
+    with:
+      ref: release/stable
+      channel: stable

--- a/.github/workflows/trigger-gitlab-pipeline.yml
+++ b/.github/workflows/trigger-gitlab-pipeline.yml
@@ -32,12 +32,13 @@ jobs:
           gitlab_project_id: 5
           gitlab_ref: ${{ github.ref_name }}
           deploy_env: royfw-dev
-          # main is the mirror / single source of truth — it has no matching jobs
-          # in .gitlab-ci.yml (jobs run on release/*, publish/npmjs, deploy/*), so
-          # triggering a pipeline on main returns 400 "No stages / jobs for this
-          # pipeline". Mirror only on main; trigger + wait on the work branches.
-          trigger_pipeline: ${{ github.ref_name != 'main' }}
-          wait_for_pipeline: ${{ github.ref_name != 'main' }}
+          # Only publish/* and deploy/* have matching jobs in .gitlab-ci.yml.
+          # main is the mirror, and release/* is versioned by GitHub Actions
+          # (cd-version-release*.yml) — GitLab has no job for either, so triggering
+          # a pipeline there returns 400 "No stages / jobs". Mirror-only on
+          # main + release/*; trigger + wait on publish/* and deploy/*.
+          trigger_pipeline: ${{ startsWith(github.ref_name, 'publish/') || startsWith(github.ref_name, 'deploy/') }}
+          wait_for_pipeline: ${{ startsWith(github.ref_name, 'publish/') || startsWith(github.ref_name, 'deploy/') }}
           gitlab_push_token: ${{ secrets.GITLAB_API_TOKEN }}
           gitlab_trigger_token: ${{ secrets.GITLAB_TRIGGER_TOKEN }}
           gitlab_api_token: ${{ secrets.GITLAB_API_TOKEN }}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,11 +3,9 @@ include:
     ref: main
     file:
       - /gitlab-ci/build_deploy/nodejs-monorepo.yml
-      - /gitlab-ci/changesets_version_channel/pnpm.yml
       - /gitlab-ci/changesets_publish/changesets-publish.yml
 
 stages:
-  - version
   - docker_build
   - deploy_trigger
   - publish
@@ -22,27 +20,10 @@ workflow:
     - when: always
 
 # ----------------------------
-# release/*：只做 version（commit + push 回 release/*）
+# release/*：版本(changeset version)由 GitHub Actions 處理(.github/workflows/
+# cd-version-release*.yml),不在 GitLab 跑,避免 GitHub 與 GitLab 各算一次。
+# GitLab 端對 release/* 無 job;bridge 已將 release/* 設為 mirror-only。
 # ----------------------------
-version_release:
-  stage: version
-  extends: .changesets_version_channel
-  rules:
-    - if: '$CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH == "release/stable"'
-      variables:
-        CHANNEL: "stable"
-    - if: '$CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH == "release/alpha"'
-      variables:
-        CHANNEL: "alpha"
-    - if: '$CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH == "release/beta"'
-      variables:
-        CHANNEL: "beta"
-    - if: '$CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH == "release/rc"'
-      variables:
-        CHANNEL: "rc"
-  variables:
-    REF: "$CI_COMMIT_BRANCH"
-    PUSH_VERSION: "true"
 
 # ----------------------------
 # publish/npmjs：只做 npm publish（不再改 repo）

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,21 +112,21 @@ The `apps/api/` follows a layered Fastify architecture:
 
 ## CI/CD
 
-Deploy and npm publish run on **GitLab CI** (`.gitlab-ci.yml`, shared DevOps toolkit). The repo lives on GitHub; `.github/workflows/trigger-gitlab-pipeline.yml` mirrors `main`, `release/*`, `deploy/*`, and `publish/*` pushes to the GitLab project and runs the pipeline there. (The previous GitHub-native CD workflows were retired to avoid double versioning/publishing — GitLab is the single source of truth.)
+CI/CD is split by responsibility: **GitHub Actions owns versioning**, **GitLab CI owns npm publish + Kubernetes deploy**. The repo lives on GitHub; `.github/workflows/trigger-gitlab-pipeline.yml` mirrors `main`, `release/*`, `deploy/*`, and `publish/*` to the GitLab project, but only **triggers** the GitLab pipeline for `publish/*` and `deploy/*` (mirror-only on `main` and `release/*`, which have no GitLab jobs).
 
-- **Deploy branch**: `deploy/dev` runs build + Kubernetes deploy (`detect_project` / `trigger_project`). `deploy/prod` is not wired yet, and per-service Helm overlays under `.deploy/env/royfw-dev/helm/` are still pending (apps build to Harbor but `[skip-deploy]` until overlays exist).
-- **Release branches**: `release/stable` (stable channel) and `release/alpha|beta|rc` (prerelease channels) run changeset versioning and push the bump back.
-- **Publish**: `publish/npmjs` (manual gate) publishes the bumped packages to npm.
+- **Release branches (GitHub Actions)**: merging a PR into `release/stable` or `release/alpha|beta|rc` runs `cd-version-release.yml` / `cd-version-release-prerelease.yml`, which call `royfw/rf-devops/.github/workflows/_changesets-version-channel-turbo.yml` to run changeset versioning, push the bump back to the release branch, and open a PR back to `main`. (rf-devops is being migrated into `github-toolkit`; the caller will repoint once ported.)
+- **Publish (GitLab)**: `publish/npmjs` (manual gate) runs `changeset publish` to npm and pushes git tags.
+- **Deploy branch (GitLab)**: `deploy/dev` runs build + Kubernetes deploy (`detect_project` / `trigger_project`). `deploy/prod` is not wired yet, and per-service Helm overlays under `.deploy/env/royfw-dev/helm/` are still pending (apps build to Harbor but `[skip-deploy]` until overlays exist).
 
 See `GITLAB_CI.md` for the full CI variable, environment, and flow reference.
 
 ## Versioning and Changesets
 
 - Uses **Changesets** for version management (`pnpm changeset:add` to create a changeset)
-- Not in pre-release mode (no `.changeset/pre.json`); `release/stable` publishes stable versions. Prerelease channels are entered per-branch by the `release/alpha|beta|rc` pipeline.
+- Not in pre-release mode (no `.changeset/pre.json`); `release/stable` produces stable versions. Prerelease channels are entered per-branch by the `release/alpha|beta|rc` versioning workflow.
 - `@rfjs/jsonb-query` is held back from publish via the changeset `ignore` list in `.changeset/config.json` until its Phase 2 (object/array) support lands.
 - Changelog: `@changesets/cli/changelog`
-- Release workflow: `pnpm changeset:add` → commit → merge to `release/*` (version) → merge to `publish/npmjs` (publish)
+- Release workflow: `pnpm changeset:add` → commit to `main` → PR `main → release/*` and merge (GitHub Actions versions, opens a PR back to `main`) → merge the versioned state to `publish/npmjs` (GitLab publishes to npm)
 
 ## Git Hooks
 

--- a/GITLAB_CI.md
+++ b/GITLAB_CI.md
@@ -23,18 +23,24 @@
 
 ```
 GitHub repo (royfw/rfjs)
-└─ .github/workflows/trigger-gitlab-pipeline.yml
+├─ .github/workflows/cd-version-release*.yml   ← 版本(changeset version)在 GitHub Actions 算
+│     PR merged → release/stable|alpha|beta|rc
+│     └─ uses royfw/rf-devops/.github/workflows/_changesets-version-channel-turbo.yml
+│          → changeset version、push 回 release/*、開 PR 回 main
+└─ .github/workflows/trigger-gitlab-pipeline.yml   ← 橋接
      push to: main / release/* / deploy/* / publish/*
      └─ royfw/gitlab-sync-action@v1
           鏡像分支 → GitLab project royfw/apps/rfjs (id 5)
-          ├─ main          → 只鏡像,不觸發 pipeline(mirror-only)
-          └─ 其餘工作分支  → 鏡像 + 觸發 + 等待 .gitlab-ci.yml
-                            (version / docker_build / deploy_trigger / publish)
+          ├─ main / release/*   → 只鏡像,不觸發 pipeline(mirror-only)
+          └─ publish/* / deploy/* → 鏡像 + 觸發 + 等待 .gitlab-ci.yml
+                                   (publish / docker_build / deploy_trigger)
 ```
 
-- **單一事實來源是 GitLab**。先前重複的 GitHub-native CD workflow(`cd-version-release*`、`cd-publish-npmjs`、`cd-npm-release`、`cd-deploy-dev`)已移除,避免「同一個 PR 同時被 GitHub 與 GitLab 各跑一次版本/發佈」造成雙重 commit / 雙重 publish。
-- GitHub 端只保留 `trigger-gitlab-pipeline.yml` 作為橋接。
-- **`main` 是鏡像-only**:`.gitlab-ci.yml` 的 job 只在 `release/*`、`publish/npmjs`、`deploy/*` 命中,`main` 上沒有任何 job。若對 `main` 觸發 pipeline,GitLab 會回 `400 "No stages / jobs for this pipeline"`,讓 GitHub Action 紅燈。因此 workflow 以 `trigger_pipeline: ${{ github.ref_name != 'main' }}` 對 `main` 改走 push-only,實際工作交給 release/publish/deploy 分支。
+- **責任分工:GitHub 管 version,GitLab 管 publish + deploy。**
+  - **版本**在 GitHub Actions 算(merge 進 `release/*` 觸發),版本 commit 直接落在 GitHub、並自動開 PR 回 `main` —— 不需要把 commit 從 GitLab 同步回 GitHub。
+  - **npm publish 與 K8s deploy**留在 GitLab(需要 `NPM_TOKEN` / `KUBECONFIG` 等 secret)。
+- **mirror-only 分支**:`.gitlab-ci.yml` 的 job 只在 `publish/npmjs`、`deploy/dev` 命中;`main` 與 `release/*` 在 GitLab 沒有任何 job。若對它們觸發 pipeline,GitLab 會回 `400 "No stages / jobs"` 讓 Action 紅燈。因此 bridge 以 `trigger_pipeline: ${{ startsWith(ref,'publish/') || startsWith(ref,'deploy/') }}` 只對 publish/deploy 觸發,其餘 push-only。
+- rf-devops 正搬遷進 `github-toolkit`;version caller 之後會 repoint 到 github-toolkit。
 
 ---
 
@@ -42,31 +48,31 @@ GitHub repo (royfw/rfjs)
 
 | Job | Stage | 觸發分支 | 動作 |
 |-----|-------|----------|------|
-| `version_release` | `version` | `release/stable\|alpha\|beta\|rc`(push) | `changeset version`,依分支設定 `CHANNEL`,`PUSH_VERSION=true` 把版本 commit 推回 release 分支 |
 | `publish_npmjs` | `publish` | `publish/npmjs`(push,**manual** 手動觸發) | `changeset publish` 發佈到 npm,`PUSH_TAGS=true`,`CHANNEL=auto`(由來源分支推導) |
 | `detect_project` | `deploy_trigger` | `deploy/dev` | 偵測異動 app、build image 推 Harbor、產生動態 child pipeline |
 | `trigger_project` | `deploy_trigger` | `deploy/dev` | 觸發動態 child pipeline,執行 Helm 部署 |
 
+> 版本(`changeset version`)**不在 GitLab**;由 GitHub Actions `cd-version-release*.yml` 處理(見第 2 節)。
 > `docker_build` stage 由 devops-toolkit 的動態 child pipeline 使用。
 
 ---
 
 ## 4. npm 發佈流程(主要工作流程)
 
-發佈是**兩段式**:先在 `release/*` 算版本,再到 `publish/npmjs` 實際 publish。
+發佈是**兩段式**:先在 `release/*` 算版本(GitHub),再到 `publish/npmjs` 實際 publish(GitLab)。
 
 ```
 1. 建立 changeset
    pnpm changeset:add        # 選套件 + bump 等級,commit 進 main
 
-2. 版本(version)
-   merge → release/stable    # 正式版
-   或 merge → release/alpha|beta|rc   # 預發版
-   → GitLab version_release:跑 changeset version、產生 CHANGELOG、把版本 commit 推回該 release 分支
+2. 版本(version)— GitHub Actions
+   開 PR: main → release/stable(正式版)或 release/alpha|beta|rc(預發),merge
+   → cd-version-release*.yml 跑 changeset version、產生 CHANGELOG、
+     push 版本 commit 回該 release 分支,並自動開 PR 回 main(merge 後 main 同步版本)
 
-3. 發佈(publish)
-   merge → publish/npmjs
-   → GitLab publish_npmjs(手動點擊執行)→ changeset publish 到 npm + 推 git tag
+3. 發佈(publish)— GitLab
+   把版本化後的狀態 merge/push → publish/npmjs
+   → GitLab publish_npmjs(手動 ▶ 執行)→ changeset publish 到 npm + 推 git tag
 ```
 
 ### 目前發佈集合(`pnpm changeset:status`)


### PR DESCRIPTION
…publish

Split CI responsibility: GitHub Actions owns versioning, GitLab owns npm publish + k8s deploy. This puts the version commit directly on GitHub (the source of truth) and auto-opens a PR back to main, instead of leaving it stranded on GitLab's release/* with no way to sync back.

- Restore cd-version-release.yml (stable) + cd-version-release-prerelease.yml (alpha|beta|rc), calling rf-devops/_changesets-version-channel-turbo.yml on PR-merge into release/*. (rf-devops is migrating into github-toolkit; the caller will repoint once ported.)
- .gitlab-ci.yml: drop version_release job, the version stage, and the changesets_version_channel include. GitLab now runs only publish_npmjs + detect/trigger.
- trigger-gitlab-pipeline.yml: gate trigger to publish/* + deploy/* only; main AND release/* are mirror-only (no GitLab jobs → would 400 on trigger).
- CLAUDE.md / GITLAB_CI.md: document the GitHub-version / GitLab-publish split.