### PR TITLE
feat(ci): move npm publish from GitLab to GitHub Actions

### DIFF
--- a/.github/workflows/cd-publish-npmjs.yml
+++ b/.github/workflows/cd-publish-npmjs.yml
@@ -1,0 +1,72 @@
+name: CD NPM Publish
+
+# Publish bumped @rfjs/* packages to npm from a versioned branch (default
+# publish/npmjs). Manual gate: trigger from the Actions tab → "Run workflow".
+#
+# Why GitHub (not GitLab): the devops-toolkit GitLab publish job guards on
+# `changeset status`, which reports nothing once `changeset version` has consumed
+# the changesets — so a versioned branch is wrongly treated as "no releases".
+# Plain `changeset publish` has no such guard: it publishes every public package
+# whose package.json version is not yet on npm, and skips private ones. Versioning
+# happens on release/* (cd-version-release*.yml); this only publishes.
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Branch to publish from (must carry the bumped versions)
+        type: string
+        default: publish/npmjs
+      channel:
+        description: dist-tag — stable publishes latest; others publish under that tag
+        type: choice
+        options: [stable, alpha, beta, rc]
+        default: stable
+
+permissions:
+  contents: write # push the git tags changeset publish creates
+
+concurrency:
+  group: npm-publish
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout ${{ inputs.ref }}
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.ref }}
+          token: ${{ secrets.GIT_TOKEN }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          registry-url: https://registry.npmjs.org
+
+      - name: Install deps
+        run: pnpm install --frozen-lockfile
+
+      - name: Build packages
+        run: pnpm build:packages
+
+      - name: Publish to npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ "${{ inputs.channel }}" = "stable" ]; then
+            pnpm changeset publish
+          else
+            pnpm changeset publish --tag "${{ inputs.channel }}"
+          fi
+
+      - name: Push git tags
+        run: git push origin --tags

--- a/.github/workflows/trigger-gitlab-pipeline.yml
+++ b/.github/workflows/trigger-gitlab-pipeline.yml
@@ -6,7 +6,6 @@ on:
       - main
       - release/*
       - deploy/*
-      - publish/*
 
 # One in-flight run per branch so two pushes don't race the same GitLab branch
 # (force_push keeps the GitLab branch identical to GitHub).
@@ -32,13 +31,12 @@ jobs:
           gitlab_project_id: 5
           gitlab_ref: ${{ github.ref_name }}
           deploy_env: royfw-dev
-          # Only publish/* and deploy/* have matching jobs in .gitlab-ci.yml.
-          # main is the mirror, and release/* is versioned by GitHub Actions
-          # (cd-version-release*.yml) — GitLab has no job for either, so triggering
-          # a pipeline there returns 400 "No stages / jobs". Mirror-only on
-          # main + release/*; trigger + wait on publish/* and deploy/*.
-          trigger_pipeline: ${{ startsWith(github.ref_name, 'publish/') || startsWith(github.ref_name, 'deploy/') }}
-          wait_for_pipeline: ${{ startsWith(github.ref_name, 'publish/') || startsWith(github.ref_name, 'deploy/') }}
+          # GitLab only runs deploy (deploy/dev) now — versioning and npm publish
+          # both moved to GitHub Actions (cd-version-release*.yml / cd-publish-npmjs.yml).
+          # So only deploy/* triggers a GitLab pipeline; main + release/* are
+          # mirror-only (GitLab has no job for them → triggering would 400).
+          trigger_pipeline: ${{ startsWith(github.ref_name, 'deploy/') }}
+          wait_for_pipeline: ${{ startsWith(github.ref_name, 'deploy/') }}
           gitlab_push_token: ${{ secrets.GITLAB_API_TOKEN }}
           gitlab_trigger_token: ${{ secrets.GITLAB_TRIGGER_TOKEN }}
           gitlab_api_token: ${{ secrets.GITLAB_API_TOKEN }}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,43 +3,23 @@ include:
     ref: main
     file:
       - /gitlab-ci/build_deploy/nodejs-monorepo.yml
-      - /gitlab-ci/changesets_publish/changesets-publish.yml
 
 stages:
   - docker_build
   - deploy_trigger
-  - publish
 
 workflow:
   rules:
-    # 讓 publish/npmjs 分支不受 [skip ci] 影響（避免 merge 時被跳）
-    - if: '$CI_COMMIT_BRANCH == "publish/npmjs"'
-      when: always
     - if: '$CI_COMMIT_MESSAGE =~ /(\[skip ci\]|\[ci skip\])/i'
       when: never
     - when: always
 
 # ----------------------------
-# release/*：版本(changeset version)由 GitHub Actions 處理(.github/workflows/
-# cd-version-release*.yml),不在 GitLab 跑,避免 GitHub 與 GitLab 各算一次。
-# GitLab 端對 release/* 無 job;bridge 已將 release/* 設為 mirror-only。
+# 版本(release/*)與 npm 發佈(publish/npmjs)都由 GitHub Actions 處理:
+#   - cd-version-release*.yml  → changeset version
+#   - cd-publish-npmjs.yml     → changeset publish
+# GitLab 只負責 deploy(deploy/dev)。bridge 只對 deploy/* 觸發,其餘 mirror-only。
 # ----------------------------
-
-# ----------------------------
-# publish/npmjs：只做 npm publish（不再改 repo）
-# ----------------------------
-publish_npmjs:
-  stage: publish
-  extends: .changesets_publish
-  rules:
-    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
-      when: never
-    - if: '$CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH == "publish/npmjs"'
-      when: manual
-      allow_failure: false
-  variables:
-    CHANNEL: "auto" # ✅ 讓 toolkit 自動從 MR 來源分支推導 stable/alpha/beta/rc
-    PUSH_TAGS: "true"
 
 # 1. 執行偵測：產出 dynamic-apps-pipeline.yml
 detect_project:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,10 +112,10 @@ The `apps/api/` follows a layered Fastify architecture:
 
 ## CI/CD
 
-CI/CD is split by responsibility: **GitHub Actions owns versioning**, **GitLab CI owns npm publish + Kubernetes deploy**. The repo lives on GitHub; `.github/workflows/trigger-gitlab-pipeline.yml` mirrors `main`, `release/*`, `deploy/*`, and `publish/*` to the GitLab project, but only **triggers** the GitLab pipeline for `publish/*` and `deploy/*` (mirror-only on `main` and `release/*`, which have no GitLab jobs).
+CI/CD is split by responsibility: **GitHub Actions owns versioning + npm publish**, **GitLab CI owns only Kubernetes deploy**. The repo lives on GitHub; `.github/workflows/trigger-gitlab-pipeline.yml` mirrors `main`, `release/*`, and `deploy/*` to the GitLab project, but only **triggers** the GitLab pipeline for `deploy/*` (mirror-only on `main` and `release/*`, which have no GitLab jobs).
 
 - **Release branches (GitHub Actions)**: merging a PR into `release/stable` or `release/alpha|beta|rc` runs `cd-version-release.yml` / `cd-version-release-prerelease.yml`, which call `royfw/rf-devops/.github/workflows/_changesets-version-channel-turbo.yml` to run changeset versioning, push the bump back to the release branch, and open a PR back to `main`. (rf-devops is being migrated into `github-toolkit`; the caller will repoint once ported.)
-- **Publish (GitLab)**: `publish/npmjs` (manual gate) runs `changeset publish` to npm and pushes git tags.
+- **Publish (GitHub Actions)**: `cd-publish-npmjs.yml` is a manual `workflow_dispatch` (Actions tab → Run workflow). It checks out the versioned branch (default `publish/npmjs`) and runs plain `changeset publish` — which publishes every public package whose version isn't yet on npm and skips private ones. (GitLab's toolkit publish guards on `changeset status`, which wrongly reports "no releases" once versioning has consumed the changesets — so publish lives on GitHub instead. `@rfjs/jsonb-query` is held back via `"private": true`, the only thing `changeset publish` honors.)
 - **Deploy branch (GitLab)**: `deploy/dev` runs build + Kubernetes deploy (`detect_project` / `trigger_project`). `deploy/prod` is not wired yet, and per-service Helm overlays under `.deploy/env/royfw-dev/helm/` are still pending (apps build to Harbor but `[skip-deploy]` until overlays exist).
 
 See `GITLAB_CI.md` for the full CI variable, environment, and flow reference.

--- a/GITLAB_CI.md
+++ b/GITLAB_CI.md
@@ -1,6 +1,6 @@
 # GITLAB_CI.md — 部署與發佈設定參考
 
-本檔說明 **rfjs** monorepo 的 CI/CD 設定:程式碼在 GitHub,部署與 npm 發佈都跑在 **GitLab CI**(透過鏡像橋接)。內容對應 `.gitlab-ci.yml` 與 `.github/workflows/trigger-gitlab-pipeline.yml` 的現況。
+本檔說明 **rfjs** monorepo 的 CI/CD 設定:程式碼在 GitHub,**版本與 npm 發佈跑在 GitHub Actions**,**K8s 部署跑在 GitLab CI**(透過鏡像橋接)。內容對應 `.github/workflows/*` 與 `.gitlab-ci.yml` 的現況。
 
 > 權威來源:devops-toolkit `docs/devops-configure/`(`deploy-toolkit-reference.md`、`github-sync-reference.md`)。
 
@@ -14,7 +14,7 @@
 | 套件管理 | `pnpm@10.24.0` |
 | Build tool | Turbo(`turbo build`) |
 | 部署目標 | Kubernetes(GitLab + devops-toolkit `nodejs-monorepo.yml`) |
-| npm 發佈 | Changesets(`changesets_version_channel` + `changesets_publish`) |
+| 版本 / npm 發佈 | Changesets,跑在 GitHub Actions(`cd-version-release*.yml` / `cd-publish-npmjs.yml`) |
 | 主要產出 | `packages/@rfjs/*` 發佈到 npm;`apps/api`、`apps/orm-app` 可部署到 K8s |
 
 ---
@@ -23,23 +23,26 @@
 
 ```
 GitHub repo (royfw/rfjs)
-├─ .github/workflows/cd-version-release*.yml   ← 版本(changeset version)在 GitHub Actions 算
+├─ .github/workflows/cd-version-release*.yml   ← 版本(changeset version)
 │     PR merged → release/stable|alpha|beta|rc
 │     └─ uses royfw/rf-devops/.github/workflows/_changesets-version-channel-turbo.yml
 │          → changeset version、push 回 release/*、開 PR 回 main
-└─ .github/workflows/trigger-gitlab-pipeline.yml   ← 橋接
-     push to: main / release/* / deploy/* / publish/*
+├─ .github/workflows/cd-publish-npmjs.yml      ← npm 發佈(手動 workflow_dispatch)
+│     Run workflow(ref=publish/npmjs)→ changeset publish → npm + tag
+└─ .github/workflows/trigger-gitlab-pipeline.yml   ← 橋接(只為了 deploy)
+     push to: main / release/* / deploy/*
      └─ royfw/gitlab-sync-action@v1
           鏡像分支 → GitLab project royfw/apps/rfjs (id 5)
           ├─ main / release/*   → 只鏡像,不觸發 pipeline(mirror-only)
-          └─ publish/* / deploy/* → 鏡像 + 觸發 + 等待 .gitlab-ci.yml
-                                   (publish / docker_build / deploy_trigger)
+          └─ deploy/*           → 鏡像 + 觸發 + 等待 .gitlab-ci.yml
+                                   (docker_build / deploy_trigger)
 ```
 
-- **責任分工:GitHub 管 version,GitLab 管 publish + deploy。**
-  - **版本**在 GitHub Actions 算(merge 進 `release/*` 觸發),版本 commit 直接落在 GitHub、並自動開 PR 回 `main` —— 不需要把 commit 從 GitLab 同步回 GitHub。
-  - **npm publish 與 K8s deploy**留在 GitLab(需要 `NPM_TOKEN` / `KUBECONFIG` 等 secret)。
-- **mirror-only 分支**:`.gitlab-ci.yml` 的 job 只在 `publish/npmjs`、`deploy/dev` 命中;`main` 與 `release/*` 在 GitLab 沒有任何 job。若對它們觸發 pipeline,GitLab 會回 `400 "No stages / jobs"` 讓 Action 紅燈。因此 bridge 以 `trigger_pipeline: ${{ startsWith(ref,'publish/') || startsWith(ref,'deploy/') }}` 只對 publish/deploy 觸發,其餘 push-only。
+- **責任分工:GitHub 管 version + npm publish,GitLab 只管 K8s deploy。**
+  - **版本**在 GitHub Actions 算(merge 進 `release/*` 觸發),版本 commit 直接落在 GitHub、並自動開 PR 回 `main`。
+  - **npm publish** 在 GitHub Actions(`cd-publish-npmjs.yml`,手動 `workflow_dispatch`)。改放 GitHub 的原因見第 4 節。
+  - **K8s deploy** 留在 GitLab(需要 `KUBECONFIG`)。
+- **mirror-only 分支**:`.gitlab-ci.yml` 只剩 `deploy/dev` 有 job;`main` 與 `release/*` 在 GitLab 沒有任何 job(觸發會回 `400 "No stages / jobs"`)。因此 bridge 以 `trigger_pipeline: ${{ startsWith(ref,'deploy/') }}` 只對 deploy 觸發,其餘 mirror-only。publish 不再經過 GitLab。
 - rf-devops 正搬遷進 `github-toolkit`;version caller 之後會 repoint 到 github-toolkit。
 
 ---
@@ -48,7 +51,6 @@ GitHub repo (royfw/rfjs)
 
 | Job | Stage | 觸發分支 | 動作 |
 |-----|-------|----------|------|
-| `publish_npmjs` | `publish` | `publish/npmjs`(push,**manual** 手動觸發) | `changeset publish` 發佈到 npm,`PUSH_TAGS=true`,`CHANNEL=auto`(由來源分支推導) |
 | `detect_project` | `deploy_trigger` | `deploy/dev` | 偵測異動 app、build image 推 Harbor、產生動態 child pipeline |
 | `trigger_project` | `deploy_trigger` | `deploy/dev` | 觸發動態 child pipeline,執行 Helm 部署 |
 
@@ -59,7 +61,9 @@ GitHub repo (royfw/rfjs)
 
 ## 4. npm 發佈流程(主要工作流程)
 
-發佈是**兩段式**:先在 `release/*` 算版本(GitHub),再到 `publish/npmjs` 實際 publish(GitLab)。
+版本與發佈**都在 GitHub Actions**:先在 `release/*` 算版本,再用 `publish/npmjs` 發佈。
+
+> **為什麼 publish 在 GitHub 不在 GitLab**:devops-toolkit 的 GitLab publish job 用 `changeset status` 當守門員,但 `changeset version` 跑完會消耗 changeset,導致 `changeset status` 在已版本化的分支回報「沒有 release」→ 跳過發佈。原生 `changeset publish` 沒有這個守門員(它比對 package.json 版本 vs npm),所以 publish 改用 GitHub Actions 的 `cd-publish-npmjs.yml`。`@rfjs/jsonb-query` 以 `"private": true` hold 住(這是 `changeset publish` 唯一認的排除方式;`ignore` 擋不住 publish)。
 
 ```
 1. 建立 changeset
@@ -70,9 +74,10 @@ GitHub repo (royfw/rfjs)
    → cd-version-release*.yml 跑 changeset version、產生 CHANGELOG、
      push 版本 commit 回該 release 分支,並自動開 PR 回 main(merge 後 main 同步版本)
 
-3. 發佈(publish)— GitLab
+3. 發佈(publish)— GitHub Actions
    把版本化後的狀態 merge/push → publish/npmjs
-   → GitLab publish_npmjs(手動 ▶ 執行)→ changeset publish 到 npm + 推 git tag
+   → Actions 分頁 → "CD NPM Publish" → Run workflow(ref 預設 publish/npmjs、channel 預設 stable)
+   → changeset publish 到 npm + 推 git tag 回 GitHub
 ```
 
 ### 目前發佈集合(`pnpm changeset:status`)
@@ -117,22 +122,21 @@ merge → deploy/dev
 | `ROYFW_KUBECONFIG` | file / variable | — | K8s kubeconfig(`detect/trigger` 使用) | `.gitlab-ci.yml` 明確引用 |
 | `HARBOR_TOKEN` | variable | yes | Harbor registry 推 image | toolkit 需要 |
 | `DEVOPS_CI_REPO_TOKEN` | variable | yes | clone `shared/devops-toolkit` 的 GitLab OAuth token | toolkit 需要 |
-| `NPM_TOKEN` | variable | yes | npm publish 認證(`publish_npmjs`) | toolkit 需要 |
-| git push token | variable | yes | version_release `PUSH_VERSION` / publish `PUSH_TAGS` 推回 repo 用 | 確認 devops-toolkit 實際變數名 |
+
 
 > 後三項的確切變數名以 devops-toolkit 模板為準;若 pipeline 報認證/權限錯,優先檢查這幾個。
 
 ---
 
-## 7. GitHub Secrets(橋接用,在 GitHub > Settings > Secrets)
+## 7. GitHub Secrets(在 GitHub > Settings > Secrets)
 
-`trigger-gitlab-pipeline.yml` 需要:
-
-| Secret | 用途 |
-|--------|------|
-| `GITLAB_PUSH_HOST` | GitLab 推送 host |
-| `GITLAB_API_TOKEN` | 鏡像 push + 讀 pipeline 狀態 |
-| `GITLAB_TRIGGER_TOKEN` | 觸發 GitLab pipeline |
+| Secret | 用途 | 被誰用 |
+|--------|------|--------|
+| `GIT_TOKEN` | checkout / push 版本 commit / 推 tag / 開 PR(PAT,需能 push `release/*`) | `cd-version-release*.yml`、`cd-publish-npmjs.yml` |
+| `NPM_TOKEN` | npm publish 認證(對 `@rfjs` scope 有發佈權) | `cd-publish-npmjs.yml` |
+| `GITLAB_PUSH_HOST` | GitLab 推送 host | `trigger-gitlab-pipeline.yml` |
+| `GITLAB_API_TOKEN` | 鏡像 push + 讀 pipeline 狀態 | `trigger-gitlab-pipeline.yml` |
+| `GITLAB_TRIGGER_TOKEN` | 觸發 GitLab pipeline | `trigger-gitlab-pipeline.yml` |
 
 ---
 
@@ -158,7 +162,7 @@ merge → deploy/dev
 
 | 想改什麼 | 改哪裡 |
 |----------|--------|
-| 加新套件到發佈 | `pnpm changeset:add` → merge `release/*` → merge `publish/npmjs` |
+| 加新套件到發佈 | `pnpm changeset:add` → merge `release/*`(GitHub 算版本)→ merge `publish/npmjs` → Run workflow 「CD NPM Publish」 |
 | 暫不發佈某套件 | `.changeset/config.json` 的 `ignore` |
 | 改 replica / resources / ingress | `.deploy/env/{ENV}/helm/{service}.yaml`(待建立) |
 | 加 secrets | `.deploy/env/{ENV}/env_files/secret.env.files` + GitLab CI Variables |
@@ -172,7 +176,9 @@ merge → deploy/dev
 
 | 症狀 | 原因 | 處理 |
 |------|------|------|
-| npm publish 報 `version already exists` | 版本已發過,或仍有殘留的重複發佈路徑 | 確認 GitHub-native CD 已移除;只用 GitLab `publish_npmjs` |
+| npm publish 報 `version already exists` | 版本已發過 | `changeset publish` 會自動跳過已存在版本;通常無害。若要重發需 bump 版本 |
+| `CD NPM Publish` 報 `ENEEDAUTH` / `401` | GitHub 缺 `NPM_TOKEN` 或無 `@rfjs` 發佈權 | 在 GitHub Settings → Secrets 設定 `NPM_TOKEN` |
+| `CD NPM Publish` 顯示沒發任何套件 | 該分支版本與 npm 上相同(無未發版本) | 確認 `publish/npmjs` 帶的是版本化後的狀態(`release/*` 已算過版本) |
 | `CreateContainerConfigError` | Secret 不存在 | 檢查 `.deploy/env/{ENV}/env_files/` 設定 |
 | `ImagePullBackOff` / `denied` | Harbor token 錯、image 未建、namespace 缺 pull secret | 檢查 `HARBOR_TOKEN`、確認 build 成功、`imagePullSecrets` 對齊 |
 | Helm upgrade 失敗 | kubeconfig 失效 | 檢查 `ROYFW_KUBECONFIG` |


### PR DESCRIPTION
The devops-toolkit GitLab publish job guards on `changeset status`, which reports no releases once `changeset version` has consumed the changesets — so a versioned publish branch was wrongly treated as "nothing to publish" (job succeeded, 0 published). The team's working publish path already lives on GitHub (rf-devops uses a git-diff release plan). Move publish there with a self-contained workflow using plain `changeset publish` (no broken guard; publishes any public package whose version isn't on npm, skips private ones).

- Add cd-publish-npmjs.yml: manual workflow_dispatch, checks out publish/npmjs, builds, `changeset publish` (--tag for non-stable channels), pushes tags.
- .gitlab-ci.yml: drop publish_npmjs job, the publish stage, the changesets_publish include, and the publish/npmjs workflow rule. GitLab now runs only the deploy jobs.
- trigger-gitlab-pipeline.yml: drop publish/* from the branch list and gate the trigger to deploy/* only (main + release/* stay mirror-only).
- CLAUDE.md / GITLAB_CI.md: document GitHub = version + publish, GitLab = deploy.

Note: jsonb-query stays held back via "private": true (set on publish/npmjs) — changeset publish honors `private`, not the changesets `ignore` list.