### PR TITLE
feat(jsonb-query): phase 2 - object/array/elemmatch, nor/not, named params, e2e

### DIFF
--- a/.github/workflows/ci-e2e-jsonb-query.yml
+++ b/.github/workflows/ci-e2e-jsonb-query.yml
@@ -1,0 +1,77 @@
+name: CI E2E jsonb-query
+
+# Runs the @rfjs/jsonb-query E2E suite against real PostgreSQL service
+# containers: 11.16 (production target — legacy dialect only, jsonpath
+# auto-skips) and 16 (both dialects). Version gating happens inside the spec
+# via server_version_num.
+#
+# Path-filtered: only runs when the package (or this workflow) changes, so it
+# never adds time to release/deploy pipelines. Local equivalent:
+#   pnpm -F @rfjs/jsonb-query test:e2e   (packages/jsonb-query/scripts/e2e.sh)
+
+on:
+  pull_request:
+    paths:
+      - 'packages/jsonb-query/**'
+      - '.github/workflows/ci-e2e-jsonb-query.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'packages/jsonb-query/**'
+      - '.github/workflows/ci-e2e-jsonb-query.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: e2e-jsonb-query-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    services:
+      pg11:
+        image: postgres:11.16
+        env:
+          POSTGRES_PASSWORD: e2e
+        ports:
+          - 54311:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 12
+      pg16:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_PASSWORD: e2e
+        ports:
+          - 54316:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 12
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install deps
+        run: pnpm install --frozen-lockfile
+
+      - name: Run unit tests
+        run: pnpm -F @rfjs/jsonb-query vitest:run
+
+      - name: Run E2E (PG 11.16 + PG 16)
+        env:
+          PG_E2E_URLS: postgres://postgres:e2e@localhost:54311/postgres,postgres://postgres:e2e@localhost:54316/postgres
+        run: pnpm -F @rfjs/jsonb-query vitest:e2e:run

--- a/docs/superpowers/plans/2026-06-05-jsonb-query-phase2.md
+++ b/docs/superpowers/plans/2026-06-05-jsonb-query-phase2.md
@@ -1,0 +1,2199 @@
+# @rfjs/jsonb-query Phase 2 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add nested-object, JSON-array, and array-of-objects query support to `buildJsonbQuery` in both dialects (legacy + jsonpath), fully parameterized, with spec coverage and README updates.
+
+**Architecture:** Phase 2 extends the existing condition union with three new condition kinds (`object`, `array` of scalars, `array` of objects / `elemmatch`). Array queries are rendered as self-contained `EXISTS (...)` subqueries in the WHERE clause (legacy) or as `[*]`-filtered jsonpath predicates (jsonpath) — the reserved `from: string[]` result field stays `[]` because EXISTS composes correctly with `or` logic where lateral FROM fragments would not. Object conditions render identical SQL in both dialects (`#>` / `@>`), because SQL/JSON path predicates cannot compare non-scalar values.
+
+**Tech Stack:** TypeScript 5.7, Vitest 3, tsdown, pnpm workspace (Turborepo). No runtime dependencies.
+
+---
+
+## Context: current state (Phase 1, must not break)
+
+Package: `packages/jsonb-query` (`@rfjs/jsonb-query`). Baseline: **6 spec files, 45 tests, all green** (`pnpm -F @rfjs/jsonb-query vitest:run`).
+
+| File | Responsibility |
+|---|---|
+| `src/types.ts` | Metadata types (`JsonbCondition`, `JsonbFilterGroup`, …) |
+| `src/build.ts` | `buildJsonbQuery` — group walker, dialect dispatch |
+| `src/param-builder.ts` | `$n` placeholder allocation (`ParamBuilder`) |
+| `src/column.ts` | Column identifier validation/quoting |
+| `src/escape.ts` | jsonpath string + regex-literal escaping |
+| `src/dialect.ts` | `ScalarDialect` interface, `fieldSegments`, value asserts, operator-per-type validation |
+| `src/dialect-legacy.ts` | `#>>` + casts dialect |
+| `src/dialect-jsonpath.ts` | `jsonb_path_exists` dialect (path + vars both parameterized) |
+
+Key Phase 1 invariants that must hold after every task:
+1. All existing spec expectations stay **byte-identical** (SQL strings unchanged).
+2. Values and field paths are always parameterized; only validated/quoted identifiers and generated aliases appear in SQL text.
+3. `paramOffset` produces contiguous global numbering.
+4. Empty groups render to `''` and are dropped.
+
+## Phase 2 API design
+
+### New metadata shapes
+
+```typescript
+// 1. Nested object (dot paths already work for scalars; this adds object-valued ops)
+{ field: 'profile', dataType: 'object', operator: 'contains', value: { vip: true } }
+// operators: eq | neq | contains | isnull | isnotnull
+
+// 2. JSON array of scalars — scalar operators with "some element matches" (∃) semantics
+{ field: 'tags', dataType: 'array', elementType: 'string', operator: 'eq', value: 'a' }
+{ field: 'nums', dataType: 'array', elementType: 'numeric', operator: 'range', value: [1, 9] }
+{ field: 'tags', dataType: 'array', elementType: 'string', operator: 'containsall', value: ['a', 'b'] }
+// isnull/isnotnull test the array FIELD itself; `neq` is excluded (∃ vs ∀ ambiguity)
+
+// 3. Array of objects — elemMatch: all sub-conditions must hold on the SAME element
+{
+  field: 'items', dataType: 'array', elementType: 'object', operator: 'elemmatch',
+  filters: {
+    logic: 'and',
+    filters: [
+      { field: 'sku', dataType: 'string', operator: 'eq', value: 'x' },
+      { field: 'qty', dataType: 'numeric', operator: 'gt', value: 1 },
+    ],
+  },
+}
+// sub-fields are relative to the element; nested and/or groups and nested elemmatch allowed
+```
+
+### Operator matrix (new rows)
+
+| dataType | operators |
+|---|---|
+| `object` | `eq` `neq` `contains` `isnull` `isnotnull` |
+| `array` + scalar `elementType` | per element (∃): string → `eq contains startswith endswith terms`; numeric → `eq gt gte lt lte range terms`; date → `eq gt gte lt lte range terms`; boolean → `eq`. Plus field-level `isnull` `isnotnull`; plus `containsall` (string/numeric only) |
+| `array` + `elementType: 'object'` | `elemmatch` (with `filters` group) |
+
+### SQL mapping
+
+| Condition | legacy | jsonpath |
+|---|---|---|
+| object `eq`/`neq` | `(col #> $f) = $v::jsonb` / `<>` | same SQL (path language can't compare objects) |
+| object `contains` | `(col #> $f) @> $v::jsonb` | same SQL |
+| object/array `isnull` | `(col #>> $f) is null` (shared with scalars) | same SQL |
+| array element op | `EXISTS (SELECT 1 FROM jsonb_array_elements_text(<guarded>) AS eN(v) WHERE <op on eN.v>)` | `$."f"[*] ? (@ <op> $v)` via `jsonb_path_exists` |
+| array `containsall` | `(col #> $f) @> $v::jsonb` | same SQL |
+| elemmatch | `EXISTS (SELECT 1 FROM jsonb_array_elements(<guarded>) AS eN WHERE <group rendered against eN.value>)` | `$."f"[*] ? (@."sku" == $v0 && …)` — one path + one vars object |
+
+`<guarded>` = `case when jsonb_typeof(col #> $f) = 'array' then col #> $f else '[]'::jsonb end` — without it, `jsonb_array_elements` raises a runtime error when the stored value is not an array. The same `$f` placeholder is referenced twice (one param).
+
+### Design decisions (and why)
+
+1. **EXISTS in WHERE, `from` stays `[]`.** Lateral `jsonb_array_elements` FROM fragments multiply rows and cannot compose under `or`. EXISTS has correct "row has ≥1 matching element" semantics and nests arbitrarily. `from` remains reserved.
+2. **∃ semantics for array element ops; `neq` excluded.** Mirrors MongoDB's implicit array matching. Mongo's `$ne` on arrays means ∀-not-equal, which contradicts ∃ — rather than ship a confusing operator, exclude it (no `not` group logic exists yet to express ∀).
+3. **Object conditions render identical SQL in both dialects.** jsonpath `==` only compares scalars, and the path language has no containment operator — so the jsonpath dialect falls back to `#>` / `@>` (precedent: Phase 1's `isnull` fallback). Bonus: `@>` is GIN-indexable.
+4. **Inside `elemmatch`, only scalar conditions, nested groups, and nested elemmatch are allowed.** Object and scalar-array conditions inside elemmatch are rejected by validation in **both** dialects (legacy could support them, but jsonpath's predicate language cannot fall back to SQL per-element; uniform API > dialect-specific capability). Future phase can lift this.
+5. **`containsall` excluded for `date`/`boolean` elements.** `@>` on date arrays compares ISO text, not datetimes; boolean containsall is meaningless. Validation rejects.
+6. **`JSON.stringify` for all `::jsonb`-bound params.** node-postgres encodes raw JS arrays as Postgres array literals (`{a,b}`), not JSON — explicit stringify is mandatory for array values and used uniformly for objects too.
+7. **jsonpath var naming.** Single-condition paths keep Phase 1 names (`$v`, `$lo`/`$hi`, `$v0…`) so existing specs stay byte-identical. elemmatch merges many conditions into one path, so it allocates sequential `$v0, $v1, …` via a `VarSink` abstraction.
+8. **Alias uniqueness.** Legacy EXISTS aliases (`e1`, `e2`, …) come from a per-`buildJsonbQuery`-call counter on a new `RenderContext`, so sibling and nested subqueries never collide.
+
+### Per-dialect difficulty notes
+
+- **legacy / arrays:** main risks are (a) runtime crash on non-array data → CASE `jsonb_typeof` guard, (b) alias collisions in nested EXISTS → `ctx.nextAlias()`, (c) recursion: elemmatch sub-groups reuse the normal group walker with `column = 'eN.value'` (the dialect already treats `column` as opaque SQL).
+- **jsonpath / arrays:** lax mode auto-unwraps arrays, so `$."f"[*]` is explicit and unambiguous. Difficulty is elemmatch: one merged predicate needs (a) unique var names across all sub-conditions, (b) parenthesization of compound predicates (`range`, multi-`terms`, `isnull`) inside `&&`/`||` chains, (c) `exists (@."sub"[*] ? (…))` for nested elemmatch, (d) `isnull` inside an element = `(!exists (@."x") || @."x" == null)` to cover both missing-key and JSON-null (matching legacy `#>>` semantics).
+- **Known semantic divergence (documented, not fixed):** when stored data is not an array, legacy's guard yields no match, while jsonpath lax mode auto-wraps a scalar into a one-element array. Same class of divergence as Phase 1 lax-mode unwrapping; goes in README.
+
+### Out of scope (Phase 2)
+
+- `neq`/∀ operators on array elements; `not` group logic
+- object / scalar-array conditions **inside** elemmatch (validated away, both dialects)
+- whole-array exact equality (`eq` on `dataType: 'array'`)
+- `containsall` for date/boolean elements
+- Anything release-related: **do not touch `packages/jsonb-query/package.json` `"private": true`, do not touch `.changeset/config.json` `ignore`, do not add changesets, never run `changeset version/publish` locally.** Release wiring happens after user sign-off, separately.
+
+## File structure
+
+| File | Change |
+|---|---|
+| `src/types.ts` | Condition union: scalar / object / array / elemmatch |
+| `src/dialect.ts` | `RenderContext`, renamed `JsonbQueryDialect` interface (+2 methods), `assertCondition` (scope-aware validation), `assertObjectValue`, shared `renderNullCheck` / `renderJsonbContains` / `isFilterGroup` |
+| `src/object-condition.ts` | **new** — dialect-independent object condition rendering |
+| `src/dialect-legacy.ts` | extract `renderScalarOp(F, …)`; add `renderArray`, `renderElemMatch` |
+| `src/dialect-jsonpath.ts` | refactor to `memberAccessor` + `VarSink` + `scalarPredicate`; add `renderArray`, `renderElemMatch` (group→predicate walker) |
+| `src/build.ts` | condition-kind dispatch, `RenderContext` creation, scope threading |
+| `src/index.ts` | unchanged (`export * from './types'` already covers new types) |
+| `src/dialect.spec.ts`, `src/object-condition.spec.ts` | **new** spec files |
+| `src/dialect-legacy.spec.ts`, `src/dialect-jsonpath.spec.ts`, `src/build.spec.ts` | additive describe blocks |
+| `README.md`, `README.zh-TW.md` | new operator rows, examples, semantics notes |
+
+Verification commands used throughout (run from repo root):
+
+```bash
+pnpm -F @rfjs/jsonb-query vitest:run     # unit tests
+pnpm -F @rfjs/jsonb-query typecheck      # tsc --noEmit
+pnpm -F @rfjs/jsonb-query lint           # eslint
+```
+
+Commits follow the repo's commit-flow conventions (conventional commits, `jsonb-query` scope). The pre-commit hook runs `turbo run lint-staged test --affected` automatically. **No changeset in any task** — the package is in the changesets `ignore` list and stays there for now.
+
+---
+
+### Task 1: Branch + baseline
+
+**Files:** none (git only)
+
+- [ ] **Step 1: Create the feature branch from main**
+
+```bash
+git checkout main && git pull && git checkout -b feat/jsonb-query-phase2
+```
+
+- [ ] **Step 2: Confirm baseline is green**
+
+Run: `pnpm -F @rfjs/jsonb-query vitest:run`
+Expected: `Test Files 6 passed (6)` / `Tests 45 passed (45)`
+
+---
+
+### Task 2: Phase 2 condition types
+
+**Files:**
+- Modify: `src/types.ts` (full replacement below)
+- Test: `pnpm -F @rfjs/jsonb-query typecheck` + existing suite (type-only change; runtime tests come with each renderer)
+
+- [ ] **Step 1: Replace `src/types.ts` with the Phase 2 union**
+
+```typescript
+export type JsonbDialect = 'legacy' | 'jsonpath';
+
+export type JsonbScalarType = 'string' | 'numeric' | 'date' | 'boolean';
+
+export type JsonbDataType = JsonbScalarType | 'object' | 'array';
+
+export type JsonbValue = string | number | boolean | Date;
+
+/** Value for object-typed conditions: a plain JSON-serializable object. */
+export type JsonbObjectValue = Record<string, unknown>;
+
+export type JsonbLogicalOperator = 'and' | 'or';
+
+export type JsonbScalarOperator =
+  | 'eq'
+  | 'neq'
+  | 'isnull'
+  | 'isnotnull'
+  | 'contains'
+  | 'startswith'
+  | 'endswith'
+  | 'gt'
+  | 'gte'
+  | 'lt'
+  | 'lte'
+  | 'range'
+  | 'terms';
+
+export type JsonbObjectOperator = 'eq' | 'neq' | 'contains' | 'isnull' | 'isnotnull';
+
+/**
+ * Operators on arrays of scalars. Scalar operators use "some element matches"
+ * (∃) semantics; `isnull`/`isnotnull` test the array field itself;
+ * `containsall` requires every listed value to be present. `neq` is excluded:
+ * its exists-vs-forall meaning is ambiguous on arrays.
+ */
+export type JsonbArrayOperator = Exclude<JsonbScalarOperator, 'neq'> | 'containsall';
+
+export interface JsonbScalarCondition {
+  field: string;
+  dataType: JsonbScalarType;
+  operator: JsonbScalarOperator;
+  value?: JsonbValue | JsonbValue[];
+  elementType?: never;
+  filters?: never;
+}
+
+export interface JsonbObjectCondition {
+  field: string;
+  dataType: 'object';
+  operator: JsonbObjectOperator;
+  value?: JsonbObjectValue;
+  elementType?: never;
+  filters?: never;
+}
+
+export interface JsonbArrayCondition {
+  field: string;
+  dataType: 'array';
+  elementType: JsonbScalarType;
+  operator: JsonbArrayOperator;
+  value?: JsonbValue | JsonbValue[];
+  filters?: never;
+}
+
+export interface JsonbElemMatchCondition {
+  field: string;
+  dataType: 'array';
+  elementType: 'object';
+  operator: 'elemmatch';
+  /** Conditions applied per element; each `field` is relative to the element. */
+  filters: JsonbFilterGroup;
+  value?: never;
+}
+
+export type JsonbCondition =
+  | JsonbScalarCondition
+  | JsonbObjectCondition
+  | JsonbArrayCondition
+  | JsonbElemMatchCondition;
+
+export interface JsonbFilterGroup {
+  logic: JsonbLogicalOperator;
+  filters: Array<JsonbCondition | JsonbFilterGroup>;
+}
+
+export interface JsonbQueryResult {
+  where: string;
+  values: unknown[];
+  /** Always `[]`. Array queries render as EXISTS subqueries inside `where`; reserved. */
+  from: string[];
+}
+
+export interface BuildJsonbOptions {
+  dialect?: JsonbDialect;
+  paramOffset?: number;
+}
+```
+
+Notes: the `?: never` members keep `cond.value` / `cond.filters` accessible on the un-narrowed union, so Phase 1 consumer code still compiles. The old `JsonbCondition` interface shape is the `JsonbScalarCondition` member — existing literals remain assignable.
+
+- [ ] **Step 2: Verify typecheck and tests stay green**
+
+Run: `pnpm -F @rfjs/jsonb-query typecheck && pnpm -F @rfjs/jsonb-query vitest:run`
+Expected: tsc exits 0; `Tests 45 passed (45)`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/jsonb-query/src/types.ts
+git commit -m "feat(jsonb-query): add phase-2 condition types (object, array, elemmatch)"
+```
+
+---
+
+### Task 3: Shared SQL helpers + `isFilterGroup` in dialect.ts
+
+Pure refactor + two new helpers. Existing specs must stay byte-identical.
+
+**Files:**
+- Modify: `src/dialect.ts`, `src/dialect-legacy.ts`, `src/dialect-jsonpath.ts`, `src/build.ts`
+- Test: Create `src/dialect.spec.ts`
+
+- [ ] **Step 1: Write failing tests for the new helpers** — create `src/dialect.spec.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { renderNullCheck, renderJsonbContains, isFilterGroup } from './dialect';
+import { ParamBuilder } from './param-builder';
+
+describe('renderNullCheck', () => {
+  it('renders is null / is not null with a parameterized path', () => {
+    const p1 = new ParamBuilder();
+    expect(renderNullCheck('"data"', 'a.b', 'isnull', p1)).toBe('(("data" #>> $1) is null)');
+    expect(p1.values).toEqual([['a', 'b']]);
+
+    const p2 = new ParamBuilder();
+    expect(renderNullCheck('"data"', 'x', 'isnotnull', p2)).toBe('(("data" #>> $1) is not null)');
+    expect(p2.values).toEqual([['x']]);
+  });
+});
+
+describe('renderJsonbContains', () => {
+  it('JSON-stringifies the value (node-postgres array-literal gotcha)', () => {
+    const p = new ParamBuilder();
+    expect(renderJsonbContains('"data"', 'tags', ['a', 'b'], p)).toBe(
+      '(("data" #> $1) @> $2::jsonb)',
+    );
+    expect(p.values).toEqual([['tags'], '["a","b"]']);
+  });
+});
+
+describe('isFilterGroup', () => {
+  it('discriminates groups from conditions', () => {
+    expect(isFilterGroup({ logic: 'and', filters: [] })).toBe(true);
+    expect(
+      isFilterGroup({ field: 'a', dataType: 'string', operator: 'eq', value: 'x' }),
+    ).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pnpm -F @rfjs/jsonb-query vitest:run`
+Expected: FAIL — `renderNullCheck` / `renderJsonbContains` / `isFilterGroup` are not exported from `./dialect`.
+
+- [ ] **Step 3: Add to `src/dialect.ts`** (below `fieldSegments`; also widen the `operator` param of `assertScalarValue` / `assertArrayValue` from `JsonbScalarOperator` to `string` so non-scalar operators like `containsall` can reuse them — message-only usage):
+
+```typescript
+import type { JsonbCondition, JsonbFilterGroup } from './types'; // extend existing type imports
+
+export function isFilterGroup(
+  node: JsonbCondition | JsonbFilterGroup,
+): node is JsonbFilterGroup {
+  return 'logic' in node && 'filters' in node;
+}
+
+/** `field IS [NOT] NULL` via `#>>`: SQL null for both missing keys and JSON null. */
+export function renderNullCheck(
+  column: string,
+  field: string,
+  operator: 'isnull' | 'isnotnull',
+  params: ParamBuilder,
+): string {
+  const F = `(${column} #>> ${params.add(fieldSegments(field))})`;
+  return operator === 'isnull' ? `(${F} is null)` : `(${F} is not null)`;
+}
+
+/**
+ * JSONB containment (`@>`). `JSON.stringify` is required: node-postgres encodes
+ * raw JS arrays as Postgres array literals ('{a,b}'), which are not valid jsonb.
+ */
+export function renderJsonbContains(
+  column: string,
+  field: string,
+  value: unknown,
+  params: ParamBuilder,
+): string {
+  const fParam = params.add(fieldSegments(field));
+  return `((${column} #> ${fParam}) @> ${params.add(JSON.stringify(value))}::jsonb)`;
+}
+```
+
+(`ParamBuilder` must become a value import: `import { ParamBuilder } from './param-builder';` → keep as `import type` if only used in signatures — it is, so keep `import type`.)
+
+- [ ] **Step 4: Refactor the three call sites to the shared helpers**
+
+In `src/dialect-legacy.ts` — replace the `isnull`/`isnotnull` switch cases with an early return before computing `F` (add `renderNullCheck` to the `./dialect` import):
+
+```typescript
+render(column, field, dataType, operator, value, params) {
+  if (operator === 'isnull' || operator === 'isnotnull') {
+    return renderNullCheck(column, field, operator, params);
+  }
+  const fParam = params.add(fieldSegments(field));
+  const F = `(${column} #>> ${fParam})`;
+  const Fc = `${F}${CASTS[dataType]}`;
+  switch (operator) {
+    // 'isnull'/'isnotnull' cases deleted; everything else unchanged
+```
+
+In `src/dialect-jsonpath.ts` — replace the inline fallback:
+
+```typescript
+if (operator === 'isnull' || operator === 'isnotnull') {
+  return renderNullCheck(column, field, operator, params);
+}
+```
+
+In `src/build.ts` — delete the local `isGroup` function and import/use `isFilterGroup` from `./dialect` instead.
+
+- [ ] **Step 5: Verify everything is green (byte-identical SQL proven by existing specs)**
+
+Run: `pnpm -F @rfjs/jsonb-query vitest:run && pnpm -F @rfjs/jsonb-query typecheck`
+Expected: `Tests 48 passed` (45 + 3 new), tsc clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/jsonb-query/src
+git commit -m "refactor(jsonb-query): extract shared null-check, containment and group-guard helpers"
+```
+
+---
+
+### Task 4: Scope-aware condition validation (`assertCondition`)
+
+**Files:**
+- Modify: `src/dialect.ts`
+- Test: `src/dialect.spec.ts` (append)
+
+- [ ] **Step 1: Write failing tests** — append to `src/dialect.spec.ts`:
+
+```typescript
+import { assertCondition, assertObjectValue } from './dialect';
+import type { JsonbCondition } from './types';
+
+describe('assertObjectValue', () => {
+  it('accepts a plain object', () => {
+    expect(assertObjectValue('eq', { a: 1 })).toEqual({ a: 1 });
+  });
+  it.each([null, undefined, [1], new Date(), 'x', 1])('rejects %p', (bad) => {
+    expect(() => assertObjectValue('eq', bad)).toThrow(/requires a plain object value/i);
+  });
+});
+
+describe('assertCondition', () => {
+  const c = (node: unknown) => () => assertCondition(node as JsonbCondition, 'root');
+  const e = (node: unknown) => () => assertCondition(node as JsonbCondition, 'elemmatch');
+
+  it('delegates scalar validation unchanged', () => {
+    expect(c({ field: 'x', dataType: 'boolean', operator: 'gt' })).toThrow(
+      /unsupported operator "gt" for type "boolean"/i,
+    );
+    expect(c({ field: 'x', dataType: 'string', operator: 'eq', value: 'a' })).not.toThrow();
+  });
+
+  it('validates object operators', () => {
+    expect(c({ field: 'p', dataType: 'object', operator: 'eq', value: {} })).not.toThrow();
+    expect(c({ field: 'p', dataType: 'object', operator: 'gt', value: {} })).toThrow(
+      /unsupported operator "gt" for type "object"/i,
+    );
+  });
+
+  it('validates array element operators per elementType', () => {
+    const arr = (elementType: string, operator: string) =>
+      c({ field: 'a', dataType: 'array', elementType, operator, value: 1 });
+    expect(arr('numeric', 'gt')).not.toThrow();
+    expect(arr('string', 'gt')).toThrow(/for array elements of type "string"/i);
+    expect(arr('numeric', 'startswith')).toThrow(/for array elements of type "numeric"/i);
+    expect(arr('string', 'neq')).toThrow(/unsupported operator "neq" for array elements/i);
+    expect(arr('boolean', 'terms')).toThrow(/for array elements of type "boolean"/i);
+    expect(arr('date', 'containsall')).toThrow(/for array elements of type "date"/i);
+    expect(arr('bogus', 'eq')).toThrow(/unsupported elementtype "bogus"/i);
+  });
+
+  it('requires elemmatch (with a non-empty group) for arrays of objects', () => {
+    const ok = {
+      field: 'items', dataType: 'array', elementType: 'object', operator: 'elemmatch',
+      filters: { logic: 'and', filters: [{ field: 's', dataType: 'string', operator: 'eq', value: 'x' }] },
+    };
+    expect(c(ok)).not.toThrow();
+    expect(c({ ...ok, operator: 'eq' })).toThrow(/use "elemmatch"/i);
+    expect(c({ ...ok, filters: { logic: 'and', filters: [] } })).toThrow(
+      /requires a filter group with at least one condition/i,
+    );
+    expect(c({ ...ok, filters: undefined })).toThrow(/requires a filter group/i);
+  });
+
+  it('rejects object and scalar-array conditions inside elemmatch', () => {
+    expect(e({ field: 'p', dataType: 'object', operator: 'eq', value: {} })).toThrow(
+      /object conditions are not supported inside elemmatch/i,
+    );
+    expect(
+      e({ field: 'a', dataType: 'array', elementType: 'string', operator: 'eq', value: 'x' }),
+    ).toThrow(/array conditions with scalar elements are not supported inside elemmatch/i);
+    // scalar + nested elemmatch ARE allowed inside elemmatch
+    expect(e({ field: 's', dataType: 'string', operator: 'eq', value: 'x' })).not.toThrow();
+    expect(
+      e({
+        field: 'sub', dataType: 'array', elementType: 'object', operator: 'elemmatch',
+        filters: { logic: 'and', filters: [{ field: 's', dataType: 'string', operator: 'eq', value: 'x' }] },
+      }),
+    ).not.toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pnpm -F @rfjs/jsonb-query vitest:run`
+Expected: FAIL — `assertCondition` / `assertObjectValue` not exported.
+
+- [ ] **Step 3: Implement in `src/dialect.ts`** (extend type imports with `JsonbObjectOperator`, `JsonbObjectValue`):
+
+```typescript
+export function assertObjectValue(operator: string, value: unknown): JsonbObjectValue {
+  if (
+    typeof value !== 'object' ||
+    value === null ||
+    Array.isArray(value) ||
+    value instanceof Date
+  ) {
+    throw new Error(`Operator "${operator}" requires a plain object value`);
+  }
+  return value as JsonbObjectValue;
+}
+
+const OBJECT_OPERATORS: ReadonlySet<JsonbObjectOperator> = new Set([
+  'eq', 'neq', 'contains', 'isnull', 'isnotnull',
+]);
+
+const ARRAY_OPERATORS_BY_ELEMENT: Record<JsonbScalarType, ReadonlySet<string>> = {
+  string: new Set(['eq', 'contains', 'startswith', 'endswith', 'terms', 'containsall', 'isnull', 'isnotnull']),
+  numeric: new Set(['eq', 'gt', 'gte', 'lt', 'lte', 'range', 'terms', 'containsall', 'isnull', 'isnotnull']),
+  date: new Set(['eq', 'gt', 'gte', 'lt', 'lte', 'range', 'terms', 'isnull', 'isnotnull']),
+  boolean: new Set(['eq', 'isnull', 'isnotnull']),
+};
+
+export type ConditionScope = 'root' | 'elemmatch';
+
+export function assertCondition(node: JsonbCondition, scope: ConditionScope): void {
+  if (node.dataType === 'object') {
+    if (scope === 'elemmatch') {
+      throw new Error('Object conditions are not supported inside elemmatch');
+    }
+    if (!OBJECT_OPERATORS.has(node.operator)) {
+      throw new Error(`Unsupported operator "${node.operator as string}" for type "object"`);
+    }
+    return;
+  }
+  if (node.dataType === 'array') {
+    if (node.elementType === 'object') {
+      if ((node.operator as string) !== 'elemmatch') {
+        throw new Error(
+          `Unsupported operator "${node.operator as string}" for array of objects (use "elemmatch")`,
+        );
+      }
+      if (!node.filters || !Array.isArray(node.filters.filters) || node.filters.filters.length === 0) {
+        throw new Error('Operator "elemmatch" requires a filter group with at least one condition');
+      }
+      return;
+    }
+    if (scope === 'elemmatch') {
+      throw new Error('Array conditions with scalar elements are not supported inside elemmatch');
+    }
+    const ops = ARRAY_OPERATORS_BY_ELEMENT[node.elementType];
+    if (!ops) {
+      throw new Error(
+        `Unsupported elementType ${JSON.stringify(node.elementType)} for array condition`,
+      );
+    }
+    if (!ops.has(node.operator)) {
+      throw new Error(
+        `Unsupported operator "${node.operator as string}" for array elements of type "${node.elementType}"`,
+      );
+    }
+    return;
+  }
+  assertOperatorForType(node.dataType, node.operator);
+}
+```
+
+- [ ] **Step 4: Verify green**
+
+Run: `pnpm -F @rfjs/jsonb-query vitest:run && pnpm -F @rfjs/jsonb-query typecheck`
+Expected: all pass (48 + new validation tests), tsc clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/jsonb-query/src/dialect.ts packages/jsonb-query/src/dialect.spec.ts
+git commit -m "feat(jsonb-query): add scope-aware condition validation for phase-2 types"
+```
+
+---
+
+### Task 5: Dialect interface + RenderContext
+
+Type-level change preparing both dialects; implement stub methods that throw, so existing behavior is untouched.
+
+**Files:**
+- Modify: `src/dialect.ts` (interface), `src/dialect-legacy.ts`, `src/dialect-jsonpath.ts`, `src/build.ts` (rename only)
+
+- [ ] **Step 1: In `src/dialect.ts`, rename `ScalarDialect` → `JsonbQueryDialect` and extend** (extend type imports with `JsonbArrayCondition`, `JsonbElemMatchCondition`):
+
+```typescript
+export interface RenderContext {
+  params: ParamBuilder;
+  /** Allocate a unique table alias (e1, e2, …) for EXISTS subqueries. */
+  nextAlias(): string;
+  /** Render a nested filter group against an element expression (elemmatch scope). */
+  renderGroup(group: JsonbFilterGroup, column: string): string;
+}
+
+export interface JsonbQueryDialect {
+  /**
+   * Render one scalar condition into a SQL boolean expression, pushing any
+   * parameter values onto `params`.
+   * @param column already-quoted column SQL, e.g. `"data"`
+   * @param field  raw dot path, e.g. "address.city"
+   */
+  render(
+    column: string,
+    field: string,
+    dataType: JsonbScalarType,
+    operator: JsonbScalarOperator,
+    value: JsonbValue | JsonbValue[] | undefined,
+    params: ParamBuilder,
+  ): string;
+  /** Render a scalar-element array condition (∃ semantics / containsall / null checks). */
+  renderArray(column: string, condition: JsonbArrayCondition, ctx: RenderContext): string;
+  /** Render an array-of-objects condition (all sub-conditions on the same element). */
+  renderElemMatch(column: string, condition: JsonbElemMatchCondition, ctx: RenderContext): string;
+}
+```
+
+- [ ] **Step 2: Update both dialects and build.ts**
+
+In `src/dialect-legacy.ts` and `src/dialect-jsonpath.ts`: change the type annotation to `JsonbQueryDialect` and add temporary stubs (replaced in Tasks 7–11):
+
+```typescript
+renderArray() {
+  throw new Error('Not implemented');
+},
+renderElemMatch() {
+  throw new Error('Not implemented');
+},
+```
+
+In `src/build.ts`: update the import/type reference (`ScalarDialect` → `JsonbQueryDialect`).
+
+- [ ] **Step 3: Verify green**
+
+Run: `pnpm -F @rfjs/jsonb-query vitest:run && pnpm -F @rfjs/jsonb-query typecheck`
+Expected: all pass, tsc clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/jsonb-query/src
+git commit -m "refactor(jsonb-query): widen dialect interface with renderArray/renderElemMatch"
+```
+
+---
+
+### Task 6: Shared object-condition renderer
+
+**Files:**
+- Create: `src/object-condition.ts`
+- Test: Create `src/object-condition.spec.ts`
+
+- [ ] **Step 1: Write failing tests** — create `src/object-condition.spec.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { renderObjectCondition } from './object-condition';
+import { ParamBuilder } from './param-builder';
+import type { JsonbObjectCondition } from './types';
+
+function run(cond: Omit<JsonbObjectCondition, 'dataType'>) {
+  const p = new ParamBuilder();
+  const where = renderObjectCondition('"data"', { ...cond, dataType: 'object' }, p);
+  return { where, values: p.values };
+}
+
+describe('renderObjectCondition', () => {
+  it('eq compares via #> against a jsonb param (structural equality)', () => {
+    expect(run({ field: 'profile', operator: 'eq', value: { vip: true } })).toEqual({
+      where: '(("data" #> $1) = $2::jsonb)',
+      values: [['profile'], '{"vip":true}'],
+    });
+  });
+
+  it('neq uses <>', () => {
+    expect(run({ field: 'profile', operator: 'neq', value: { vip: true } })).toEqual({
+      where: '(("data" #> $1) <> $2::jsonb)',
+      values: [['profile'], '{"vip":true}'],
+    });
+  });
+
+  it('contains uses @> and supports dot paths', () => {
+    expect(run({ field: 'meta.flags', operator: 'contains', value: { beta: true } })).toEqual({
+      where: '(("data" #> $1) @> $2::jsonb)',
+      values: [['meta', 'flags'], '{"beta":true}'],
+    });
+  });
+
+  it('isnull / isnotnull use the shared #>> null check', () => {
+    expect(run({ field: 'profile', operator: 'isnull' })).toEqual({
+      where: '(("data" #>> $1) is null)',
+      values: [['profile']],
+    });
+    expect(run({ field: 'profile', operator: 'isnotnull' })).toEqual({
+      where: '(("data" #>> $1) is not null)',
+      values: [['profile']],
+    });
+  });
+
+  it('rejects non-object values', () => {
+    expect(() => run({ field: 'p', operator: 'eq', value: [1] as never })).toThrow(
+      /requires a plain object value/i,
+    );
+  });
+
+  it('keeps hostile values in params, never in SQL', () => {
+    const { where, values } = run({
+      field: 'p', operator: 'eq', value: { name: "x'; DROP TABLE t; --" },
+    });
+    expect(where).toBe('(("data" #> $1) = $2::jsonb)');
+    expect(values[1]).toBe('{"name":"x\'; DROP TABLE t; --"}');
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pnpm -F @rfjs/jsonb-query vitest:run`
+Expected: FAIL — cannot resolve `./object-condition`.
+
+- [ ] **Step 3: Create `src/object-condition.ts`**
+
+```typescript
+import type { JsonbObjectCondition } from './types';
+import type { ParamBuilder } from './param-builder';
+import {
+  fieldSegments,
+  assertObjectValue,
+  renderNullCheck,
+  renderJsonbContains,
+} from './dialect';
+
+/**
+ * Object conditions render the same SQL in both dialects: SQL/JSON path
+ * predicates cannot compare or contain non-scalar values, so the jsonpath
+ * dialect falls back to `#>` / `@>` (both GIN-indexable). jsonb `=` is
+ * structural equality (key order and whitespace insensitive).
+ */
+export function renderObjectCondition(
+  column: string,
+  condition: JsonbObjectCondition,
+  params: ParamBuilder,
+): string {
+  const { field, operator, value } = condition;
+  switch (operator) {
+    case 'isnull':
+    case 'isnotnull':
+      return renderNullCheck(column, field, operator, params);
+    case 'contains':
+      return renderJsonbContains(column, field, assertObjectValue(operator, value), params);
+    case 'eq':
+    case 'neq': {
+      const obj = assertObjectValue(operator, value);
+      const F = `(${column} #> ${params.add(fieldSegments(field))})`;
+      return `(${F} ${operator === 'eq' ? '=' : '<>'} ${params.add(JSON.stringify(obj))}::jsonb)`;
+    }
+    default:
+      throw new Error(`Unsupported operator "${operator as string}" for type "object"`);
+  }
+}
+```
+
+- [ ] **Step 4: Verify green**
+
+Run: `pnpm -F @rfjs/jsonb-query vitest:run && pnpm -F @rfjs/jsonb-query typecheck`
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/jsonb-query/src/object-condition.ts packages/jsonb-query/src/object-condition.spec.ts
+git commit -m "feat(jsonb-query): render object conditions (eq/neq/contains/null checks)"
+```
+
+---
+
+### Task 7: Legacy — extract `renderScalarOp` (pure refactor)
+
+**Files:**
+- Modify: `src/dialect-legacy.ts`
+
+- [ ] **Step 1: Refactor** — move the operator switch into a module-level function taking the text expression `F` (the null-check early return from Task 3 stays in `render`):
+
+```typescript
+import type { JsonbScalarType, JsonbScalarOperator, JsonbValue } from './types';
+import {
+  type JsonbQueryDialect,
+  fieldSegments,
+  assertScalarValue,
+  assertArrayValue,
+  renderNullCheck,
+} from './dialect';
+import type { ParamBuilder } from './param-builder';
+
+const CASTS: Record<JsonbScalarType, string> = {
+  string: '',
+  numeric: '::numeric',
+  date: '::timestamptz',
+  boolean: '::boolean',
+};
+
+const ARRAY_CASTS: Record<JsonbScalarType, string> = {
+  string: '::text[]',
+  numeric: '::numeric[]',
+  date: '::timestamptz[]',
+  boolean: '::boolean[]',
+};
+
+/** Render a scalar operator against `F`, a text-valued SQL expression. */
+function renderScalarOp(
+  F: string,
+  dataType: JsonbScalarType,
+  operator: JsonbScalarOperator,
+  value: JsonbValue | JsonbValue[] | undefined,
+  params: ParamBuilder,
+): string {
+  const Fc = `${F}${CASTS[dataType]}`;
+  switch (operator) {
+    case 'eq':
+      return `(${Fc} = ${params.add(assertScalarValue(operator, value))})`;
+    case 'neq':
+      return `(${Fc} <> ${params.add(assertScalarValue(operator, value))})`;
+    case 'gt':
+      return `(${Fc} > ${params.add(assertScalarValue(operator, value))})`;
+    case 'gte':
+      return `(${Fc} >= ${params.add(assertScalarValue(operator, value))})`;
+    case 'lt':
+      return `(${Fc} < ${params.add(assertScalarValue(operator, value))})`;
+    case 'lte':
+      return `(${Fc} <= ${params.add(assertScalarValue(operator, value))})`;
+    case 'range': {
+      const [lo, hi] = assertArrayValue(operator, value, 2);
+      return `(${Fc} between ${params.add(lo)} and ${params.add(hi)})`;
+    }
+    case 'terms':
+      return `(${Fc} = ANY(${params.add(assertArrayValue(operator, value))}${ARRAY_CASTS[dataType]}))`;
+    case 'contains':
+      return `(position(${params.add(assertScalarValue(operator, value))} in ${F}) > 0)`;
+    case 'startswith': {
+      const v = params.add(assertScalarValue(operator, value));
+      return `(left(${F}, char_length(${v})) = ${v})`;
+    }
+    case 'endswith': {
+      const v = params.add(assertScalarValue(operator, value));
+      return `(right(${F}, char_length(${v})) = ${v})`;
+    }
+    default:
+      throw new Error(`Unsupported operator "${operator as string}"`);
+  }
+}
+
+export const legacyDialect: JsonbQueryDialect = {
+  render(column, field, dataType, operator, value, params) {
+    if (operator === 'isnull' || operator === 'isnotnull') {
+      return renderNullCheck(column, field, operator, params);
+    }
+    const F = `(${column} #>> ${params.add(fieldSegments(field))})`;
+    return renderScalarOp(F, dataType, operator, value, params);
+  },
+  // renderArray / renderElemMatch stubs unchanged for now
+};
+```
+
+- [ ] **Step 2: Verify byte-identical behavior via existing specs**
+
+Run: `pnpm -F @rfjs/jsonb-query vitest:run`
+Expected: all pass, no expectation changes.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/jsonb-query/src/dialect-legacy.ts
+git commit -m "refactor(jsonb-query): extract renderScalarOp for reuse on array elements"
+```
+
+---### Task 8: Legacy — `renderArray`
+
+**Files:**
+- Modify: `src/dialect-legacy.ts`
+- Test: `src/dialect-legacy.spec.ts` (append)
+
+- [ ] **Step 1: Write failing tests** — append to `src/dialect-legacy.spec.ts` (add imports for `RenderContext`, `JsonbArrayCondition` types):
+
+```typescript
+import type { RenderContext } from './dialect';
+import type { JsonbArrayCondition } from './types';
+
+function makeCtx(
+  p: ParamBuilder,
+  renderGroup: RenderContext['renderGroup'] = () => {
+    throw new Error('renderGroup not stubbed');
+  },
+): RenderContext {
+  let n = 0;
+  return {
+    params: p,
+    nextAlias: () => {
+      n += 1;
+      return `e${n}`;
+    },
+    renderGroup,
+  };
+}
+
+const GUARD = (col: string, ph: string) =>
+  `case when jsonb_typeof(${col} #> ${ph}) = 'array' then ${col} #> ${ph} else '[]'::jsonb end`;
+
+describe('legacyDialect.renderArray', () => {
+  function runArray(cond: Omit<JsonbArrayCondition, 'dataType'>) {
+    const p = new ParamBuilder();
+    const ctx = makeCtx(p);
+    const where = legacyDialect.renderArray('"data"', { ...cond, dataType: 'array' }, ctx);
+    return { where, values: p.values, ctx };
+  }
+
+  it('element eq uses EXISTS over jsonb_array_elements_text with a typeof guard', () => {
+    expect(runArray({ field: 'tags', elementType: 'string', operator: 'eq', value: 'a' })).toMatchObject({
+      where: `(exists (select 1 from jsonb_array_elements_text(${GUARD('"data"', '$1')}) as e1(v) where (e1.v = $2)))`,
+      values: [['tags'], 'a'],
+    });
+  });
+
+  it('element gt casts the element', () => {
+    expect(runArray({ field: 'nums', elementType: 'numeric', operator: 'gt', value: 5 }).where).toBe(
+      `(exists (select 1 from jsonb_array_elements_text(${GUARD('"data"', '$1')}) as e1(v) where (e1.v::numeric > $2)))`,
+    );
+  });
+
+  it('element range / terms / string ops reuse the scalar operator rendering', () => {
+    expect(runArray({ field: 'nums', elementType: 'numeric', operator: 'range', value: [1, 9] }).where).toContain(
+      '(e1.v::numeric between $2 and $3)',
+    );
+    expect(runArray({ field: 'tags', elementType: 'string', operator: 'terms', value: ['a', 'b'] }).where).toContain(
+      '(e1.v = ANY($2::text[]))',
+    );
+    expect(runArray({ field: 'tags', elementType: 'string', operator: 'startswith', value: 'x' }).where).toContain(
+      '(left(e1.v, char_length($2)) = $2)',
+    );
+    expect(runArray({ field: 'dates', elementType: 'date', operator: 'gt', value: '2020-01-01' }).where).toContain(
+      '(e1.v::timestamptz > $2)',
+    );
+  });
+
+  it('containsall maps to @> with a JSON-stringified param', () => {
+    expect(runArray({ field: 'tags', elementType: 'string', operator: 'containsall', value: ['a', 'b'] })).toMatchObject({
+      where: '(("data" #> $1) @> $2::jsonb)',
+      values: [['tags'], '["a","b"]'],
+    });
+  });
+
+  it('isnull / isnotnull test the array field itself', () => {
+    expect(runArray({ field: 'tags', elementType: 'string', operator: 'isnull' })).toMatchObject({
+      where: '(("data" #>> $1) is null)',
+      values: [['tags']],
+    });
+  });
+
+  it('allocates unique aliases across calls sharing a context', () => {
+    const p = new ParamBuilder();
+    const ctx = makeCtx(p);
+    const a = legacyDialect.renderArray('"data"', { field: 'x', dataType: 'array', elementType: 'string', operator: 'eq', value: 'a' }, ctx);
+    const b = legacyDialect.renderArray('"data"', { field: 'y', dataType: 'array', elementType: 'string', operator: 'eq', value: 'b' }, ctx);
+    expect(a).toContain('as e1(v)');
+    expect(b).toContain('as e2(v)');
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pnpm -F @rfjs/jsonb-query vitest:run`
+Expected: FAIL — `Not implemented` from the Task 5 stub.
+
+- [ ] **Step 3: Implement `renderArray` in `src/dialect-legacy.ts`** (replace the stub; add `renderJsonbContains` to the `./dialect` import):
+
+```typescript
+renderArray(column, condition, ctx) {
+  const { params } = ctx;
+  const { field, elementType, operator, value } = condition;
+  if (operator === 'isnull' || operator === 'isnotnull') {
+    return renderNullCheck(column, field, operator, params);
+  }
+  if (operator === 'containsall') {
+    return renderJsonbContains(column, field, assertArrayValue(operator, value), params);
+  }
+  const fParam = params.add(fieldSegments(field));
+  const guarded = `case when jsonb_typeof(${column} #> ${fParam}) = 'array' then ${column} #> ${fParam} else '[]'::jsonb end`;
+  const alias = ctx.nextAlias();
+  const predicate = renderScalarOp(`${alias}.v`, elementType, operator, value, params);
+  return `(exists (select 1 from jsonb_array_elements_text(${guarded}) as ${alias}(v) where ${predicate}))`;
+},
+```
+
+- [ ] **Step 4: Verify green**
+
+Run: `pnpm -F @rfjs/jsonb-query vitest:run && pnpm -F @rfjs/jsonb-query typecheck`
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/jsonb-query/src/dialect-legacy.ts packages/jsonb-query/src/dialect-legacy.spec.ts
+git commit -m "feat(jsonb-query): legacy scalar-array conditions via guarded EXISTS"
+```
+
+---
+
+### Task 9: Legacy — `renderElemMatch`
+
+**Files:**
+- Modify: `src/dialect-legacy.ts`
+- Test: `src/dialect-legacy.spec.ts` (append)
+
+- [ ] **Step 1: Write failing tests** — append inside the spec file (reuses `makeCtx`/`GUARD` from Task 8):
+
+```typescript
+describe('legacyDialect.renderElemMatch', () => {
+  const cond = {
+    field: 'items',
+    dataType: 'array',
+    elementType: 'object',
+    operator: 'elemmatch',
+    filters: { logic: 'and', filters: [{ field: 'sku', dataType: 'string', operator: 'eq', value: 'x' }] },
+  } as const;
+
+  it('wraps the sub-group in EXISTS over jsonb_array_elements, rendered against the alias', () => {
+    const p = new ParamBuilder();
+    const seen: string[] = [];
+    const ctx = makeCtx(p, (_group, col) => {
+      seen.push(col);
+      return `<<sub:${col}>>`;
+    });
+    const where = legacyDialect.renderElemMatch('"data"', cond, ctx);
+    expect(where).toBe(
+      `(exists (select 1 from jsonb_array_elements(${GUARD('"data"', '$1')}) as e1 where <<sub:e1.value>>))`,
+    );
+    expect(seen).toEqual(['e1.value']);
+    expect(p.values).toEqual([['items']]);
+  });
+
+  it('throws when the sub-group renders empty', () => {
+    const p = new ParamBuilder();
+    const ctx = makeCtx(p, () => '');
+    expect(() => legacyDialect.renderElemMatch('"data"', cond, ctx)).toThrow(
+      /requires a filter group with at least one condition/i,
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pnpm -F @rfjs/jsonb-query vitest:run`
+Expected: FAIL — `Not implemented`.
+
+- [ ] **Step 3: Implement `renderElemMatch` in `src/dialect-legacy.ts`** (replace the stub):
+
+```typescript
+renderElemMatch(column, condition, ctx) {
+  const fParam = ctx.params.add(fieldSegments(condition.field));
+  const guarded = `case when jsonb_typeof(${column} #> ${fParam}) = 'array' then ${column} #> ${fParam} else '[]'::jsonb end`;
+  const alias = ctx.nextAlias();
+  const sub = ctx.renderGroup(condition.filters, `${alias}.value`);
+  if (sub.length === 0) {
+    throw new Error('Operator "elemmatch" requires a filter group with at least one condition');
+  }
+  return `(exists (select 1 from jsonb_array_elements(${guarded}) as ${alias} where ${sub}))`;
+},
+```
+
+- [ ] **Step 4: Verify green**
+
+Run: `pnpm -F @rfjs/jsonb-query vitest:run && pnpm -F @rfjs/jsonb-query typecheck`
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/jsonb-query/src/dialect-legacy.ts packages/jsonb-query/src/dialect-legacy.spec.ts
+git commit -m "feat(jsonb-query): legacy elemmatch via EXISTS over jsonb_array_elements"
+```
+
+---
+
+### Task 10: jsonpath — refactor to `memberAccessor` + `VarSink` + `scalarPredicate` (pure refactor)
+
+Phase 1 jsonpath output must stay **byte-identical** — the existing spec is the proof.
+
+**Files:**
+- Modify: `src/dialect-jsonpath.ts`
+
+- [ ] **Step 1: Refactor** — replace the body of `src/dialect-jsonpath.ts` with:
+
+```typescript
+import type { JsonbScalarType, JsonbScalarOperator, JsonbValue } from './types';
+import {
+  type JsonbQueryDialect,
+  fieldSegments,
+  assertScalarValue,
+  assertArrayValue,
+  renderNullCheck,
+} from './dialect';
+import type { ParamBuilder } from './param-builder';
+import { escapeJsonpathString, escapeRegexLiteral } from './escape';
+
+/** `$."a"."b"` / `@."a"."b"` accessor for a dot path, members escaped. */
+function memberAccessor(root: '$' | '@', field: string): string {
+  return (
+    root +
+    fieldSegments(field)
+      .map((seg) => `."${escapeJsonpathString(seg)}"`)
+      .join('')
+  );
+}
+
+const COMPARATORS: Partial<Record<JsonbScalarOperator, string>> = {
+  eq: '==',
+  neq: '!=',
+  gt: '>',
+  gte: '>=',
+  lt: '<',
+  lte: '<=',
+};
+
+/** Allocates jsonpath variable names and collects their values. */
+interface VarSink {
+  vars: Record<string, JsonbValue>;
+  one(value: JsonbValue): string;
+  pair(lo: JsonbValue, hi: JsonbValue): [string, string];
+  many(values: JsonbValue[]): string[];
+}
+
+/** Phase-1 naming for single-condition paths: $v, $lo/$hi, $v0… */
+function namedSink(): VarSink {
+  const vars: Record<string, JsonbValue> = {};
+  return {
+    vars,
+    one(value) {
+      vars.v = value;
+      return 'v';
+    },
+    pair(lo, hi) {
+      vars.lo = lo;
+      vars.hi = hi;
+      return ['lo', 'hi'];
+    },
+    many(values) {
+      return values.map((v, i) => {
+        vars[`v${i}`] = v;
+        return `v${i}`;
+      });
+    },
+  };
+}
+
+interface Predicate {
+  pred: string;
+  /** true when the predicate contains a top-level && / || and needs parens when embedded */
+  compound: boolean;
+}
+
+function scalarPredicate(
+  acc: string,
+  dataType: JsonbScalarType,
+  operator: JsonbScalarOperator,
+  value: JsonbValue | JsonbValue[] | undefined,
+  sink: VarSink,
+): Predicate {
+  const lhs = dataType === 'date' ? `${acc}.datetime()` : acc;
+  const rhs = (name: string) => (dataType === 'date' ? `$${name}.datetime()` : `$${name}`);
+
+  const comparator = COMPARATORS[operator];
+  if (comparator) {
+    const name = sink.one(assertScalarValue(operator, value));
+    return { pred: `${lhs} ${comparator} ${rhs(name)}`, compound: false };
+  }
+
+  switch (operator) {
+    case 'range': {
+      const [lo, hi] = assertArrayValue(operator, value, 2);
+      const [a, b] = sink.pair(lo, hi);
+      return { pred: `${lhs} >= ${rhs(a)} && ${lhs} <= ${rhs(b)}`, compound: true };
+    }
+    case 'terms': {
+      const items = assertArrayValue(operator, value);
+      const names = sink.many(items);
+      return {
+        pred: names.map((name) => `${lhs} == ${rhs(name)}`).join(' || '),
+        compound: items.length > 1,
+      };
+    }
+    // startswith/contains/endswith are string predicates: they operate on the
+    // text form (`acc`), never `.datetime()`.
+    case 'startswith': {
+      const name = sink.one(assertScalarValue(operator, value));
+      return { pred: `${acc} starts with $${name}`, compound: false };
+    }
+    case 'contains': {
+      const raw = String(assertScalarValue(operator, value));
+      const lit = escapeJsonpathString(escapeRegexLiteral(raw));
+      return { pred: `${acc} like_regex "${lit}"`, compound: false };
+    }
+    case 'endswith': {
+      const raw = String(assertScalarValue(operator, value));
+      const lit = escapeJsonpathString(escapeRegexLiteral(raw) + '$');
+      return { pred: `${acc} like_regex "${lit}"`, compound: false };
+    }
+    // isnull/isnotnull only reach here inside elemmatch (root conditions use
+    // the SQL fallback). Covers both a missing member and a JSON null, matching
+    // legacy `#>>` semantics.
+    case 'isnull':
+      return { pred: `!exists (${acc}) || ${acc} == null`, compound: true };
+    case 'isnotnull':
+      return { pred: `exists (${acc}) && ${acc} != null`, compound: true };
+    default:
+      throw new Error(`Unsupported operator "${operator as string}"`);
+  }
+}
+
+/** Emit jsonb_path_exists; omits the vars argument when no variables were used. */
+function pathExists(
+  column: string,
+  path: string,
+  vars: Record<string, JsonbValue>,
+  params: ParamBuilder,
+): string {
+  const pParam = params.add(path);
+  if (Object.keys(vars).length === 0) {
+    return `jsonb_path_exists(${column}, ${pParam}::jsonpath)`;
+  }
+  return `jsonb_path_exists(${column}, ${pParam}::jsonpath, ${params.add(vars)}::jsonb)`;
+}
+
+export const jsonpathDialect: JsonbQueryDialect = {
+  render(column, field, dataType, operator, value, params) {
+    // isnull/isnotnull are dialect-independent.
+    if (operator === 'isnull' || operator === 'isnotnull') {
+      return renderNullCheck(column, field, operator, params);
+    }
+    const sink = namedSink();
+    const { pred } = scalarPredicate('@', dataType, operator, value, sink);
+    return pathExists(column, `${memberAccessor('$', field)} ? (${pred})`, sink.vars, params);
+  },
+  renderArray() {
+    throw new Error('Not implemented');
+  },
+  renderElemMatch() {
+    throw new Error('Not implemented');
+  },
+};
+```
+
+- [ ] **Step 2: Verify byte-identical output via existing specs**
+
+Run: `pnpm -F @rfjs/jsonb-query vitest:run`
+Expected: all pass with zero expectation changes (this is the whole point of the task).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/jsonb-query/src/dialect-jsonpath.ts
+git commit -m "refactor(jsonb-query): extract jsonpath predicate builder and var sinks"
+```
+
+---
+
+### Task 11: jsonpath — `renderArray`
+
+**Files:**
+- Modify: `src/dialect-jsonpath.ts`
+- Test: `src/dialect-jsonpath.spec.ts` (append)
+
+- [ ] **Step 1: Write failing tests** — append to `src/dialect-jsonpath.spec.ts`:
+
+```typescript
+import type { RenderContext } from './dialect';
+import type { JsonbArrayCondition } from './types';
+
+function makeCtx(p: ParamBuilder): RenderContext {
+  let n = 0;
+  return {
+    params: p,
+    nextAlias: () => {
+      n += 1;
+      return `e${n}`;
+    },
+    renderGroup: () => {
+      throw new Error('renderGroup not used by jsonpath dialect');
+    },
+  };
+}
+
+describe('jsonpathDialect.renderArray', () => {
+  function runArray(cond: Omit<JsonbArrayCondition, 'dataType'>) {
+    const p = new ParamBuilder();
+    const where = jsonpathDialect.renderArray('"data"', { ...cond, dataType: 'array' }, makeCtx(p));
+    return { where, values: p.values };
+  }
+
+  it('element eq filters over [*] with phase-1 var naming', () => {
+    expect(runArray({ field: 'tags', elementType: 'string', operator: 'eq', value: 'a' })).toEqual({
+      where: 'jsonb_path_exists("data", $1::jsonpath, $2::jsonb)',
+      values: ['$."tags"[*] ? (@ == $v)', { v: 'a' }],
+    });
+  });
+
+  it('element range / terms / date / contains', () => {
+    expect(runArray({ field: 'nums', elementType: 'numeric', operator: 'range', value: [1, 9] }).values[0]).toBe(
+      '$."nums"[*] ? (@ >= $lo && @ <= $hi)',
+    );
+    expect(runArray({ field: 'tags', elementType: 'string', operator: 'terms', value: ['a', 'b'] }).values[0]).toBe(
+      '$."tags"[*] ? (@ == $v0 || @ == $v1)',
+    );
+    expect(runArray({ field: 'dates', elementType: 'date', operator: 'eq', value: '2020-01-01' }).values[0]).toBe(
+      '$."dates"[*] ? (@.datetime() == $v.datetime())',
+    );
+    // contains embeds an escaped regex literal and emits the 2-arg form
+    expect(runArray({ field: 'tags', elementType: 'string', operator: 'contains', value: 'a.b' })).toEqual({
+      where: 'jsonb_path_exists("data", $1::jsonpath)',
+      values: ['$."tags"[*] ? (@ like_regex "a\\\\.b")'],
+    });
+  });
+
+  it('containsall falls back to @> (identical to legacy)', () => {
+    expect(runArray({ field: 'tags', elementType: 'string', operator: 'containsall', value: ['a', 'b'] })).toEqual({
+      where: '(("data" #> $1) @> $2::jsonb)',
+      values: [['tags'], '["a","b"]'],
+    });
+  });
+
+  it('isnull / isnotnull use the dialect-independent null check', () => {
+    expect(runArray({ field: 'tags', elementType: 'string', operator: 'isnull' })).toEqual({
+      where: '(("data" #>> $1) is null)',
+      values: [['tags']],
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pnpm -F @rfjs/jsonb-query vitest:run`
+Expected: FAIL — `Not implemented`.
+
+- [ ] **Step 3: Implement `renderArray`** (replace the stub; add `renderJsonbContains` to the `./dialect` import):
+
+```typescript
+renderArray(column, condition, ctx) {
+  const { params } = ctx;
+  const { field, elementType, operator, value } = condition;
+  if (operator === 'isnull' || operator === 'isnotnull') {
+    return renderNullCheck(column, field, operator, params);
+  }
+  if (operator === 'containsall') {
+    return renderJsonbContains(column, field, assertArrayValue(operator, value), params);
+  }
+  const sink = namedSink();
+  const { pred } = scalarPredicate('@', elementType, operator, value, sink);
+  return pathExists(column, `${memberAccessor('$', field)}[*] ? (${pred})`, sink.vars, params);
+},
+```
+
+- [ ] **Step 4: Verify green**
+
+Run: `pnpm -F @rfjs/jsonb-query vitest:run && pnpm -F @rfjs/jsonb-query typecheck`
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/jsonb-query/src/dialect-jsonpath.ts packages/jsonb-query/src/dialect-jsonpath.spec.ts
+git commit -m "feat(jsonb-query): jsonpath scalar-array conditions via [*] filters"
+```
+
+---
+
+### Task 12: jsonpath — `renderElemMatch` (group → predicate walker)
+
+**Files:**
+- Modify: `src/dialect-jsonpath.ts`
+- Test: `src/dialect-jsonpath.spec.ts` (append)
+
+- [ ] **Step 1: Write failing tests** — append (reuses `makeCtx`; add `JsonbElemMatchCondition`, `JsonbFilterGroup` to type imports):
+
+```typescript
+import type { JsonbElemMatchCondition, JsonbFilterGroup } from './types';
+
+describe('jsonpathDialect.renderElemMatch', () => {
+  function runElem(field: string, filters: JsonbFilterGroup) {
+    const p = new ParamBuilder();
+    const cond: JsonbElemMatchCondition = {
+      field, dataType: 'array', elementType: 'object', operator: 'elemmatch', filters,
+    };
+    const where = jsonpathDialect.renderElemMatch('"data"', cond, makeCtx(p));
+    return { where, values: p.values };
+  }
+
+  it('merges all sub-conditions into one path with sequential vars', () => {
+    expect(
+      runElem('items', {
+        logic: 'and',
+        filters: [
+          { field: 'sku', dataType: 'string', operator: 'eq', value: 'x' },
+          { field: 'qty', dataType: 'numeric', operator: 'gt', value: 1 },
+        ],
+      }),
+    ).toEqual({
+      where: 'jsonb_path_exists("data", $1::jsonpath, $2::jsonb)',
+      values: ['$."items"[*] ? (@."sku" == $v0 && @."qty" > $v1)', { v0: 'x', v1: 1 }],
+    });
+  });
+
+  it('wraps nested or-groups and compound predicates in parens', () => {
+    expect(
+      runElem('items', {
+        logic: 'and',
+        filters: [
+          { field: 'sku', dataType: 'string', operator: 'eq', value: 'x' },
+          {
+            logic: 'or',
+            filters: [
+              { field: 'qty', dataType: 'numeric', operator: 'range', value: [1, 9] },
+              { field: 'tag', dataType: 'string', operator: 'terms', value: ['a', 'b'] },
+            ],
+          },
+        ],
+      }).values[0],
+    ).toBe(
+      '$."items"[*] ? (@."sku" == $v0 && ((@."qty" >= $v1 && @."qty" <= $v2) || (@."tag" == $v3 || @."tag" == $v4)))',
+    );
+  });
+
+  it('supports dotted sub-fields, datetime, startswith and null checks', () => {
+    expect(
+      runElem('items', {
+        logic: 'and',
+        filters: [
+          { field: 'detail.x', dataType: 'numeric', operator: 'eq', value: 1 },
+          { field: 'd', dataType: 'date', operator: 'gte', value: '2020-01-01' },
+          { field: 's', dataType: 'string', operator: 'startswith', value: 'x' },
+          { field: 'n', dataType: 'string', operator: 'isnull' },
+          { field: 'm', dataType: 'string', operator: 'isnotnull' },
+        ],
+      }).values[0],
+    ).toBe(
+      '$."items"[*] ? (@."detail"."x" == $v0 && @."d".datetime() >= $v1.datetime() && @."s" starts with $v2 && (!exists (@."n") || @."n" == null) && (exists (@."m") && @."m" != null))',
+    );
+  });
+
+  it('renders nested elemmatch via exists()', () => {
+    expect(
+      runElem('orders', {
+        logic: 'and',
+        filters: [
+          { field: 'status', dataType: 'string', operator: 'eq', value: 'open' },
+          {
+            field: 'lines', dataType: 'array', elementType: 'object', operator: 'elemmatch',
+            filters: { logic: 'and', filters: [{ field: 'sku', dataType: 'string', operator: 'eq', value: 'x' }] },
+          },
+        ],
+      }).values[0],
+    ).toBe('$."orders"[*] ? (@."status" == $v0 && exists (@."lines"[*] ? (@."sku" == $v1)))');
+  });
+
+  it('emits the 2-arg form when no vars are used', () => {
+    expect(
+      runElem('items', {
+        logic: 'and',
+        filters: [{ field: 's', dataType: 'string', operator: 'contains', value: 'x' }],
+      }),
+    ).toEqual({
+      where: 'jsonb_path_exists("data", $1::jsonpath)',
+      values: ['$."items"[*] ? (@."s" like_regex "x")'],
+    });
+  });
+
+  it('escapes hostile member names into the path parameter', () => {
+    expect(
+      runElem('items', {
+        logic: 'and',
+        filters: [{ field: 'a"b', dataType: 'string', operator: 'eq', value: 'x' }],
+      }).values[0],
+    ).toBe('$."items"[*] ? (@."a\\"b" == $v0)');
+  });
+
+  it('rejects object / scalar-array conditions inside elemmatch', () => {
+    expect(() =>
+      runElem('items', {
+        logic: 'and',
+        filters: [{ field: 'p', dataType: 'object', operator: 'eq', value: {} }],
+      }),
+    ).toThrow(/not supported inside elemmatch/i);
+    expect(() =>
+      runElem('items', {
+        logic: 'and',
+        filters: [{ field: 't', dataType: 'array', elementType: 'string', operator: 'eq', value: 'x' }],
+      }),
+    ).toThrow(/not supported inside elemmatch/i);
+  });
+
+  it('throws when the group renders empty', () => {
+    expect(() =>
+      runElem('items', { logic: 'and', filters: [{ logic: 'or', filters: [] }] }),
+    ).toThrow(/requires a filter group with at least one condition/i);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pnpm -F @rfjs/jsonb-query vitest:run`
+Expected: FAIL — `Not implemented`.
+
+- [ ] **Step 3: Implement the walker in `src/dialect-jsonpath.ts`**
+
+Add a sequential sink and the group walker (module level, above the dialect object). Extend imports: `assertCondition`, `isFilterGroup` from `./dialect`; `JsonbCondition`, `JsonbFilterGroup`, `JsonbScalarCondition` types from `./types`.
+
+```typescript
+/** Sequential naming (v0, v1, …) for predicates that merge many conditions. */
+function sequentialSink(): VarSink {
+  const vars: Record<string, JsonbValue> = {};
+  let n = 0;
+  const next = (value: JsonbValue) => {
+    const name = `v${n}`;
+    n += 1;
+    vars[name] = value;
+    return name;
+  };
+  return {
+    vars,
+    one: next,
+    pair: (lo, hi) => [next(lo), next(hi)],
+    many: (values) => values.map(next),
+  };
+}
+
+function groupPredicate(group: JsonbFilterGroup, sink: VarSink): string {
+  const parts = group.filters
+    .map((node) => {
+      if (isFilterGroup(node)) {
+        const inner = groupPredicate(node, sink);
+        return inner.length > 0 ? `(${inner})` : '';
+      }
+      return conditionPredicate(node, sink);
+    })
+    .filter((part) => part.length > 0);
+  return parts.join(group.logic === 'or' ? ' || ' : ' && ');
+}
+
+function conditionPredicate(node: JsonbCondition, sink: VarSink): string {
+  assertCondition(node, 'elemmatch');
+  if (node.dataType === 'array' && node.elementType === 'object') {
+    const inner = groupPredicate(node.filters, sink);
+    if (inner.length === 0) {
+      throw new Error('Operator "elemmatch" requires a filter group with at least one condition');
+    }
+    return `exists (${memberAccessor('@', node.field)}[*] ? (${inner}))`;
+  }
+  // assertCondition only lets scalar conditions through past this point.
+  const scalar = node as JsonbScalarCondition;
+  const { pred, compound } = scalarPredicate(
+    memberAccessor('@', scalar.field),
+    scalar.dataType,
+    scalar.operator,
+    scalar.value,
+    sink,
+  );
+  return compound ? `(${pred})` : pred;
+}
+```
+
+Replace the `renderElemMatch` stub:
+
+```typescript
+renderElemMatch(column, condition, ctx) {
+  const sink = sequentialSink();
+  const pred = groupPredicate(condition.filters, sink);
+  if (pred.length === 0) {
+    throw new Error('Operator "elemmatch" requires a filter group with at least one condition');
+  }
+  return pathExists(
+    column,
+    `${memberAccessor('$', condition.field)}[*] ? (${pred})`,
+    sink.vars,
+    ctx.params,
+  );
+},
+```
+
+- [ ] **Step 4: Verify green**
+
+Run: `pnpm -F @rfjs/jsonb-query vitest:run && pnpm -F @rfjs/jsonb-query typecheck`
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/jsonb-query/src/dialect-jsonpath.ts packages/jsonb-query/src/dialect-jsonpath.spec.ts
+git commit -m "feat(jsonb-query): jsonpath elemmatch as a single merged path predicate"
+```
+
+---
+
+### Task 13: build.ts — dispatch + RenderContext wiring (integration)
+
+**Files:**
+- Modify: `src/build.ts`
+- Test: `src/build.spec.ts` (append)
+
+- [ ] **Step 1: Write failing integration tests** — append to `src/build.spec.ts`:
+
+```typescript
+const GUARD = (col: string, ph: string) =>
+  `case when jsonb_typeof(${col} #> ${ph}) = 'array' then ${col} #> ${ph} else '[]'::jsonb end`;
+
+describe('buildJsonbQuery — phase 2', () => {
+  it('object conditions render identically in both dialects', () => {
+    const filter: JsonbFilterGroup = {
+      logic: 'and',
+      filters: [{ field: 'profile', dataType: 'object', operator: 'eq', value: { vip: true } }],
+    };
+    const legacy = buildJsonbQuery('data', filter);
+    expect(legacy).toEqual({
+      where: '(("data" #> $1) = $2::jsonb)',
+      values: [['profile'], '{"vip":true}'],
+      from: [],
+    });
+    expect(buildJsonbQuery('data', filter, { dialect: 'jsonpath' })).toEqual(legacy);
+  });
+
+  it('array element eq — legacy EXISTS vs jsonpath [*] filter', () => {
+    const filter: JsonbFilterGroup = {
+      logic: 'and',
+      filters: [{ field: 'tags', dataType: 'array', elementType: 'string', operator: 'eq', value: 'a' }],
+    };
+    expect(buildJsonbQuery('data', filter)).toEqual({
+      where: `(exists (select 1 from jsonb_array_elements_text(${GUARD('"data"', '$1')}) as e1(v) where (e1.v = $2)))`,
+      values: [['tags'], 'a'],
+      from: [],
+    });
+    expect(buildJsonbQuery('data', filter, { dialect: 'jsonpath' })).toEqual({
+      where: 'jsonb_path_exists("data", $1::jsonpath, $2::jsonb)',
+      values: ['$."tags"[*] ? (@ == $v)', { v: 'a' }],
+      from: [],
+    });
+  });
+
+  it('sibling array conditions get unique aliases and contiguous params (legacy)', () => {
+    const r = buildJsonbQuery('data', {
+      logic: 'and',
+      filters: [
+        { field: 'tags', dataType: 'array', elementType: 'string', operator: 'eq', value: 'a' },
+        { field: 'nums', dataType: 'array', elementType: 'numeric', operator: 'gt', value: 5 },
+      ],
+    });
+    expect(r.where).toBe(
+      `(exists (select 1 from jsonb_array_elements_text(${GUARD('"data"', '$1')}) as e1(v) where (e1.v = $2))) and ` +
+        `(exists (select 1 from jsonb_array_elements_text(${GUARD('"data"', '$3')}) as e2(v) where (e2.v::numeric > $4)))`,
+    );
+    expect(r.values).toEqual([['tags'], 'a', ['nums'], 5]);
+  });
+
+  it('containsall is identical in both dialects', () => {
+    const filter: JsonbFilterGroup = {
+      logic: 'and',
+      filters: [{ field: 'tags', dataType: 'array', elementType: 'string', operator: 'containsall', value: ['a', 'b'] }],
+    };
+    const legacy = buildJsonbQuery('data', filter);
+    expect(legacy).toEqual({
+      where: '(("data" #> $1) @> $2::jsonb)',
+      values: [['tags'], '["a","b"]'],
+      from: [],
+    });
+    expect(buildJsonbQuery('data', filter, { dialect: 'jsonpath' })).toEqual(legacy);
+  });
+
+  it('elemmatch end-to-end (legacy)', () => {
+    const filter: JsonbFilterGroup = {
+      logic: 'and',
+      filters: [
+        {
+          field: 'items', dataType: 'array', elementType: 'object', operator: 'elemmatch',
+          filters: {
+            logic: 'and',
+            filters: [
+              { field: 'sku', dataType: 'string', operator: 'eq', value: 'x' },
+              { field: 'qty', dataType: 'numeric', operator: 'gt', value: 1 },
+            ],
+          },
+        },
+      ],
+    };
+    expect(buildJsonbQuery('data', filter)).toEqual({
+      where:
+        `(exists (select 1 from jsonb_array_elements(${GUARD('"data"', '$1')}) as e1 ` +
+        'where ((e1.value #>> $2) = $3) and ((e1.value #>> $4)::numeric > $5)))',
+      values: [['items'], ['sku'], 'x', ['qty'], 1],
+      from: [],
+    });
+  });
+
+  it('elemmatch end-to-end (jsonpath)', () => {
+    const filter: JsonbFilterGroup = {
+      logic: 'and',
+      filters: [
+        {
+          field: 'items', dataType: 'array', elementType: 'object', operator: 'elemmatch',
+          filters: {
+            logic: 'and',
+            filters: [
+              { field: 'sku', dataType: 'string', operator: 'eq', value: 'x' },
+              {
+                logic: 'or',
+                filters: [
+                  { field: 'qty', dataType: 'numeric', operator: 'gt', value: 10 },
+                  { field: 'flag', dataType: 'boolean', operator: 'eq', value: true },
+                ],
+              },
+            ],
+          },
+        },
+      ],
+    };
+    expect(buildJsonbQuery('data', filter, { dialect: 'jsonpath' })).toEqual({
+      where: 'jsonb_path_exists("data", $1::jsonpath, $2::jsonb)',
+      values: [
+        '$."items"[*] ? (@."sku" == $v0 && (@."qty" > $v1 || @."flag" == $v2))',
+        { v0: 'x', v1: 10, v2: true },
+      ],
+      from: [],
+    });
+  });
+
+  it('nested elemmatch recurses in both dialects', () => {
+    const filter: JsonbFilterGroup = {
+      logic: 'and',
+      filters: [
+        {
+          field: 'orders', dataType: 'array', elementType: 'object', operator: 'elemmatch',
+          filters: {
+            logic: 'and',
+            filters: [
+              { field: 'status', dataType: 'string', operator: 'eq', value: 'open' },
+              {
+                field: 'lines', dataType: 'array', elementType: 'object', operator: 'elemmatch',
+                filters: { logic: 'and', filters: [{ field: 'sku', dataType: 'string', operator: 'eq', value: 'x' }] },
+              },
+            ],
+          },
+        },
+      ],
+    };
+    expect(buildJsonbQuery('data', filter)).toEqual({
+      where:
+        `(exists (select 1 from jsonb_array_elements(${GUARD('"data"', '$1')}) as e1 ` +
+        'where ((e1.value #>> $2) = $3) and ' +
+        `(exists (select 1 from jsonb_array_elements(${GUARD('e1.value', '$4')}) as e2 where ((e2.value #>> $5) = $6)))))`,
+      values: [['orders'], ['status'], 'open', ['lines'], ['sku'], 'x'],
+      from: [],
+    });
+    expect(buildJsonbQuery('data', filter, { dialect: 'jsonpath' }).values).toEqual([
+      '$."orders"[*] ? (@."status" == $v0 && exists (@."lines"[*] ? (@."sku" == $v1)))',
+      { v0: 'open', v1: 'x' },
+    ]);
+  });
+
+  it('mixes scalar and phase-2 conditions with contiguous params and honours paramOffset', () => {
+    const r = buildJsonbQuery(
+      'data',
+      {
+        logic: 'and',
+        filters: [
+          { field: 'name', dataType: 'string', operator: 'eq', value: 'bob' },
+          { field: 'profile', dataType: 'object', operator: 'contains', value: { vip: true } },
+          { field: 'tags', dataType: 'array', elementType: 'string', operator: 'eq', value: 'a' },
+        ],
+      },
+      { paramOffset: 1 },
+    );
+    expect(r.where).toBe(
+      '(("data" #>> $2) = $3) and (("data" #> $4) @> $5::jsonb) and ' +
+        `(exists (select 1 from jsonb_array_elements_text(${GUARD('"data"', '$6')}) as e1(v) where (e1.v = $7)))`,
+    );
+    expect(r.values).toEqual([['name'], 'bob', ['profile'], '{"vip":true}', ['tags'], 'a']);
+  });
+
+  it('rejects object / scalar-array conditions inside elemmatch in both dialects', () => {
+    const filter: JsonbFilterGroup = {
+      logic: 'and',
+      filters: [
+        {
+          field: 'items', dataType: 'array', elementType: 'object', operator: 'elemmatch',
+          filters: { logic: 'and', filters: [{ field: 'p', dataType: 'object', operator: 'eq', value: {} }] },
+        },
+      ],
+    };
+    expect(() => buildJsonbQuery('data', filter)).toThrow(/not supported inside elemmatch/i);
+    expect(() => buildJsonbQuery('data', filter, { dialect: 'jsonpath' })).toThrow(
+      /not supported inside elemmatch/i,
+    );
+  });
+
+  it('throws when elemmatch filters are empty or render empty', () => {
+    const empty: JsonbFilterGroup = {
+      logic: 'and',
+      filters: [
+        {
+          field: 'items', dataType: 'array', elementType: 'object', operator: 'elemmatch',
+          filters: { logic: 'and', filters: [] },
+        },
+      ],
+    };
+    expect(() => buildJsonbQuery('data', empty)).toThrow(/requires a filter group/i);
+
+    const rendersEmpty: JsonbFilterGroup = {
+      logic: 'and',
+      filters: [
+        {
+          field: 'items', dataType: 'array', elementType: 'object', operator: 'elemmatch',
+          filters: { logic: 'and', filters: [{ logic: 'or', filters: [] }] },
+        },
+      ],
+    };
+    expect(() => buildJsonbQuery('data', rendersEmpty)).toThrow(/at least one condition/i);
+    expect(() => buildJsonbQuery('data', rendersEmpty, { dialect: 'jsonpath' })).toThrow(
+      /at least one condition/i,
+    );
+  });
+
+  it('rejects invalid phase-2 operator combinations', () => {
+    const one = (f: unknown) => () =>
+      buildJsonbQuery('data', { logic: 'and', filters: [f as never] });
+    expect(one({ field: 'p', dataType: 'object', operator: 'gt', value: {} })).toThrow(
+      /unsupported operator "gt" for type "object"/i,
+    );
+    expect(
+      one({ field: 't', dataType: 'array', elementType: 'string', operator: 'neq', value: 'x' }),
+    ).toThrow(/unsupported operator "neq" for array elements/i);
+    expect(
+      one({ field: 'i', dataType: 'array', elementType: 'object', operator: 'eq', value: {} }),
+    ).toThrow(/use "elemmatch"/i);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pnpm -F @rfjs/jsonb-query vitest:run`
+Expected: FAIL — `Not implemented` / validation not yet wired into `build.ts`.
+
+- [ ] **Step 3: Rewrite `src/build.ts`**
+
+```typescript
+import type {
+  JsonbCondition,
+  JsonbDialect,
+  JsonbElemMatchCondition,
+  JsonbFilterGroup,
+  JsonbQueryResult,
+  BuildJsonbOptions,
+} from './types';
+import { ParamBuilder } from './param-builder';
+import { quoteJsonbColumn } from './column';
+import {
+  type ConditionScope,
+  type JsonbQueryDialect,
+  type RenderContext,
+  assertCondition,
+  isFilterGroup,
+} from './dialect';
+import { renderObjectCondition } from './object-condition';
+import { legacyDialect } from './dialect-legacy';
+import { jsonpathDialect } from './dialect-jsonpath';
+
+const DIALECTS = {
+  legacy: legacyDialect,
+  jsonpath: jsonpathDialect,
+} satisfies Record<JsonbDialect, JsonbQueryDialect>;
+
+function isElemMatch(node: JsonbCondition): node is JsonbElemMatchCondition {
+  return node.dataType === 'array' && node.elementType === 'object';
+}
+
+function renderCondition(
+  node: JsonbCondition,
+  column: string,
+  dialect: JsonbQueryDialect,
+  ctx: RenderContext,
+  scope: ConditionScope,
+): string {
+  assertCondition(node, scope);
+  if (isElemMatch(node)) {
+    return dialect.renderElemMatch(column, node, ctx);
+  }
+  if (node.dataType === 'object') {
+    return renderObjectCondition(column, node, ctx.params);
+  }
+  if (node.dataType === 'array') {
+    return dialect.renderArray(column, node, ctx);
+  }
+  return dialect.render(column, node.field, node.dataType, node.operator, node.value, ctx.params);
+}
+
+function buildGroup(
+  group: JsonbFilterGroup,
+  column: string,
+  dialect: JsonbQueryDialect,
+  ctx: RenderContext,
+  scope: ConditionScope,
+): string {
+  const parts = group.filters
+    .map((node) =>
+      isFilterGroup(node)
+        ? wrap(buildGroup(node, column, dialect, ctx, scope))
+        : renderCondition(node, column, dialect, ctx, scope),
+    )
+    .filter((sql) => sql.length > 0);
+  return parts.join(group.logic === 'or' ? ' or ' : ' and ');
+}
+
+function wrap(sql: string): string {
+  return sql.length > 0 ? `(${sql})` : '';
+}
+
+export function buildJsonbQuery(
+  column: string,
+  filter: JsonbFilterGroup,
+  options: BuildJsonbOptions = {},
+): JsonbQueryResult {
+  const quoted = quoteJsonbColumn(column);
+  const dialectName = options.dialect ?? 'legacy';
+  const dialect = DIALECTS[dialectName];
+  if (!dialect) {
+    throw new Error(`Unknown JSONB dialect: "${dialectName}"`);
+  }
+  const params = new ParamBuilder(options.paramOffset ?? 0);
+  let aliasCount = 0;
+  const ctx: RenderContext = {
+    params,
+    nextAlias: () => {
+      aliasCount += 1;
+      return `e${aliasCount}`;
+    },
+    renderGroup: (group, col) => buildGroup(group, col, dialect, ctx, 'elemmatch'),
+  };
+  const where = buildGroup(filter, quoted, dialect, ctx, 'root');
+  return { where, values: params.values, from: [] };
+}
+```
+
+- [ ] **Step 4: Verify the WHOLE suite is green (Phase 1 + Phase 2)**
+
+Run: `pnpm -F @rfjs/jsonb-query vitest:run && pnpm -F @rfjs/jsonb-query typecheck && pnpm -F @rfjs/jsonb-query lint`
+Expected: all tests pass (Phase 1 expectations untouched), tsc and eslint clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/jsonb-query/src/build.ts packages/jsonb-query/src/build.spec.ts
+git commit -m "feat(jsonb-query): dispatch phase-2 conditions through buildJsonbQuery"
+```
+
+---
+
+### Task 14: README updates (en + zh-TW)
+
+**Files:**
+- Modify: `README.md`, `README.zh-TW.md`
+
+- [ ] **Step 1: Update `README.md`** — replace the operator table + trailing "planned" note with:
+
+````markdown
+## Supported types & operators
+
+| dataType | operators |
+|----------|-----------|
+| `string` | `eq` `neq` `isnull` `isnotnull` `contains` `startswith` `endswith` `terms` |
+| `numeric` | `eq` `neq` `isnull` `isnotnull` `gt` `gte` `lt` `lte` `range` `terms` |
+| `date` | `eq` `neq` `isnull` `isnotnull` `gt` `gte` `lt` `lte` `range` `terms` |
+| `boolean` | `eq` `neq` `isnull` `isnotnull` |
+| `object` | `eq` `neq` `contains` `isnull` `isnotnull` |
+| `array` + scalar `elementType` | element ops (see below) + `containsall` + `isnull` `isnotnull` |
+| `array` + `elementType: 'object'` | `elemmatch` |
+
+`range` takes a 2-element `[lo, hi]` value; `terms` takes a non-empty array.
+
+### Nested objects
+
+Dot paths reach nested scalars (`profile.vip`). `dataType: 'object'` compares the
+object value itself — `eq`/`neq` are structural jsonb equality, `contains` is
+jsonb containment (`@>`):
+
+```typescript
+{ field: 'profile', dataType: 'object', operator: 'contains', value: { vip: true } }
+// legacy & jsonpath: (("data" #> $1) @> $2::jsonb)   values: [['profile'], '{"vip":true}']
+```
+
+Object conditions render the same SQL in both dialects (SQL/JSON path predicates
+cannot compare non-scalar values), and `@>` is GIN-indexable.
+
+### JSON arrays (scalar elements)
+
+Declare `dataType: 'array'` with the element type in `elementType`. Scalar
+operators match with **"some element matches"** (∃) semantics; `isnull`/
+`isnotnull` test the array field itself; `containsall` (string/numeric elements)
+requires every listed value to be present. `neq` is not allowed on elements
+(exists-vs-forall ambiguity).
+
+```typescript
+{ field: 'tags', dataType: 'array', elementType: 'string', operator: 'eq', value: 'a' }
+// legacy:   (exists (select 1 from jsonb_array_elements_text(...) as e1(v) where (e1.v = $2)))
+// jsonpath: $."tags"[*] ? (@ == $v)
+
+{ field: 'tags', dataType: 'array', elementType: 'string', operator: 'containsall', value: ['a', 'b'] }
+// both: (("data" #> $1) @> $2::jsonb)
+```
+
+Element operators: string → `eq contains startswith endswith terms`;
+numeric → `eq gt gte lt lte range terms`; date → `eq gt gte lt lte range terms`;
+boolean → `eq`.
+
+### Arrays of objects (`elemmatch`)
+
+All sub-conditions must hold on the **same element**. Sub-`field`s are relative
+to the element; nested `and`/`or` groups and nested `elemmatch` are supported.
+Object-valued and scalar-array conditions inside `elemmatch` are not supported
+yet (rejected in both dialects).
+
+```typescript
+{
+  field: 'items', dataType: 'array', elementType: 'object', operator: 'elemmatch',
+  filters: {
+    logic: 'and',
+    filters: [
+      { field: 'sku', dataType: 'string', operator: 'eq', value: 'x' },
+      { field: 'qty', dataType: 'numeric', operator: 'gt', value: 1 },
+    ],
+  },
+}
+// legacy:   (exists (select 1 from jsonb_array_elements(...) as e1
+//             where ((e1.value #>> $2) = $3) and ((e1.value #>> $4)::numeric > $5)))
+// jsonpath: $."items"[*] ? (@."sku" == $v0 && @."qty" > $v1)
+```
+
+### Semantics notes
+
+- Array element values destined for `::jsonb` parameters are `JSON.stringify`-ed
+  by the builder; pass plain JS values as usual.
+- When the stored value is **not** an array: the legacy dialect treats it as an
+  empty array (no match); the jsonpath dialect (lax mode) auto-wraps a scalar as
+  a one-element array. Keep stored shapes consistent to avoid the divergence.
+- `containsall` on `date` elements is rejected: jsonb containment would compare
+  ISO text, not datetimes.
+````
+
+Also update the Dialects section sentence "Both dialects accept the same filter metadata." → unchanged (still true), and the result-shape note if present: `from` is always `[]`; array queries are self-contained in `where`.
+
+- [ ] **Step 2: Update `README.zh-TW.md`** — mirror the same sections in Traditional Chinese (same code blocks):
+
+````markdown
+## 支援的型別與運算子
+
+| dataType | operators |
+|----------|-----------|
+| `string` | `eq` `neq` `isnull` `isnotnull` `contains` `startswith` `endswith` `terms` |
+| `numeric` | `eq` `neq` `isnull` `isnotnull` `gt` `gte` `lt` `lte` `range` `terms` |
+| `date` | `eq` `neq` `isnull` `isnotnull` `gt` `gte` `lt` `lte` `range` `terms` |
+| `boolean` | `eq` `neq` `isnull` `isnotnull` |
+| `object` | `eq` `neq` `contains` `isnull` `isnotnull` |
+| `array` + 純量 `elementType` | 元素運算子（見下方）+ `containsall` + `isnull` `isnotnull` |
+| `array` + `elementType: 'object'` | `elemmatch` |
+
+`range` 接受 2 個元素的 `[lo, hi]` 陣列；`terms` 接受非空陣列。
+
+### 巢狀物件
+
+點記號路徑可存取巢狀純量（`profile.vip`）。`dataType: 'object'` 則比較物件值
+本身 — `eq`/`neq` 為 jsonb 結構相等比較，`contains` 為 jsonb 包含（`@>`）：
+
+```typescript
+{ field: 'profile', dataType: 'object', operator: 'contains', value: { vip: true } }
+// legacy 與 jsonpath 皆為: (("data" #> $1) @> $2::jsonb)   values: [['profile'], '{"vip":true}']
+```
+
+物件條件在兩種方言中產生相同 SQL（SQL/JSON path 述詞無法比較非純量值），
+且 `@>` 可使用 GIN 索引。
+
+### JSON 陣列（純量元素）
+
+宣告 `dataType: 'array'` 並以 `elementType` 指定元素型別。純量運算子採
+**「任一元素符合」**（∃）語意；`isnull`/`isnotnull` 檢查陣列欄位本身；
+`containsall`（限 string/numeric 元素）要求所有列出的值皆存在。
+元素不支援 `neq`（存在 ∃ 與全稱 ∀ 語意混淆）。
+
+```typescript
+{ field: 'tags', dataType: 'array', elementType: 'string', operator: 'eq', value: 'a' }
+// legacy:   (exists (select 1 from jsonb_array_elements_text(...) as e1(v) where (e1.v = $2)))
+// jsonpath: $."tags"[*] ? (@ == $v)
+
+{ field: 'tags', dataType: 'array', elementType: 'string', operator: 'containsall', value: ['a', 'b'] }
+// 兩種方言皆為: (("data" #> $1) @> $2::jsonb)
+```
+
+元素運算子：string → `eq contains startswith endswith terms`；
+numeric → `eq gt gte lt lte range terms`；date → `eq gt gte lt lte range terms`；
+boolean → `eq`。
+
+### 物件陣列（`elemmatch`）
+
+所有子條件必須在**同一個元素**上成立。子條件的 `field` 為相對於元素的路徑；
+支援巢狀 `and`/`or` 群組與巢狀 `elemmatch`。`elemmatch` 內尚不支援物件條件與
+純量陣列條件（兩種方言皆會拒絕）。
+
+```typescript
+{
+  field: 'items', dataType: 'array', elementType: 'object', operator: 'elemmatch',
+  filters: {
+    logic: 'and',
+    filters: [
+      { field: 'sku', dataType: 'string', operator: 'eq', value: 'x' },
+      { field: 'qty', dataType: 'numeric', operator: 'gt', value: 1 },
+    ],
+  },
+}
+// legacy:   (exists (select 1 from jsonb_array_elements(...) as e1
+//             where ((e1.value #>> $2) = $3) and ((e1.value #>> $4)::numeric > $5)))
+// jsonpath: $."items"[*] ? (@."sku" == $v0 && @."qty" > $v1)
+```
+
+### 語意注意事項
+
+- 進入 `::jsonb` 參數的陣列／物件值會由建構器自動 `JSON.stringify`；照常傳入
+  一般 JS 值即可。
+- 當儲存的值**不是**陣列時：legacy 方言視為空陣列（不符合）；jsonpath 方言
+  （lax 模式）會把純量自動包裝成單元素陣列。請保持資料形狀一致以避免差異。
+- `date` 元素不支援 `containsall`：jsonb 包含比較的是 ISO 文字而非時間值。
+````
+
+(Both files: delete the trailing "planned for a later release" blockquote.)
+
+- [ ] **Step 3: Verify formatting and suite**
+
+Run: `pnpm -F @rfjs/jsonb-query vitest:run && pnpm format`
+Expected: tests pass; prettier reformats nothing unexpected outside the two READMEs.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/jsonb-query/README.md packages/jsonb-query/README.zh-TW.md
+git commit -m "docs(jsonb-query): document phase-2 object/array/elemmatch queries"
+```
+
+---
+
+### Task 15: Final verification (no release steps)
+
+**Files:** none
+
+- [ ] **Step 1: Full package verification**
+
+```bash
+pnpm -F @rfjs/jsonb-query vitest:run
+pnpm -F @rfjs/jsonb-query typecheck
+pnpm -F @rfjs/jsonb-query lint
+pnpm -F @rfjs/jsonb-query build
+```
+
+Expected: all green; tsdown build succeeds.
+
+- [ ] **Step 2: Confirm release guardrails were untouched**
+
+```bash
+git diff main -- packages/jsonb-query/package.json .changeset/config.json
+```
+
+Expected: **empty diff** (`"private": true` intact, changeset `ignore` intact, no changeset files added).
+
+- [ ] **Step 3: Confirm monorepo-level checks**
+
+```bash
+pnpm -F @rfjs/jsonb-query test
+git status
+```
+
+Expected: clean tree, all commits on `feat/jsonb-query-phase2`.
+
+- [ ] **Step 4: STOP — hand back to the user**
+
+Do **not** merge, do not open a PR, do not add a changeset, do not modify `private`/`ignore`. The user reviews the branch first; release wiring (changeset → un-private → un-ignore → release flow, first publish 0.1.0) is an explicitly separate follow-up after sign-off.
+
+---
+
+## Self-review
+
+1. **Spec coverage:** nested objects (Task 6 + 13), JSON arrays (Tasks 8, 11, 13), arrays of objects (Tasks 9, 12, 13), both dialects throughout, parameterization preserved (validated/quoted identifiers + generated aliases are the only SQL-text inputs; hostile-value tests in Tasks 6, 12, 13), spec tests per task, README both languages (Task 14), release guardrails (Task 15). ✓
+2. **Placeholder scan:** none — every step carries full code/commands. ✓
+3. **Type consistency:** `JsonbQueryDialect.renderArray/renderElemMatch(column, condition, ctx)` used identically in Tasks 5, 8, 9, 11, 12, 13; `RenderContext { params, nextAlias, renderGroup }` consistent; `assertCondition(node, scope)` consistent; error strings in implementations match every regex asserted in specs (checked pairwise). ✓

--- a/packages/jsonb-query/README.md
+++ b/packages/jsonb-query/README.md
@@ -63,6 +63,12 @@ interpolated into SQL. The **column** argument is a developer-provided
 identifier: it is validated and quoted (`data`, `t.payload`), and anything that
 is not a plain (optionally qualified) column reference is rejected.
 
+> **API stability:** the exact SQL text this builder emits (casts, parentheses,
+> alias names, jsonpath variable names) is an implementation detail and may
+> change between minor versions — only the query **semantics** and the
+> **parameterization contract** are stable. Don't snapshot-assert the generated
+> strings in consumer tests; assert query results instead.
+
 ## Supported types & operators
 
 | dataType                          | operators                                                                  |

--- a/packages/jsonb-query/README.md
+++ b/packages/jsonb-query/README.md
@@ -134,6 +134,40 @@ yet (rejected in both dialects).
 // jsonpath: $."items"[*] ? (@."sku" == $v0 && @."qty" > $v1)
 ```
 
+### Group logic (`and` / `or` / `nor` / `not`)
+
+Group `logic` is aligned with `@rfjs/data-filter`'s `LogicalOperator`:
+
+| logic | matches when | SQL |
+|-------|--------------|-----|
+| `and` | all children match | `A and B` |
+| `or` | any child matches | `A or B` |
+| `not` | NOT(all children match) | `not (A and B)` |
+| `nor` | NOT(any child matches) | `not (A or B)` |
+
+`not` with a single array condition expresses **"array does not contain"**
+(∀ semantics), consistently in both dialects:
+
+```typescript
+{
+  logic: 'not',
+  filters: [
+    { field: 'tags', dataType: 'array', elementType: 'string', operator: 'eq', value: 'a' },
+  ],
+}
+// legacy:   not ((exists (select 1 from jsonb_array_elements_text(...) where (e1.v = $2))))
+// jsonpath: not (jsonb_path_exists("data", $1::jsonpath, $2::jsonb))
+// A missing field or non-array value counts as "does not contain" in both dialects.
+```
+
+> **SQL three-valued logic caveat:** negating a **scalar** condition on a
+> *missing* field yields SQL `NULL`, so the row does **not** match — unlike
+> `@rfjs/data-filter`, which evaluates the same `not` in memory and matches.
+> When "missing field" should match, add an explicit `isnull` condition:
+> `{ logic: 'or', filters: [{ logic: 'not', ... }, { field, dataType, operator: 'isnull' }] }`.
+> Array conditions are not affected (the empty-array guard keeps both dialects
+> consistent).
+
 ### Semantics notes
 
 - Array element values destined for `::jsonb` parameters are `JSON.stringify`-ed

--- a/packages/jsonb-query/README.md
+++ b/packages/jsonb-query/README.md
@@ -64,14 +64,82 @@ is not a plain (optionally qualified) column reference is rejected.
 
 ## Supported types & operators
 
-| dataType | operators |
-|----------|-----------|
-| `string` | `eq` `neq` `isnull` `isnotnull` `contains` `startswith` `endswith` `terms` |
-| `numeric` | `eq` `neq` `isnull` `isnotnull` `gt` `gte` `lt` `lte` `range` `terms` |
-| `date` | `eq` `neq` `isnull` `isnotnull` `gt` `gte` `lt` `lte` `range` `terms` |
-| `boolean` | `eq` `neq` `isnull` `isnotnull` |
+| dataType                          | operators                                                                  |
+| --------------------------------- | -------------------------------------------------------------------------- |
+| `string`                          | `eq` `neq` `isnull` `isnotnull` `contains` `startswith` `endswith` `terms` |
+| `numeric`                         | `eq` `neq` `isnull` `isnotnull` `gt` `gte` `lt` `lte` `range` `terms`      |
+| `date`                            | `eq` `neq` `isnull` `isnotnull` `gt` `gte` `lt` `lte` `range` `terms`      |
+| `boolean`                         | `eq` `neq` `isnull` `isnotnull`                                            |
+| `object`                          | `eq` `neq` `contains` `isnull` `isnotnull`                                 |
+| `array` + scalar `elementType`    | element ops (see below) + `containsall` + `isnull` `isnotnull`             |
+| `array` + `elementType: 'object'` | `elemmatch`                                                                |
 
 `range` takes a 2-element `[lo, hi]` value; `terms` takes a non-empty array.
 
-> Nested objects, JSON arrays, and arrays of objects are planned for a later
-> release.
+### Nested objects
+
+Dot paths reach nested scalars (`profile.vip`). `dataType: 'object'` compares the
+object value itself — `eq`/`neq` are structural jsonb equality, `contains` is
+jsonb containment (`@>`):
+
+```typescript
+{ field: 'profile', dataType: 'object', operator: 'contains', value: { vip: true } }
+// legacy & jsonpath: (("data" #> $1) @> $2::jsonb)   values: [['profile'], '{"vip":true}']
+```
+
+Object conditions render the same SQL in both dialects (SQL/JSON path predicates
+cannot compare non-scalar values), and `@>` is GIN-indexable.
+
+### JSON arrays (scalar elements)
+
+Declare `dataType: 'array'` with the element type in `elementType`. Scalar
+operators match with **"some element matches"** (∃) semantics; `isnull`/
+`isnotnull` test the array field itself; `containsall` (string/numeric elements)
+requires every listed value to be present. `neq` is not allowed on elements
+(exists-vs-forall ambiguity).
+
+```typescript
+{ field: 'tags', dataType: 'array', elementType: 'string', operator: 'eq', value: 'a' }
+// legacy:   (exists (select 1 from jsonb_array_elements_text(...) as e1(v) where (e1.v = $2)))
+// jsonpath: $."tags"[*] ? (@ == $v)
+
+{ field: 'tags', dataType: 'array', elementType: 'string', operator: 'containsall', value: ['a', 'b'] }
+// both: (("data" #> $1) @> $2::jsonb)
+```
+
+Element operators: string → `eq contains startswith endswith terms`;
+numeric → `eq gt gte lt lte range terms`; date → `eq gt gte lt lte range terms`;
+boolean → `eq`.
+
+### Arrays of objects (`elemmatch`)
+
+All sub-conditions must hold on the **same element**. Sub-`field`s are relative
+to the element; nested `and`/`or` groups and nested `elemmatch` are supported.
+Object-valued and scalar-array conditions inside `elemmatch` are not supported
+yet (rejected in both dialects).
+
+```typescript
+{
+  field: 'items', dataType: 'array', elementType: 'object', operator: 'elemmatch',
+  filters: {
+    logic: 'and',
+    filters: [
+      { field: 'sku', dataType: 'string', operator: 'eq', value: 'x' },
+      { field: 'qty', dataType: 'numeric', operator: 'gt', value: 1 },
+    ],
+  },
+}
+// legacy:   (exists (select 1 from jsonb_array_elements(...) as e1
+//             where ((e1.value #>> $2) = $3) and ((e1.value #>> $4)::numeric > $5)))
+// jsonpath: $."items"[*] ? (@."sku" == $v0 && @."qty" > $v1)
+```
+
+### Semantics notes
+
+- Array element values destined for `::jsonb` parameters are `JSON.stringify`-ed
+  by the builder; pass plain JS values as usual.
+- When the stored value is **not** an array: the legacy dialect treats it as an
+  empty array (no match); the jsonpath dialect (lax mode) auto-wraps a scalar as
+  a one-element array. Keep stored shapes consistent to avoid the divergence.
+- `containsall` on `date` elements is rejected: jsonb containment would compare
+  ISO text, not datetimes.

--- a/packages/jsonb-query/README.md
+++ b/packages/jsonb-query/README.md
@@ -56,6 +56,25 @@ const { where, values } = buildJsonbQuery('data', filter, { paramOffset: 1 });
 await client.query(`SELECT * FROM t WHERE org_id = $1 AND ${where}`, [orgId, ...values]);
 ```
 
+### Named parameters (TypeORM QueryBuilder, Knex)
+
+The positional `$N` output feeds `pg`, TypeORM raw queries, Prisma
+(`$queryRawUnsafe`) and Kysely (`CompiledQuery.raw`) directly. Query layers
+with **named** bindings don't accept `$N` — convert with `toNamedParams`:
+
+```typescript
+import { buildJsonbQuery, toNamedParams } from '@rfjs/jsonb-query';
+
+const { where, params } = toNamedParams(buildJsonbQuery('data', filter));
+// where:  '(("data" #>> :p1) = :p2)'
+// params: { p1: ['name'], p2: 'bob' }
+qb.andWhere(where, params); // TypeORM QueryBuilder / knex.whereRaw(where, params)
+```
+
+Placeholder numbers are detected from the SQL, so `paramOffset` results map
+correctly, and repeated placeholder references (e.g. `startswith`) stay
+pointed at a single named param.
+
 ## Safety
 
 Condition **values** and **field paths** are always parameterized — never

--- a/packages/jsonb-query/README.md
+++ b/packages/jsonb-query/README.md
@@ -41,8 +41,9 @@ buildJsonbQuery('data', filter, { dialect: 'jsonpath' });
 
 - `legacy` (default) — `#>>` extraction with casts. Works on all supported
   PostgreSQL versions.
-- `jsonpath` — `jsonb_path_exists` with SQL/JSON path. Requires PostgreSQL 12+
-  (13+ for `date` comparisons, which use `.datetime()`).
+- `jsonpath` — `jsonb_path_exists` with SQL/JSON path. Requires PostgreSQL 12+.
+  `date` conditions render `jsonb_path_exists_tz` with `.datetime()` and
+  require PostgreSQL 13+.
 
 Both dialects accept the same filter metadata.
 
@@ -177,3 +178,9 @@ Group `logic` is aligned with `@rfjs/data-filter`'s `LogicalOperator`:
   a one-element array. Keep stored shapes consistent to avoid the divergence.
 - `containsall` on `date` elements is rejected: jsonb containment would compare
   ISO text, not datetimes.
+- **jsonpath `date` format caveat:** PG's `.datetime()` does not recognize the
+  trailing `Z` that JS `Date#toISOString()` emits. Query-side values are
+  normalized by the builder (`Z` → `+00:00`, `Date` instances serialized with
+  an offset), but **stored** `"…Z"` strings fail to parse and lax mode silently
+  treats them as non-matching. Store offset formats (`+00:00`) — or use the
+  legacy dialect, whose `::timestamptz` cast accepts every common format.

--- a/packages/jsonb-query/README.md
+++ b/packages/jsonb-query/README.md
@@ -60,20 +60,23 @@ await client.query(`SELECT * FROM t WHERE org_id = $1 AND ${where}`, [orgId, ...
 
 The positional `$N` output feeds `pg`, TypeORM raw queries, Prisma
 (`$queryRawUnsafe`) and Kysely (`CompiledQuery.raw`) directly. Query layers
-with **named** bindings don't accept `$N` — convert with `toNamedParams`:
+with **named** bindings don't accept `$N` — use `buildNamedJsonbQuery`:
 
 ```typescript
-import { buildJsonbQuery, toNamedParams } from '@rfjs/jsonb-query';
+import { buildNamedJsonbQuery } from '@rfjs/jsonb-query';
 
-const { where, params } = toNamedParams(buildJsonbQuery('data', filter));
+const { where, params } = buildNamedJsonbQuery('data', filter);
 // where:  '(("data" #>> :p1) = :p2)'
 // params: { p1: ['name'], p2: 'bob' }
 qb.andWhere(where, params); // TypeORM QueryBuilder / knex.whereRaw(where, params)
 ```
 
-Placeholder numbers are detected from the SQL, so `paramOffset` results map
-correctly, and repeated placeholder references (e.g. `startswith`) stay
-pointed at a single named param.
+It accepts every `buildJsonbQuery` option plus `prefix` (default `"p"`);
+`paramOffset` shifts the parameter *names* (`:p5`, …), which also avoids key
+collisions when composing several fragments. Repeated placeholder references
+(e.g. `startswith`) stay pointed at a single named param — something naive
+positional-`?` conversion cannot express. To convert an existing positional
+result instead, use the underlying `toNamedParams(result, prefix?)`.
 
 ## Safety
 

--- a/packages/jsonb-query/README.zh-TW.md
+++ b/packages/jsonb-query/README.zh-TW.md
@@ -39,7 +39,7 @@ buildJsonbQuery('data', filter, { dialect: 'jsonpath' });
 ```
 
 - `legacy`（預設）— 使用 `#>>` 提取並加型別轉換，相容所有支援的 PostgreSQL 版本。
-- `jsonpath` — 使用 `jsonb_path_exists` 搭配 SQL/JSON 路徑，需要 PostgreSQL 12+（`date` 比較使用 `.datetime()`，需要 PostgreSQL 13+）。
+- `jsonpath` — 使用 `jsonb_path_exists` 搭配 SQL/JSON 路徑，需要 PostgreSQL 12+。`date` 條件會渲染為 `jsonb_path_exists_tz` 搭配 `.datetime()`，需要 PostgreSQL 13+。
 
 兩種方言接受相同的過濾條件格式。
 
@@ -163,3 +163,9 @@ boolean → `eq`。
 - 當儲存的值**不是**陣列時：legacy 方言視為空陣列（不符合）；jsonpath 方言
   （lax 模式）會把純量自動包裝成單元素陣列。請保持資料形狀一致以避免差異。
 - `date` 元素不支援 `containsall`：jsonb 包含比較的是 ISO 文字而非時間值。
+- **jsonpath `date` 格式注意事項：**PG 的 `.datetime()` 不認得 JS
+  `Date#toISOString()` 輸出的 `Z` 後綴。查詢端的值由建構器自動正規化
+  （`Z` → `+00:00`、`Date` 實例序列化為帶偏移量的格式），但**儲存端**的
+  `"…Z"` 字串會解析失敗，且 lax 模式會默默視為不符合。請以偏移量格式
+  （`+00:00`）儲存——或改用 legacy 方言，其 `::timestamptz` 轉型接受所有
+  常見格式。

--- a/packages/jsonb-query/README.zh-TW.md
+++ b/packages/jsonb-query/README.zh-TW.md
@@ -56,19 +56,22 @@ await client.query(`SELECT * FROM t WHERE org_id = $1 AND ${where}`, [orgId, ...
 
 位置型 `$N` 輸出可直接餵給 `pg`、TypeORM raw query、Prisma
 （`$queryRawUnsafe`）與 Kysely（`CompiledQuery.raw`）。使用**具名**綁定的
-查詢層不接受 `$N`——以 `toNamedParams` 轉換：
+查詢層不接受 `$N`——改用 `buildNamedJsonbQuery`：
 
 ```typescript
-import { buildJsonbQuery, toNamedParams } from '@rfjs/jsonb-query';
+import { buildNamedJsonbQuery } from '@rfjs/jsonb-query';
 
-const { where, params } = toNamedParams(buildJsonbQuery('data', filter));
+const { where, params } = buildNamedJsonbQuery('data', filter);
 // where:  '(("data" #>> :p1) = :p2)'
 // params: { p1: ['name'], p2: 'bob' }
 qb.andWhere(where, params); // TypeORM QueryBuilder / knex.whereRaw(where, params)
 ```
 
-佔位符編號會自動從 SQL 偵測，因此 `paramOffset` 的結果也能正確對應；同一
-佔位符被重複引用時（如 `startswith`）仍指向同一個具名參數。
+它接受 `buildJsonbQuery` 的所有選項，外加 `prefix`（預設 `"p"`）；
+`paramOffset` 會位移參數**名稱**（`:p5`、…），組合多個片段時可避免 key
+撞名。同一佔位符被重複引用時（如 `startswith`）仍指向同一個具名參數——
+這是 naive 的位置型 `?` 轉換做不到的。若要轉換既有的位置型結果，可使用
+底層的 `toNamedParams(result, prefix?)`。
 
 ## 安全性
 

--- a/packages/jsonb-query/README.zh-TW.md
+++ b/packages/jsonb-query/README.zh-TW.md
@@ -52,6 +52,24 @@ const { where, values } = buildJsonbQuery('data', filter, { paramOffset: 1 });
 await client.query(`SELECT * FROM t WHERE org_id = $1 AND ${where}`, [orgId, ...values]);
 ```
 
+### 具名參數（TypeORM QueryBuilder、Knex）
+
+位置型 `$N` 輸出可直接餵給 `pg`、TypeORM raw query、Prisma
+（`$queryRawUnsafe`）與 Kysely（`CompiledQuery.raw`）。使用**具名**綁定的
+查詢層不接受 `$N`——以 `toNamedParams` 轉換：
+
+```typescript
+import { buildJsonbQuery, toNamedParams } from '@rfjs/jsonb-query';
+
+const { where, params } = toNamedParams(buildJsonbQuery('data', filter));
+// where:  '(("data" #>> :p1) = :p2)'
+// params: { p1: ['name'], p2: 'bob' }
+qb.andWhere(where, params); // TypeORM QueryBuilder / knex.whereRaw(where, params)
+```
+
+佔位符編號會自動從 SQL 偵測，因此 `paramOffset` 的結果也能正確對應；同一
+佔位符被重複引用時（如 `startswith`）仍指向同一個具名參數。
+
 ## 安全性
 
 條件的**值**與**欄位路徑**一律透過參數化處理，永遠不會插值到 SQL 中。**column** 引數是由開發者提供的識別符：系統會對其進行驗證並加上引號（`data`、`t.payload`），任何不符合純（選擇性限定）欄位參考的輸入都會被拒絕。

--- a/packages/jsonb-query/README.zh-TW.md
+++ b/packages/jsonb-query/README.zh-TW.md
@@ -56,6 +56,11 @@ await client.query(`SELECT * FROM t WHERE org_id = $1 AND ${where}`, [orgId, ...
 
 條件的**值**與**欄位路徑**一律透過參數化處理，永遠不會插值到 SQL 中。**column** 引數是由開發者提供的識別符：系統會對其進行驗證並加上引號（`data`、`t.payload`），任何不符合純（選擇性限定）欄位參考的輸入都會被拒絕。
 
+> **API 穩定性：**本建構器輸出的 SQL 文字細節（型別轉換、括號、別名、
+> jsonpath 變數名稱）屬於實作細節，可能在 minor 版本之間變動——穩定的只有
+> 查詢**語意**與**參數化契約**。請勿在使用端測試中對產出的字串做 snapshot
+> 斷言；應改為斷言查詢結果。
+
 ## 支援的型別與運算子
 
 | dataType                          | operators                                                                  |

--- a/packages/jsonb-query/README.zh-TW.md
+++ b/packages/jsonb-query/README.zh-TW.md
@@ -125,6 +125,37 @@ boolean → `eq`。
 // jsonpath: $."items"[*] ? (@."sku" == $v0 && @."qty" > $v1)
 ```
 
+### 群組邏輯（`and` / `or` / `nor` / `not`）
+
+群組的 `logic` 與 `@rfjs/data-filter` 的 `LogicalOperator` 對齊：
+
+| logic | 符合條件 | SQL |
+|-------|---------|-----|
+| `and` | 所有子條件皆符合 | `A and B` |
+| `or` | 任一子條件符合 | `A or B` |
+| `not` | NOT（所有子條件皆符合） | `not (A and B)` |
+| `nor` | NOT（任一子條件符合） | `not (A or B)` |
+
+`not` 包住單一陣列條件即可表達**「陣列不包含」**（∀ 語意），兩種方言行為一致：
+
+```typescript
+{
+  logic: 'not',
+  filters: [
+    { field: 'tags', dataType: 'array', elementType: 'string', operator: 'eq', value: 'a' },
+  ],
+}
+// legacy:   not ((exists (select 1 from jsonb_array_elements_text(...) where (e1.v = $2))))
+// jsonpath: not (jsonb_path_exists("data", $1::jsonpath, $2::jsonb))
+// 欄位缺失或非陣列值在兩種方言都視為「不包含」（符合條件）。
+```
+
+> **SQL 三值邏輯注意事項：**對**純量**條件取反時，若欄位**缺失**會得到 SQL
+> `NULL`，該 row **不會**符合——這與 `@rfjs/data-filter` 在記憶體中對同一個
+> `not` 的求值結果（符合）不同。若「欄位缺失」也應符合，請明確加上 `isnull`
+> 條件組合：`{ logic: 'or', filters: [{ logic: 'not', ... }, { field, dataType, operator: 'isnull' }] }`。
+> 陣列條件不受影響（空陣列 guard 讓兩種方言行為一致）。
+
 ### 語意注意事項
 
 - 進入 `::jsonb` 參數的陣列／物件值會由建構器自動 `JSON.stringify`；照常傳入

--- a/packages/jsonb-query/README.zh-TW.md
+++ b/packages/jsonb-query/README.zh-TW.md
@@ -58,13 +58,77 @@ await client.query(`SELECT * FROM t WHERE org_id = $1 AND ${where}`, [orgId, ...
 
 ## 支援的型別與運算子
 
-| dataType | operators |
-|----------|-----------|
-| `string` | `eq` `neq` `isnull` `isnotnull` `contains` `startswith` `endswith` `terms` |
-| `numeric` | `eq` `neq` `isnull` `isnotnull` `gt` `gte` `lt` `lte` `range` `terms` |
-| `date` | `eq` `neq` `isnull` `isnotnull` `gt` `gte` `lt` `lte` `range` `terms` |
-| `boolean` | `eq` `neq` `isnull` `isnotnull` |
+| dataType                          | operators                                                                  |
+| --------------------------------- | -------------------------------------------------------------------------- |
+| `string`                          | `eq` `neq` `isnull` `isnotnull` `contains` `startswith` `endswith` `terms` |
+| `numeric`                         | `eq` `neq` `isnull` `isnotnull` `gt` `gte` `lt` `lte` `range` `terms`      |
+| `date`                            | `eq` `neq` `isnull` `isnotnull` `gt` `gte` `lt` `lte` `range` `terms`      |
+| `boolean`                         | `eq` `neq` `isnull` `isnotnull`                                            |
+| `object`                          | `eq` `neq` `contains` `isnull` `isnotnull`                                 |
+| `array` + 純量 `elementType`      | 元素運算子（見下方）+ `containsall` + `isnull` `isnotnull`                 |
+| `array` + `elementType: 'object'` | `elemmatch`                                                                |
 
 `range` 接受 2 個元素的 `[lo, hi]` 陣列；`terms` 接受非空陣列。
 
-> 巢狀物件、JSON 陣列及物件陣列的支援規劃於後續版本推出。
+### 巢狀物件
+
+點記號路徑可存取巢狀純量（`profile.vip`）。`dataType: 'object'` 則比較物件值
+本身 — `eq`/`neq` 為 jsonb 結構相等比較，`contains` 為 jsonb 包含（`@>`）：
+
+```typescript
+{ field: 'profile', dataType: 'object', operator: 'contains', value: { vip: true } }
+// legacy 與 jsonpath 皆為: (("data" #> $1) @> $2::jsonb)   values: [['profile'], '{"vip":true}']
+```
+
+物件條件在兩種方言中產生相同 SQL（SQL/JSON path 述詞無法比較非純量值），
+且 `@>` 可使用 GIN 索引。
+
+### JSON 陣列（純量元素）
+
+宣告 `dataType: 'array'` 並以 `elementType` 指定元素型別。純量運算子採
+**「任一元素符合」**（∃）語意；`isnull`/`isnotnull` 檢查陣列欄位本身；
+`containsall`（限 string/numeric 元素）要求所有列出的值皆存在。
+元素不支援 `neq`（存在 ∃ 與全稱 ∀ 語意混淆）。
+
+```typescript
+{ field: 'tags', dataType: 'array', elementType: 'string', operator: 'eq', value: 'a' }
+// legacy:   (exists (select 1 from jsonb_array_elements_text(...) as e1(v) where (e1.v = $2)))
+// jsonpath: $."tags"[*] ? (@ == $v)
+
+{ field: 'tags', dataType: 'array', elementType: 'string', operator: 'containsall', value: ['a', 'b'] }
+// 兩種方言皆為: (("data" #> $1) @> $2::jsonb)
+```
+
+元素運算子：string → `eq contains startswith endswith terms`；
+numeric → `eq gt gte lt lte range terms`；date → `eq gt gte lt lte range terms`；
+boolean → `eq`。
+
+### 物件陣列（`elemmatch`）
+
+所有子條件必須在**同一個元素**上成立。子條件的 `field` 為相對於元素的路徑；
+支援巢狀 `and`/`or` 群組與巢狀 `elemmatch`。`elemmatch` 內尚不支援物件條件與
+純量陣列條件（兩種方言皆會拒絕）。
+
+```typescript
+{
+  field: 'items', dataType: 'array', elementType: 'object', operator: 'elemmatch',
+  filters: {
+    logic: 'and',
+    filters: [
+      { field: 'sku', dataType: 'string', operator: 'eq', value: 'x' },
+      { field: 'qty', dataType: 'numeric', operator: 'gt', value: 1 },
+    ],
+  },
+}
+// legacy:   (exists (select 1 from jsonb_array_elements(...) as e1
+//             where ((e1.value #>> $2) = $3) and ((e1.value #>> $4)::numeric > $5)))
+// jsonpath: $."items"[*] ? (@."sku" == $v0 && @."qty" > $v1)
+```
+
+### 語意注意事項
+
+- 進入 `::jsonb` 參數的陣列／物件值會由建構器自動 `JSON.stringify`；照常傳入
+  一般 JS 值即可。
+- 當儲存的值**不是**陣列時：legacy 方言視為空陣列（不符合）；jsonpath 方言
+  （lax 模式）會把純量自動包裝成單元素陣列。請保持資料形狀一致以避免差異。
+- `date` 元素不支援 `containsall`：jsonb 包含比較的是 ISO 文字而非時間值。

--- a/packages/jsonb-query/package.json
+++ b/packages/jsonb-query/package.json
@@ -33,7 +33,9 @@
     "vitest:run": "vitest --passWithNoTests --run",
     "vitest:ui": "vitest --passWithNoTests --ui",
     "vitest:e2e": "vitest --config vitest.config.e2e.mts --passWithNoTests",
-    "vitest:e2e:run": "vitest --config vitest.config.e2e.mts --passWithNoTests --run"
+    "vitest:e2e:run": "vitest --config vitest.config.e2e.mts --passWithNoTests --run",
+    "test:e2e": "bash scripts/e2e.sh",
+    "test:e2e:down": "bash scripts/e2e.sh --down"
   },
   "keywords": [],
   "author": "Roy Chuang",

--- a/packages/jsonb-query/package.json
+++ b/packages/jsonb-query/package.json
@@ -31,7 +31,9 @@
     "lint:fix": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "pnpm run vitest:run",
     "vitest:run": "vitest --passWithNoTests --run",
-    "vitest:ui": "vitest --passWithNoTests --ui"
+    "vitest:ui": "vitest --passWithNoTests --ui",
+    "vitest:e2e": "vitest --config vitest.config.e2e.mts --passWithNoTests",
+    "vitest:e2e:run": "vitest --config vitest.config.e2e.mts --passWithNoTests --run"
   },
   "keywords": [],
   "author": "Roy Chuang",
@@ -43,11 +45,13 @@
   ],
   "devDependencies": {
     "@eslint/js": "^9.20.0",
+    "@types/pg": "^8.16.0",
     "@vitest/coverage-istanbul": "^3.2.3",
     "@vitest/ui": "^3.2.3",
     "eslint": "^9.20.1",
     "eslint-config-prettier": "^10.0.1",
     "npm-run-all": "^4.1.5",
+    "pg": "^8.16.3",
     "prettier": "^3.5.1",
     "rimraf": "^6.0.1",
     "ts-node": "^10.9.2",
@@ -55,6 +59,5 @@
     "typescript": "^5.7.3",
     "typescript-eslint": "^8.24.0",
     "vitest": "^3.2.3"
-  },
-  "dependencies": {}
+  }
 }

--- a/packages/jsonb-query/scripts/e2e.sh
+++ b/packages/jsonb-query/scripts/e2e.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# One-shot local E2E for @rfjs/jsonb-query: ensure the PG 11.16 + 16 docker
+# containers exist, wait for readiness, then run the vitest e2e suite.
+#
+# Usage:
+#   pnpm -F @rfjs/jsonb-query test:e2e          # start (if needed) + run
+#   pnpm -F @rfjs/jsonb-query test:e2e:down     # remove the containers
+#
+# CI equivalent: .github/workflows/ci-e2e-jsonb-query.yml (service containers).
+set -euo pipefail
+
+PG11_NAME=jsonb-e2e-pg11
+PG16_NAME=jsonb-e2e-pg16
+PG11_PORT=54311
+PG16_PORT=54316
+
+if [[ "${1:-}" == "--down" ]]; then
+  docker rm -f "$PG11_NAME" "$PG16_NAME" >/dev/null 2>&1 || true
+  echo "e2e containers removed"
+  exit 0
+fi
+
+ensure() { # name image port
+  if ! docker ps --format '{{.Names}}' | grep -qx "$1"; then
+    docker rm -f "$1" >/dev/null 2>&1 || true
+    docker run -d --name "$1" -e POSTGRES_PASSWORD=e2e -p "$3:5432" "$2" >/dev/null
+    echo "started $1 ($2 on :$3)"
+  fi
+}
+
+ensure "$PG11_NAME" postgres:11.16 "$PG11_PORT"
+ensure "$PG16_NAME" postgres:16-alpine "$PG16_PORT"
+
+for name in "$PG11_NAME" "$PG16_NAME"; do
+  ready=0
+  for _ in $(seq 1 30); do
+    if docker exec "$name" pg_isready -U postgres >/dev/null 2>&1; then
+      ready=1
+      break
+    fi
+    sleep 1
+  done
+  if [[ $ready -ne 1 ]]; then
+    echo "$name not ready after 30s" >&2
+    exit 1
+  fi
+done
+
+export PG_E2E_URLS="postgres://postgres:e2e@localhost:${PG11_PORT}/postgres,postgres://postgres:e2e@localhost:${PG16_PORT}/postgres"
+pnpm run vitest:e2e:run

--- a/packages/jsonb-query/src/build.spec.ts
+++ b/packages/jsonb-query/src/build.spec.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import { buildJsonbQuery } from './build';
-import type { JsonbFilterGroup } from './types';
+import type {
+  JsonbArrayCondition,
+  JsonbElemMatchCondition,
+  JsonbFilterGroup,
+  JsonbObjectCondition,
+} from './types';
 
 describe('buildJsonbQuery', () => {
   it('builds a single-condition where with contiguous params (legacy default)', () => {
@@ -141,5 +146,60 @@ describe('buildJsonbQuery', () => {
       '(("data" #>> $1) = $2) and ((("data" #>> $3)::numeric > $4) or ((("data" #>> $5) = $6) and (("data" #>> $7)::boolean = $8)))',
     );
     expect(r.values).toEqual([['a'], 'x', ['b'], 1, ['c'], 'y', ['d'], true]);
+  });
+
+  // Phase 2 condition types are part of the JsonbCondition union but their
+  // rendering lands in later tasks. Until then the dispatcher must reject them
+  // explicitly rather than silently mis-render them as scalar conditions.
+  describe('phase-2 condition types', () => {
+    const object: JsonbObjectCondition = {
+      field: 'profile',
+      dataType: 'object',
+      operator: 'contains',
+      value: { vip: true },
+    };
+    const array: JsonbArrayCondition = {
+      field: 'tags',
+      dataType: 'array',
+      elementType: 'string',
+      operator: 'eq',
+      value: 'a',
+    };
+    const elemMatch: JsonbElemMatchCondition = {
+      field: 'items',
+      dataType: 'array',
+      elementType: 'object',
+      operator: 'elemmatch',
+      filters: {
+        logic: 'and',
+        filters: [{ field: 'sku', dataType: 'string', operator: 'eq', value: 'x' }],
+      },
+    };
+
+    it.each([
+      ['object', object],
+      ['scalar array', array],
+      ['array of objects (elemmatch)', elemMatch],
+    ])('rejects %s conditions instead of mis-rendering them as scalars', (_label, condition) => {
+      expect(() =>
+        buildJsonbQuery('data', { logic: 'and', filters: [condition] }),
+      ).toThrow(/datatype "(object|array)" is not yet supported/i);
+      expect(() =>
+        buildJsonbQuery('data', { logic: 'and', filters: [condition] }, { dialect: 'jsonpath' }),
+      ).toThrow(/datatype "(object|array)" is not yet supported/i);
+    });
+
+    it('still renders scalar conditions on the same field (no scalar regression)', () => {
+      expect(
+        buildJsonbQuery('data', {
+          logic: 'and',
+          filters: [{ field: 'profile', dataType: 'string', operator: 'eq', value: 'a' }],
+        }),
+      ).toEqual({
+        where: '(("data" #>> $1) = $2)',
+        values: [['profile'], 'a'],
+        from: [],
+      });
+    });
   });
 });

--- a/packages/jsonb-query/src/build.spec.ts
+++ b/packages/jsonb-query/src/build.spec.ts
@@ -1,11 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { buildJsonbQuery } from './build';
-import type {
-  JsonbArrayCondition,
-  JsonbElemMatchCondition,
-  JsonbFilterGroup,
-  JsonbObjectCondition,
-} from './types';
+import type { JsonbFilterGroup } from './types';
 
 describe('buildJsonbQuery', () => {
   it('builds a single-condition where with contiguous params (legacy default)', () => {
@@ -148,47 +143,11 @@ describe('buildJsonbQuery', () => {
     expect(r.values).toEqual([['a'], 'x', ['b'], 1, ['c'], 'y', ['d'], true]);
   });
 
-  // Phase 2 condition types are part of the JsonbCondition union but their
-  // rendering lands in later tasks. Until then the dispatcher must reject them
-  // explicitly rather than silently mis-render them as scalar conditions.
+  // Phase 2 condition types (object / scalar-array / elemmatch) are dispatched
+  // and rendered by buildJsonbQuery as of Task 13; full end-to-end coverage
+  // lives in the "buildJsonbQuery — phase 2" describe block below. This block
+  // only guards that scalar rendering on the same field is unaffected.
   describe('phase-2 condition types', () => {
-    const object: JsonbObjectCondition = {
-      field: 'profile',
-      dataType: 'object',
-      operator: 'contains',
-      value: { vip: true },
-    };
-    const array: JsonbArrayCondition = {
-      field: 'tags',
-      dataType: 'array',
-      elementType: 'string',
-      operator: 'eq',
-      value: 'a',
-    };
-    const elemMatch: JsonbElemMatchCondition = {
-      field: 'items',
-      dataType: 'array',
-      elementType: 'object',
-      operator: 'elemmatch',
-      filters: {
-        logic: 'and',
-        filters: [{ field: 'sku', dataType: 'string', operator: 'eq', value: 'x' }],
-      },
-    };
-
-    it.each([
-      ['object', object],
-      ['scalar array', array],
-      ['array of objects (elemmatch)', elemMatch],
-    ])('rejects %s conditions instead of mis-rendering them as scalars', (_label, condition) => {
-      expect(() =>
-        buildJsonbQuery('data', { logic: 'and', filters: [condition] }),
-      ).toThrow(/datatype "(object|array)" is not yet supported/i);
-      expect(() =>
-        buildJsonbQuery('data', { logic: 'and', filters: [condition] }, { dialect: 'jsonpath' }),
-      ).toThrow(/datatype "(object|array)" is not yet supported/i);
-    });
-
     it('still renders scalar conditions on the same field (no scalar regression)', () => {
       expect(
         buildJsonbQuery('data', {
@@ -201,5 +160,237 @@ describe('buildJsonbQuery', () => {
         from: [],
       });
     });
+  });
+});
+
+const GUARD = (col: string, ph: string) =>
+  `case when jsonb_typeof(${col} #> ${ph}) = 'array' then ${col} #> ${ph} else '[]'::jsonb end`;
+
+describe('buildJsonbQuery — phase 2', () => {
+  it('object conditions render identically in both dialects', () => {
+    const filter: JsonbFilterGroup = {
+      logic: 'and',
+      filters: [{ field: 'profile', dataType: 'object', operator: 'eq', value: { vip: true } }],
+    };
+    const legacy = buildJsonbQuery('data', filter);
+    expect(legacy).toEqual({
+      where: '(("data" #> $1) = $2::jsonb)',
+      values: [['profile'], '{"vip":true}'],
+      from: [],
+    });
+    expect(buildJsonbQuery('data', filter, { dialect: 'jsonpath' })).toEqual(legacy);
+  });
+
+  it('array element eq — legacy EXISTS vs jsonpath [*] filter', () => {
+    const filter: JsonbFilterGroup = {
+      logic: 'and',
+      filters: [{ field: 'tags', dataType: 'array', elementType: 'string', operator: 'eq', value: 'a' }],
+    };
+    expect(buildJsonbQuery('data', filter)).toEqual({
+      where: `(exists (select 1 from jsonb_array_elements_text(${GUARD('"data"', '$1')}) as e1(v) where (e1.v = $2)))`,
+      values: [['tags'], 'a'],
+      from: [],
+    });
+    expect(buildJsonbQuery('data', filter, { dialect: 'jsonpath' })).toEqual({
+      where: 'jsonb_path_exists("data", $1::jsonpath, $2::jsonb)',
+      values: ['$."tags"[*] ? (@ == $v)', { v: 'a' }],
+      from: [],
+    });
+  });
+
+  it('sibling array conditions get unique aliases and contiguous params (legacy)', () => {
+    const r = buildJsonbQuery('data', {
+      logic: 'and',
+      filters: [
+        { field: 'tags', dataType: 'array', elementType: 'string', operator: 'eq', value: 'a' },
+        { field: 'nums', dataType: 'array', elementType: 'numeric', operator: 'gt', value: 5 },
+      ],
+    });
+    expect(r.where).toBe(
+      `(exists (select 1 from jsonb_array_elements_text(${GUARD('"data"', '$1')}) as e1(v) where (e1.v = $2))) and ` +
+        `(exists (select 1 from jsonb_array_elements_text(${GUARD('"data"', '$3')}) as e2(v) where (e2.v::numeric > $4)))`,
+    );
+    expect(r.values).toEqual([['tags'], 'a', ['nums'], 5]);
+  });
+
+  it('containsall is identical in both dialects', () => {
+    const filter: JsonbFilterGroup = {
+      logic: 'and',
+      filters: [{ field: 'tags', dataType: 'array', elementType: 'string', operator: 'containsall', value: ['a', 'b'] }],
+    };
+    const legacy = buildJsonbQuery('data', filter);
+    expect(legacy).toEqual({
+      where: '(("data" #> $1) @> $2::jsonb)',
+      values: [['tags'], '["a","b"]'],
+      from: [],
+    });
+    expect(buildJsonbQuery('data', filter, { dialect: 'jsonpath' })).toEqual(legacy);
+  });
+
+  it('elemmatch end-to-end (legacy)', () => {
+    const filter: JsonbFilterGroup = {
+      logic: 'and',
+      filters: [
+        {
+          field: 'items', dataType: 'array', elementType: 'object', operator: 'elemmatch',
+          filters: {
+            logic: 'and',
+            filters: [
+              { field: 'sku', dataType: 'string', operator: 'eq', value: 'x' },
+              { field: 'qty', dataType: 'numeric', operator: 'gt', value: 1 },
+            ],
+          },
+        },
+      ],
+    };
+    expect(buildJsonbQuery('data', filter)).toEqual({
+      where:
+        `(exists (select 1 from jsonb_array_elements(${GUARD('"data"', '$1')}) as e1 ` +
+        'where ((e1.value #>> $2) = $3) and ((e1.value #>> $4)::numeric > $5)))',
+      values: [['items'], ['sku'], 'x', ['qty'], 1],
+      from: [],
+    });
+  });
+
+  it('elemmatch end-to-end (jsonpath)', () => {
+    const filter: JsonbFilterGroup = {
+      logic: 'and',
+      filters: [
+        {
+          field: 'items', dataType: 'array', elementType: 'object', operator: 'elemmatch',
+          filters: {
+            logic: 'and',
+            filters: [
+              { field: 'sku', dataType: 'string', operator: 'eq', value: 'x' },
+              {
+                logic: 'or',
+                filters: [
+                  { field: 'qty', dataType: 'numeric', operator: 'gt', value: 10 },
+                  { field: 'flag', dataType: 'boolean', operator: 'eq', value: true },
+                ],
+              },
+            ],
+          },
+        },
+      ],
+    };
+    expect(buildJsonbQuery('data', filter, { dialect: 'jsonpath' })).toEqual({
+      where: 'jsonb_path_exists("data", $1::jsonpath, $2::jsonb)',
+      values: [
+        '$."items"[*] ? (@."sku" == $v0 && (@."qty" > $v1 || @."flag" == $v2))',
+        { v0: 'x', v1: 10, v2: true },
+      ],
+      from: [],
+    });
+  });
+
+  it('nested elemmatch recurses in both dialects', () => {
+    const filter: JsonbFilterGroup = {
+      logic: 'and',
+      filters: [
+        {
+          field: 'orders', dataType: 'array', elementType: 'object', operator: 'elemmatch',
+          filters: {
+            logic: 'and',
+            filters: [
+              { field: 'status', dataType: 'string', operator: 'eq', value: 'open' },
+              {
+                field: 'lines', dataType: 'array', elementType: 'object', operator: 'elemmatch',
+                filters: { logic: 'and', filters: [{ field: 'sku', dataType: 'string', operator: 'eq', value: 'x' }] },
+              },
+            ],
+          },
+        },
+      ],
+    };
+    expect(buildJsonbQuery('data', filter)).toEqual({
+      where:
+        `(exists (select 1 from jsonb_array_elements(${GUARD('"data"', '$1')}) as e1 ` +
+        'where ((e1.value #>> $2) = $3) and ' +
+        `(exists (select 1 from jsonb_array_elements(${GUARD('e1.value', '$4')}) as e2 where ((e2.value #>> $5) = $6)))))`,
+      values: [['orders'], ['status'], 'open', ['lines'], ['sku'], 'x'],
+      from: [],
+    });
+    expect(buildJsonbQuery('data', filter, { dialect: 'jsonpath' }).values).toEqual([
+      '$."orders"[*] ? (@."status" == $v0 && exists (@."lines"[*] ? (@."sku" == $v1)))',
+      { v0: 'open', v1: 'x' },
+    ]);
+  });
+
+  it('mixes scalar and phase-2 conditions with contiguous params and honours paramOffset', () => {
+    const r = buildJsonbQuery(
+      'data',
+      {
+        logic: 'and',
+        filters: [
+          { field: 'name', dataType: 'string', operator: 'eq', value: 'bob' },
+          { field: 'profile', dataType: 'object', operator: 'contains', value: { vip: true } },
+          { field: 'tags', dataType: 'array', elementType: 'string', operator: 'eq', value: 'a' },
+        ],
+      },
+      { paramOffset: 1 },
+    );
+    expect(r.where).toBe(
+      '(("data" #>> $2) = $3) and (("data" #> $4) @> $5::jsonb) and ' +
+        `(exists (select 1 from jsonb_array_elements_text(${GUARD('"data"', '$6')}) as e1(v) where (e1.v = $7)))`,
+    );
+    expect(r.values).toEqual([['name'], 'bob', ['profile'], '{"vip":true}', ['tags'], 'a']);
+  });
+
+  it('rejects object / scalar-array conditions inside elemmatch in both dialects', () => {
+    const filter: JsonbFilterGroup = {
+      logic: 'and',
+      filters: [
+        {
+          field: 'items', dataType: 'array', elementType: 'object', operator: 'elemmatch',
+          filters: { logic: 'and', filters: [{ field: 'p', dataType: 'object', operator: 'eq', value: {} }] },
+        },
+      ],
+    };
+    expect(() => buildJsonbQuery('data', filter)).toThrow(/not supported inside elemmatch/i);
+    expect(() => buildJsonbQuery('data', filter, { dialect: 'jsonpath' })).toThrow(
+      /not supported inside elemmatch/i,
+    );
+  });
+
+  it('throws when elemmatch filters are empty or render empty', () => {
+    const empty: JsonbFilterGroup = {
+      logic: 'and',
+      filters: [
+        {
+          field: 'items', dataType: 'array', elementType: 'object', operator: 'elemmatch',
+          filters: { logic: 'and', filters: [] },
+        },
+      ],
+    };
+    expect(() => buildJsonbQuery('data', empty)).toThrow(/requires a filter group/i);
+
+    const rendersEmpty: JsonbFilterGroup = {
+      logic: 'and',
+      filters: [
+        {
+          field: 'items', dataType: 'array', elementType: 'object', operator: 'elemmatch',
+          filters: { logic: 'and', filters: [{ logic: 'or', filters: [] }] },
+        },
+      ],
+    };
+    expect(() => buildJsonbQuery('data', rendersEmpty)).toThrow(/at least one condition/i);
+    expect(() => buildJsonbQuery('data', rendersEmpty, { dialect: 'jsonpath' })).toThrow(
+      /at least one condition/i,
+    );
+  });
+
+  it('rejects invalid phase-2 operator combinations', () => {
+    const one = (f: unknown) => () =>
+      buildJsonbQuery('data', { logic: 'and', filters: [f as never] });
+    expect(one({ field: 'p', dataType: 'object', operator: 'gt', value: {} })).toThrow(
+      /unsupported operator "gt" for type "object"/i,
+    );
+    expect(
+      one({ field: 't', dataType: 'array', elementType: 'string', operator: 'neq', value: 'x' }),
+    ).toThrow(/unsupported operator "neq" for array elements/i);
+    expect(
+      one({ field: 'i', dataType: 'array', elementType: 'object', operator: 'eq', value: {} }),
+    ).toThrow(/use "elemmatch"/i);
   });
 });

--- a/packages/jsonb-query/src/build.spec.ts
+++ b/packages/jsonb-query/src/build.spec.ts
@@ -394,3 +394,101 @@ describe('buildJsonbQuery — phase 2', () => {
     ).toThrow(/use "elemmatch"/i);
   });
 });
+
+describe('buildJsonbQuery — nor/not logical operators', () => {
+  const GUARD2 = (col: string, ph: string) =>
+    `case when jsonb_typeof(${col} #> ${ph}) = 'array' then ${col} #> ${ph} else '[]'::jsonb end`;
+
+  it('not negates the conjunction of its children', () => {
+    expect(
+      buildJsonbQuery('data', {
+        logic: 'not',
+        filters: [
+          { field: 'name', dataType: 'string', operator: 'eq', value: 'bob' },
+          { field: 'age', dataType: 'numeric', operator: 'gt', value: 18 },
+        ],
+      }),
+    ).toEqual({
+      where: 'not ((("data" #>> $1) = $2) and (("data" #>> $3)::numeric > $4))',
+      values: [['name'], 'bob', ['age'], 18],
+      from: [],
+    });
+  });
+
+  it('nor negates the disjunction of its children', () => {
+    expect(
+      buildJsonbQuery('data', {
+        logic: 'nor',
+        filters: [
+          { field: 'name', dataType: 'string', operator: 'eq', value: 'bob' },
+          { field: 'age', dataType: 'numeric', operator: 'gt', value: 18 },
+        ],
+      }).where,
+    ).toBe('not ((("data" #>> $1) = $2) or (("data" #>> $3)::numeric > $4))');
+  });
+
+  it('expresses array not-contains in both dialects', () => {
+    const filter: JsonbFilterGroup = {
+      logic: 'not',
+      filters: [
+        { field: 'tags', dataType: 'array', elementType: 'string', operator: 'eq', value: 'a' },
+      ],
+    };
+    expect(buildJsonbQuery('data', filter)).toEqual({
+      where: `not ((exists (select 1 from jsonb_array_elements_text(${GUARD2('"data"', '$1')}) as e1(v) where (e1.v = $2))))`,
+      values: [['tags'], 'a'],
+      from: [],
+    });
+    expect(buildJsonbQuery('data', filter, { dialect: 'jsonpath' })).toEqual({
+      where: 'not (jsonb_path_exists("data", $1::jsonpath, $2::jsonb))',
+      values: ['$."tags"[*] ? (@ == $v)', { v: 'a' }],
+      from: [],
+    });
+  });
+
+  it('wraps a nested not group inside an and group', () => {
+    expect(
+      buildJsonbQuery('data', {
+        logic: 'and',
+        filters: [
+          { field: 'name', dataType: 'string', operator: 'eq', value: 'bob' },
+          {
+            logic: 'not',
+            filters: [{ field: 'vip', dataType: 'boolean', operator: 'eq', value: true }],
+          },
+        ],
+      }).where,
+    ).toBe('(("data" #>> $1) = $2) and (not ((("data" #>> $3)::boolean = $4)))');
+  });
+
+  it('supports not groups inside elemmatch (legacy)', () => {
+    expect(
+      buildJsonbQuery('data', {
+        logic: 'and',
+        filters: [
+          {
+            field: 'items', dataType: 'array', elementType: 'object', operator: 'elemmatch',
+            filters: {
+              logic: 'and',
+              filters: [
+                { field: 'sku', dataType: 'string', operator: 'eq', value: 'x' },
+                {
+                  logic: 'not',
+                  filters: [{ field: 'qty', dataType: 'numeric', operator: 'gt', value: 5 }],
+                },
+              ],
+            },
+          },
+        ],
+      }).where,
+    ).toBe(
+      `(exists (select 1 from jsonb_array_elements(${GUARD2('"data"', '$1')}) as e1 ` +
+        'where ((e1.value #>> $2) = $3) and (not (((e1.value #>> $4)::numeric > $5)))))',
+    );
+  });
+
+  it('drops empty not/nor groups (phase-1 empty-group convention)', () => {
+    expect(buildJsonbQuery('data', { logic: 'not', filters: [] }).where).toBe('');
+    expect(buildJsonbQuery('data', { logic: 'nor', filters: [] }).where).toBe('');
+  });
+});

--- a/packages/jsonb-query/src/build.ts
+++ b/packages/jsonb-query/src/build.ts
@@ -1,14 +1,21 @@
 import type {
   JsonbCondition,
   JsonbDialect,
+  JsonbElemMatchCondition,
   JsonbFilterGroup,
   JsonbQueryResult,
   BuildJsonbOptions,
 } from './types';
 import { ParamBuilder } from './param-builder';
 import { quoteJsonbColumn } from './column';
-import type { JsonbQueryDialect } from './dialect';
-import { assertOperatorForType, isFilterGroup } from './dialect';
+import {
+  type ConditionScope,
+  type JsonbQueryDialect,
+  type RenderContext,
+  assertCondition,
+  isFilterGroup,
+} from './dialect';
+import { renderObjectCondition } from './object-condition';
 import { legacyDialect } from './dialect-legacy';
 import { jsonpathDialect } from './dialect-jsonpath';
 
@@ -17,34 +24,42 @@ const DIALECTS = {
   jsonpath: jsonpathDialect,
 } satisfies Record<JsonbDialect, JsonbQueryDialect>;
 
+function isElemMatch(node: JsonbCondition): node is JsonbElemMatchCondition {
+  return node.dataType === 'array' && node.elementType === 'object';
+}
+
 function renderCondition(
   node: JsonbCondition,
   column: string,
   dialect: JsonbQueryDialect,
-  params: ParamBuilder,
+  ctx: RenderContext,
+  scope: ConditionScope,
 ): string {
-  if (node.dataType === 'object' || node.dataType === 'array') {
-    // Object / scalar-array / elemmatch rendering lands in later tasks; until
-    // then reject them explicitly rather than mis-render them as scalars.
-    throw new Error(
-      `dataType "${node.dataType}" is not yet supported by buildJsonbQuery`,
-    );
+  assertCondition(node, scope);
+  if (isElemMatch(node)) {
+    return dialect.renderElemMatch(column, node, ctx);
   }
-  assertOperatorForType(node.dataType, node.operator);
-  return dialect.render(column, node.field, node.dataType, node.operator, node.value, params);
+  if (node.dataType === 'object') {
+    return renderObjectCondition(column, node, ctx.params);
+  }
+  if (node.dataType === 'array') {
+    return dialect.renderArray(column, node, ctx);
+  }
+  return dialect.render(column, node.field, node.dataType, node.operator, node.value, ctx.params);
 }
 
 function buildGroup(
   group: JsonbFilterGroup,
   column: string,
   dialect: JsonbQueryDialect,
-  params: ParamBuilder,
+  ctx: RenderContext,
+  scope: ConditionScope,
 ): string {
   const parts = group.filters
     .map((node) =>
       isFilterGroup(node)
-        ? wrap(buildGroup(node, column, dialect, params))
-        : renderCondition(node, column, dialect, params),
+        ? wrap(buildGroup(node, column, dialect, ctx, scope))
+        : renderCondition(node, column, dialect, ctx, scope),
     )
     .filter((sql) => sql.length > 0);
   return parts.join(group.logic === 'or' ? ' or ' : ' and ');
@@ -66,6 +81,15 @@ export function buildJsonbQuery(
     throw new Error(`Unknown JSONB dialect: "${dialectName}"`);
   }
   const params = new ParamBuilder(options.paramOffset ?? 0);
-  const where = buildGroup(filter, quoted, dialect, params);
+  let aliasCount = 0;
+  const ctx: RenderContext = {
+    params,
+    nextAlias: () => {
+      aliasCount += 1;
+      return `e${aliasCount}`;
+    },
+    renderGroup: (group, col) => buildGroup(group, col, dialect, ctx, 'elemmatch'),
+  };
+  const where = buildGroup(filter, quoted, dialect, ctx, 'root');
   return { where, values: params.values, from: [] };
 }

--- a/packages/jsonb-query/src/build.ts
+++ b/packages/jsonb-query/src/build.ts
@@ -7,7 +7,7 @@ import type {
 } from './types';
 import { ParamBuilder } from './param-builder';
 import { quoteJsonbColumn } from './column';
-import type { ScalarDialect } from './dialect';
+import type { JsonbQueryDialect } from './dialect';
 import { assertOperatorForType, isFilterGroup } from './dialect';
 import { legacyDialect } from './dialect-legacy';
 import { jsonpathDialect } from './dialect-jsonpath';
@@ -15,12 +15,12 @@ import { jsonpathDialect } from './dialect-jsonpath';
 const DIALECTS = {
   legacy: legacyDialect,
   jsonpath: jsonpathDialect,
-} satisfies Record<JsonbDialect, ScalarDialect>;
+} satisfies Record<JsonbDialect, JsonbQueryDialect>;
 
 function renderCondition(
   node: JsonbCondition,
   column: string,
-  dialect: ScalarDialect,
+  dialect: JsonbQueryDialect,
   params: ParamBuilder,
 ): string {
   if (node.dataType === 'object' || node.dataType === 'array') {
@@ -37,7 +37,7 @@ function renderCondition(
 function buildGroup(
   group: JsonbFilterGroup,
   column: string,
-  dialect: ScalarDialect,
+  dialect: JsonbQueryDialect,
   params: ParamBuilder,
 ): string {
   const parts = group.filters

--- a/packages/jsonb-query/src/build.ts
+++ b/packages/jsonb-query/src/build.ts
@@ -8,7 +8,7 @@ import type {
 import { ParamBuilder } from './param-builder';
 import { quoteJsonbColumn } from './column';
 import type { ScalarDialect } from './dialect';
-import { assertOperatorForType } from './dialect';
+import { assertOperatorForType, isFilterGroup } from './dialect';
 import { legacyDialect } from './dialect-legacy';
 import { jsonpathDialect } from './dialect-jsonpath';
 
@@ -16,12 +16,6 @@ const DIALECTS = {
   legacy: legacyDialect,
   jsonpath: jsonpathDialect,
 } satisfies Record<JsonbDialect, ScalarDialect>;
-
-function isGroup(
-  node: JsonbCondition | JsonbFilterGroup,
-): node is JsonbFilterGroup {
-  return 'logic' in node && 'filters' in node;
-}
 
 function renderCondition(
   node: JsonbCondition,
@@ -48,7 +42,7 @@ function buildGroup(
 ): string {
   const parts = group.filters
     .map((node) =>
-      isGroup(node)
+      isFilterGroup(node)
         ? wrap(buildGroup(node, column, dialect, params))
         : renderCondition(node, column, dialect, params),
     )

--- a/packages/jsonb-query/src/build.ts
+++ b/packages/jsonb-query/src/build.ts
@@ -29,6 +29,13 @@ function renderCondition(
   dialect: ScalarDialect,
   params: ParamBuilder,
 ): string {
+  if (node.dataType === 'object' || node.dataType === 'array') {
+    // Object / scalar-array / elemmatch rendering lands in later tasks; until
+    // then reject them explicitly rather than mis-render them as scalars.
+    throw new Error(
+      `dataType "${node.dataType}" is not yet supported by buildJsonbQuery`,
+    );
+  }
   assertOperatorForType(node.dataType, node.operator);
   return dialect.render(column, node.field, node.dataType, node.operator, node.value, params);
 }

--- a/packages/jsonb-query/src/build.ts
+++ b/packages/jsonb-query/src/build.ts
@@ -62,7 +62,16 @@ function buildGroup(
         : renderCondition(node, column, dialect, ctx, scope),
     )
     .filter((sql) => sql.length > 0);
-  return parts.join(group.logic === 'or' ? ' or ' : ' and ');
+  return joinLogic(parts, group.logic);
+}
+
+/** Join rendered parts per group logic; `not`/`nor` negate the joined result. */
+function joinLogic(parts: string[], logic: JsonbFilterGroup['logic']): string {
+  if (parts.length === 0) {
+    return '';
+  }
+  const joined = parts.join(logic === 'or' || logic === 'nor' ? ' or ' : ' and ');
+  return logic === 'not' || logic === 'nor' ? `not (${joined})` : joined;
 }
 
 function wrap(sql: string): string {

--- a/packages/jsonb-query/src/dialect-jsonpath.spec.ts
+++ b/packages/jsonb-query/src/dialect-jsonpath.spec.ts
@@ -317,3 +317,70 @@ describe('jsonpathDialect.renderElemMatch — nor/not groups', () => {
     ).toBe('$."items"[*] ? (@."sku" == $v0 && (!(@."qty" > $v1)))');
   });
 });
+
+describe('jsonpathDialect — datetime normalization and _tz switch', () => {
+  it('date comparisons emit jsonb_path_exists_tz', () => {
+    expect(run('d', 'date', 'eq', '2020-01-01')).toEqual({
+      where: 'jsonb_path_exists_tz("data", $1::jsonpath, $2::jsonb)',
+      values: ['$."d" ? (@.datetime() == $v.datetime())', { v: '2020-01-01' }],
+    });
+  });
+
+  it('non-date conditions keep jsonb_path_exists', () => {
+    expect(run('name', 'string', 'eq', 'bob').where).toBe(
+      'jsonb_path_exists("data", $1::jsonpath, $2::jsonb)',
+    );
+  });
+
+  it('normalizes a trailing Z (JS toISOString format) to +00:00', () => {
+    expect(run('d', 'date', 'eq', '2020-01-15T08:30:00Z').values[1]).toEqual({
+      v: '2020-01-15T08:30:00+00:00',
+    });
+  });
+
+  it('normalizes Date instances to an offset ISO string', () => {
+    expect(run('d', 'date', 'eq', new Date('2020-01-15T08:30:00Z')).values[1]).toEqual({
+      v: '2020-01-15T08:30:00.000+00:00',
+    });
+  });
+
+  it('normalizes range and terms date values', () => {
+    expect(
+      run('d', 'date', 'range', ['2020-01-01T00:00:00Z', '2021-01-01T00:00:00Z']).values[1],
+    ).toEqual({ lo: '2020-01-01T00:00:00+00:00', hi: '2021-01-01T00:00:00+00:00' });
+    expect(run('d', 'date', 'terms', ['2020-01-01T00:00:00Z']).values[1]).toEqual({
+      v0: '2020-01-01T00:00:00+00:00',
+    });
+  });
+
+  it('renderArray with date elements uses _tz and normalized values', () => {
+    const p = new ParamBuilder();
+    const where = jsonpathDialect.renderArray(
+      '"data"',
+      { field: 'dates', dataType: 'array', elementType: 'date', operator: 'gt', value: '2020-06-01T00:00:00Z' },
+      makeCtx(p),
+    );
+    expect(where).toBe('jsonb_path_exists_tz("data", $1::jsonpath, $2::jsonb)');
+    expect(p.values[1]).toEqual({ v: '2020-06-01T00:00:00+00:00' });
+  });
+
+  it('elemmatch containing a date sub-condition switches the whole path to _tz', () => {
+    const p = new ParamBuilder();
+    const where = jsonpathDialect.renderElemMatch(
+      '"data"',
+      {
+        field: 'items', dataType: 'array', elementType: 'object', operator: 'elemmatch',
+        filters: {
+          logic: 'and',
+          filters: [
+            { field: 'sku', dataType: 'string', operator: 'eq', value: 'y' },
+            { field: 'ship', dataType: 'date', operator: 'gt', value: '2020-12-31T00:00:00Z' },
+          ],
+        },
+      },
+      makeCtx(p),
+    );
+    expect(where).toBe('jsonb_path_exists_tz("data", $1::jsonpath, $2::jsonb)');
+    expect(p.values[1]).toEqual({ v0: 'y', v1: '2020-12-31T00:00:00+00:00' });
+  });
+});

--- a/packages/jsonb-query/src/dialect-jsonpath.spec.ts
+++ b/packages/jsonb-query/src/dialect-jsonpath.spec.ts
@@ -1,6 +1,22 @@
 import { describe, it, expect } from 'vitest';
 import { jsonpathDialect } from './dialect-jsonpath';
 import { ParamBuilder } from './param-builder';
+import type { RenderContext } from './dialect';
+import type { JsonbArrayCondition } from './types';
+
+function makeCtx(p: ParamBuilder): RenderContext {
+  let n = 0;
+  return {
+    params: p,
+    nextAlias: () => {
+      n += 1;
+      return `e${n}`;
+    },
+    renderGroup: () => {
+      throw new Error('renderGroup not used by jsonpath dialect');
+    },
+  };
+}
 
 function run(
   field: string,
@@ -91,5 +107,51 @@ describe('jsonpathDialect', () => {
 
   it('throws on an unknown operator', () => {
     expect(() => run('name', 'string', 'bogus' as never, 'x')).toThrow(/unsupported operator/i);
+  });
+});
+
+describe('jsonpathDialect.renderArray', () => {
+  function runArray(cond: Omit<JsonbArrayCondition, 'dataType'>) {
+    const p = new ParamBuilder();
+    const where = jsonpathDialect.renderArray('"data"', { ...cond, dataType: 'array' }, makeCtx(p));
+    return { where, values: p.values };
+  }
+
+  it('element eq filters over [*] with phase-1 var naming', () => {
+    expect(runArray({ field: 'tags', elementType: 'string', operator: 'eq', value: 'a' })).toEqual({
+      where: 'jsonb_path_exists("data", $1::jsonpath, $2::jsonb)',
+      values: ['$."tags"[*] ? (@ == $v)', { v: 'a' }],
+    });
+  });
+
+  it('element range / terms / date / contains', () => {
+    expect(runArray({ field: 'nums', elementType: 'numeric', operator: 'range', value: [1, 9] }).values[0]).toBe(
+      '$."nums"[*] ? (@ >= $lo && @ <= $hi)',
+    );
+    expect(runArray({ field: 'tags', elementType: 'string', operator: 'terms', value: ['a', 'b'] }).values[0]).toBe(
+      '$."tags"[*] ? (@ == $v0 || @ == $v1)',
+    );
+    expect(runArray({ field: 'dates', elementType: 'date', operator: 'eq', value: '2020-01-01' }).values[0]).toBe(
+      '$."dates"[*] ? (@.datetime() == $v.datetime())',
+    );
+    // contains embeds an escaped regex literal and emits the 2-arg form
+    expect(runArray({ field: 'tags', elementType: 'string', operator: 'contains', value: 'a.b' })).toEqual({
+      where: 'jsonb_path_exists("data", $1::jsonpath)',
+      values: ['$."tags"[*] ? (@ like_regex "a\\\\.b")'],
+    });
+  });
+
+  it('containsall falls back to @> (identical to legacy)', () => {
+    expect(runArray({ field: 'tags', elementType: 'string', operator: 'containsall', value: ['a', 'b'] })).toEqual({
+      where: '(("data" #> $1) @> $2::jsonb)',
+      values: [['tags'], '["a","b"]'],
+    });
+  });
+
+  it('isnull / isnotnull use the dialect-independent null check', () => {
+    expect(runArray({ field: 'tags', elementType: 'string', operator: 'isnull' })).toEqual({
+      where: '(("data" #>> $1) is null)',
+      values: [['tags']],
+    });
   });
 });

--- a/packages/jsonb-query/src/dialect-jsonpath.spec.ts
+++ b/packages/jsonb-query/src/dialect-jsonpath.spec.ts
@@ -2,7 +2,11 @@ import { describe, it, expect } from 'vitest';
 import { jsonpathDialect } from './dialect-jsonpath';
 import { ParamBuilder } from './param-builder';
 import type { RenderContext } from './dialect';
-import type { JsonbArrayCondition } from './types';
+import type {
+  JsonbArrayCondition,
+  JsonbElemMatchCondition,
+  JsonbFilterGroup,
+} from './types';
 
 function makeCtx(p: ParamBuilder): RenderContext {
   let n = 0;
@@ -153,5 +157,125 @@ describe('jsonpathDialect.renderArray', () => {
       where: '(("data" #>> $1) is null)',
       values: [['tags']],
     });
+  });
+});
+
+describe('jsonpathDialect.renderElemMatch', () => {
+  function runElem(field: string, filters: JsonbFilterGroup) {
+    const p = new ParamBuilder();
+    const cond: JsonbElemMatchCondition = {
+      field, dataType: 'array', elementType: 'object', operator: 'elemmatch', filters,
+    };
+    const where = jsonpathDialect.renderElemMatch('"data"', cond, makeCtx(p));
+    return { where, values: p.values };
+  }
+
+  it('merges all sub-conditions into one path with sequential vars', () => {
+    expect(
+      runElem('items', {
+        logic: 'and',
+        filters: [
+          { field: 'sku', dataType: 'string', operator: 'eq', value: 'x' },
+          { field: 'qty', dataType: 'numeric', operator: 'gt', value: 1 },
+        ],
+      }),
+    ).toEqual({
+      where: 'jsonb_path_exists("data", $1::jsonpath, $2::jsonb)',
+      values: ['$."items"[*] ? (@."sku" == $v0 && @."qty" > $v1)', { v0: 'x', v1: 1 }],
+    });
+  });
+
+  it('wraps nested or-groups and compound predicates in parens', () => {
+    expect(
+      runElem('items', {
+        logic: 'and',
+        filters: [
+          { field: 'sku', dataType: 'string', operator: 'eq', value: 'x' },
+          {
+            logic: 'or',
+            filters: [
+              { field: 'qty', dataType: 'numeric', operator: 'range', value: [1, 9] },
+              { field: 'tag', dataType: 'string', operator: 'terms', value: ['a', 'b'] },
+            ],
+          },
+        ],
+      }).values[0],
+    ).toBe(
+      '$."items"[*] ? (@."sku" == $v0 && ((@."qty" >= $v1 && @."qty" <= $v2) || (@."tag" == $v3 || @."tag" == $v4)))',
+    );
+  });
+
+  it('supports dotted sub-fields, datetime, startswith and null checks', () => {
+    expect(
+      runElem('items', {
+        logic: 'and',
+        filters: [
+          { field: 'detail.x', dataType: 'numeric', operator: 'eq', value: 1 },
+          { field: 'd', dataType: 'date', operator: 'gte', value: '2020-01-01' },
+          { field: 's', dataType: 'string', operator: 'startswith', value: 'x' },
+          { field: 'n', dataType: 'string', operator: 'isnull' },
+          { field: 'm', dataType: 'string', operator: 'isnotnull' },
+        ],
+      }).values[0],
+    ).toBe(
+      '$."items"[*] ? (@."detail"."x" == $v0 && @."d".datetime() >= $v1.datetime() && @."s" starts with $v2 && (!exists (@."n") || @."n" == null) && (exists (@."m") && @."m" != null))',
+    );
+  });
+
+  it('renders nested elemmatch via exists()', () => {
+    expect(
+      runElem('orders', {
+        logic: 'and',
+        filters: [
+          { field: 'status', dataType: 'string', operator: 'eq', value: 'open' },
+          {
+            field: 'lines', dataType: 'array', elementType: 'object', operator: 'elemmatch',
+            filters: { logic: 'and', filters: [{ field: 'sku', dataType: 'string', operator: 'eq', value: 'x' }] },
+          },
+        ],
+      }).values[0],
+    ).toBe('$."orders"[*] ? (@."status" == $v0 && exists (@."lines"[*] ? (@."sku" == $v1)))');
+  });
+
+  it('emits the 2-arg form when no vars are used', () => {
+    expect(
+      runElem('items', {
+        logic: 'and',
+        filters: [{ field: 's', dataType: 'string', operator: 'contains', value: 'x' }],
+      }),
+    ).toEqual({
+      where: 'jsonb_path_exists("data", $1::jsonpath)',
+      values: ['$."items"[*] ? (@."s" like_regex "x")'],
+    });
+  });
+
+  it('escapes hostile member names into the path parameter', () => {
+    expect(
+      runElem('items', {
+        logic: 'and',
+        filters: [{ field: 'a"b', dataType: 'string', operator: 'eq', value: 'x' }],
+      }).values[0],
+    ).toBe('$."items"[*] ? (@."a\\"b" == $v0)');
+  });
+
+  it('rejects object / scalar-array conditions inside elemmatch', () => {
+    expect(() =>
+      runElem('items', {
+        logic: 'and',
+        filters: [{ field: 'p', dataType: 'object', operator: 'eq', value: {} }],
+      }),
+    ).toThrow(/not supported inside elemmatch/i);
+    expect(() =>
+      runElem('items', {
+        logic: 'and',
+        filters: [{ field: 't', dataType: 'array', elementType: 'string', operator: 'eq', value: 'x' }],
+      }),
+    ).toThrow(/not supported inside elemmatch/i);
+  });
+
+  it('throws when the group renders empty', () => {
+    expect(() =>
+      runElem('items', { logic: 'and', filters: [{ logic: 'or', filters: [] }] }),
+    ).toThrow(/requires a filter group with at least one condition/i);
   });
 });

--- a/packages/jsonb-query/src/dialect-jsonpath.spec.ts
+++ b/packages/jsonb-query/src/dialect-jsonpath.spec.ts
@@ -279,3 +279,41 @@ describe('jsonpathDialect.renderElemMatch', () => {
     ).toThrow(/requires a filter group with at least one condition/i);
   });
 });
+
+describe('jsonpathDialect.renderElemMatch — nor/not groups', () => {
+  function runElem2(field: string, filters: JsonbFilterGroup) {
+    const p = new ParamBuilder();
+    const cond: JsonbElemMatchCondition = {
+      field, dataType: 'array', elementType: 'object', operator: 'elemmatch', filters,
+    };
+    const where = jsonpathDialect.renderElemMatch('"data"', cond, makeCtx(p));
+    return { where, values: p.values };
+  }
+
+  it('negates a top-level nor group with !(… || …)', () => {
+    expect(
+      runElem2('items', {
+        logic: 'nor',
+        filters: [
+          { field: 'a', dataType: 'numeric', operator: 'eq', value: 1 },
+          { field: 'b', dataType: 'numeric', operator: 'eq', value: 2 },
+        ],
+      }).values[0],
+    ).toBe('$."items"[*] ? (!(@."a" == $v0 || @."b" == $v1))');
+  });
+
+  it('negates a nested not group with !(…) and wraps it in the conjunction', () => {
+    expect(
+      runElem2('items', {
+        logic: 'and',
+        filters: [
+          { field: 'sku', dataType: 'string', operator: 'eq', value: 'x' },
+          {
+            logic: 'not',
+            filters: [{ field: 'qty', dataType: 'numeric', operator: 'gt', value: 5 }],
+          },
+        ],
+      }).values[0],
+    ).toBe('$."items"[*] ? (@."sku" == $v0 && (!(@."qty" > $v1)))');
+  });
+});

--- a/packages/jsonb-query/src/dialect-jsonpath.ts
+++ b/packages/jsonb-query/src/dialect-jsonpath.ts
@@ -4,6 +4,7 @@ import {
   fieldSegments,
   assertScalarValue,
   assertArrayValue,
+  renderNullCheck,
 } from './dialect';
 import { escapeJsonpathString, escapeRegexLiteral } from './escape';
 
@@ -29,8 +30,7 @@ export const jsonpathDialect: ScalarDialect = {
   render(column, field, dataType, operator, value, params) {
     // isnull/isnotnull are dialect-independent.
     if (operator === 'isnull' || operator === 'isnotnull') {
-      const F = `(${column} #>> ${params.add(fieldSegments(field))})`;
-      return operator === 'isnull' ? `(${F} is null)` : `(${F} is not null)`;
+      return renderNullCheck(column, field, operator, params);
     }
 
     const base = basePath(field);

--- a/packages/jsonb-query/src/dialect-jsonpath.ts
+++ b/packages/jsonb-query/src/dialect-jsonpath.ts
@@ -1,4 +1,4 @@
-import type { JsonbScalarOperator, JsonbValue } from './types';
+import type { JsonbScalarType, JsonbScalarOperator, JsonbValue } from './types';
 import {
   type JsonbQueryDialect,
   fieldSegments,
@@ -6,11 +6,13 @@ import {
   assertArrayValue,
   renderNullCheck,
 } from './dialect';
+import type { ParamBuilder } from './param-builder';
 import { escapeJsonpathString, escapeRegexLiteral } from './escape';
 
-function basePath(field: string): string {
+/** `$."a"."b"` / `@."a"."b"` accessor for a dot path, members escaped. */
+function memberAccessor(root: '$' | '@', field: string): string {
   return (
-    '$' +
+    root +
     fieldSegments(field)
       .map((seg) => `."${escapeJsonpathString(seg)}"`)
       .join('')
@@ -26,70 +28,124 @@ const COMPARATORS: Partial<Record<JsonbScalarOperator, string>> = {
   lte: '<=',
 };
 
+/** Allocates jsonpath variable names and collects their values. */
+interface VarSink {
+  vars: Record<string, JsonbValue>;
+  one(value: JsonbValue): string;
+  pair(lo: JsonbValue, hi: JsonbValue): [string, string];
+  many(values: JsonbValue[]): string[];
+}
+
+/** Phase-1 naming for single-condition paths: $v, $lo/$hi, $v0… */
+function namedSink(): VarSink {
+  const vars: Record<string, JsonbValue> = {};
+  return {
+    vars,
+    one(value) {
+      vars.v = value;
+      return 'v';
+    },
+    pair(lo, hi) {
+      vars.lo = lo;
+      vars.hi = hi;
+      return ['lo', 'hi'];
+    },
+    many(values) {
+      return values.map((v, i) => {
+        vars[`v${i}`] = v;
+        return `v${i}`;
+      });
+    },
+  };
+}
+
+interface Predicate {
+  pred: string;
+  /** true when the predicate contains a top-level && / || and needs parens when embedded */
+  compound: boolean;
+}
+
+function scalarPredicate(
+  acc: string,
+  dataType: JsonbScalarType,
+  operator: JsonbScalarOperator,
+  value: JsonbValue | JsonbValue[] | undefined,
+  sink: VarSink,
+): Predicate {
+  const lhs = dataType === 'date' ? `${acc}.datetime()` : acc;
+  const rhs = (name: string) => (dataType === 'date' ? `$${name}.datetime()` : `$${name}`);
+
+  const comparator = COMPARATORS[operator];
+  if (comparator) {
+    const name = sink.one(assertScalarValue(operator, value));
+    return { pred: `${lhs} ${comparator} ${rhs(name)}`, compound: false };
+  }
+
+  switch (operator) {
+    case 'range': {
+      const [lo, hi] = assertArrayValue(operator, value, 2);
+      const [a, b] = sink.pair(lo, hi);
+      return { pred: `${lhs} >= ${rhs(a)} && ${lhs} <= ${rhs(b)}`, compound: true };
+    }
+    case 'terms': {
+      const items = assertArrayValue(operator, value);
+      const names = sink.many(items);
+      return {
+        pred: names.map((name) => `${lhs} == ${rhs(name)}`).join(' || '),
+        compound: items.length > 1,
+      };
+    }
+    // startswith/contains/endswith are string predicates: they operate on the
+    // text form (`acc`), never `.datetime()`.
+    case 'startswith': {
+      const name = sink.one(assertScalarValue(operator, value));
+      return { pred: `${acc} starts with $${name}`, compound: false };
+    }
+    case 'contains': {
+      const raw = String(assertScalarValue(operator, value));
+      const lit = escapeJsonpathString(escapeRegexLiteral(raw));
+      return { pred: `${acc} like_regex "${lit}"`, compound: false };
+    }
+    case 'endswith': {
+      const raw = String(assertScalarValue(operator, value));
+      const lit = escapeJsonpathString(escapeRegexLiteral(raw) + '$');
+      return { pred: `${acc} like_regex "${lit}"`, compound: false };
+    }
+    // isnull/isnotnull only reach here inside elemmatch (root conditions use
+    // the SQL fallback). Covers both a missing member and a JSON null, matching
+    // legacy `#>>` semantics.
+    case 'isnull':
+      return { pred: `!exists (${acc}) || ${acc} == null`, compound: true };
+    case 'isnotnull':
+      return { pred: `exists (${acc}) && ${acc} != null`, compound: true };
+    default:
+      throw new Error(`Unsupported operator "${operator as string}"`);
+  }
+}
+
+/** Emit jsonb_path_exists; omits the vars argument when no variables were used. */
+function pathExists(
+  column: string,
+  path: string,
+  vars: Record<string, JsonbValue>,
+  params: ParamBuilder,
+): string {
+  const pParam = params.add(path);
+  if (Object.keys(vars).length === 0) {
+    return `jsonb_path_exists(${column}, ${pParam}::jsonpath)`;
+  }
+  return `jsonb_path_exists(${column}, ${pParam}::jsonpath, ${params.add(vars)}::jsonb)`;
+}
+
 export const jsonpathDialect: JsonbQueryDialect = {
   render(column, field, dataType, operator, value, params) {
     // isnull/isnotnull are dialect-independent.
     if (operator === 'isnull' || operator === 'isnotnull') {
       return renderNullCheck(column, field, operator, params);
     }
-
-    const base = basePath(field);
-    const lhs = dataType === 'date' ? '@.datetime()' : '@';
-    const rhs = (name: string) => (dataType === 'date' ? `${name}.datetime()` : name);
-
-    const withVars = (predicate: string, vars: Record<string, JsonbValue>): string => {
-      const pParam = params.add(`${base} ? (${predicate})`);
-      const vParam = params.add(vars);
-      return `jsonb_path_exists(${column}, ${pParam}::jsonpath, ${vParam}::jsonb)`;
-    };
-
-    const withoutVars = (predicate: string): string => {
-      const pParam = params.add(`${base} ? (${predicate})`);
-      return `jsonb_path_exists(${column}, ${pParam}::jsonpath)`;
-    };
-
-    const comparator = COMPARATORS[operator];
-    if (comparator) {
-      const v = assertScalarValue(operator, value);
-      return withVars(`${lhs} ${comparator} ${rhs('$v')}`, { v });
-    }
-
-    switch (operator) {
-      case 'range': {
-        const [lo, hi] = assertArrayValue(operator, value, 2);
-        return withVars(
-          `${lhs} >= ${rhs('$lo')} && ${lhs} <= ${rhs('$hi')}`,
-          { lo, hi },
-        );
-      }
-      case 'terms': {
-        const items = assertArrayValue(operator, value);
-        const vars: Record<string, JsonbValue> = {};
-        const predicate = items
-          .map((item, i) => {
-            vars[`v${i}`] = item;
-            return `${lhs} == ${rhs(`$v${i}`)}`;
-          })
-          .join(' || ');
-        return withVars(predicate, vars);
-      }
-      // startswith/contains/endswith are string predicates: they operate on the
-      // text form (`@`), never `.datetime()`. `lhs` is intentionally unused here.
-      case 'startswith':
-        return withVars('@ starts with $v', { v: assertScalarValue(operator, value) });
-      case 'contains': {
-        const raw = String(assertScalarValue(operator, value));
-        const lit = escapeJsonpathString(escapeRegexLiteral(raw));
-        return withoutVars(`@ like_regex "${lit}"`);
-      }
-      case 'endswith': {
-        const raw = String(assertScalarValue(operator, value));
-        const lit = escapeJsonpathString(escapeRegexLiteral(raw) + '$');
-        return withoutVars(`@ like_regex "${lit}"`);
-      }
-      default:
-        throw new Error(`Unsupported operator "${operator as string}"`);
-    }
+    const sink = namedSink();
+    const { pred } = scalarPredicate('@', dataType, operator, value, sink);
+    return pathExists(column, `${memberAccessor('$', field)} ? (${pred})`, sink.vars, params);
   },
   renderArray() {
     throw new Error('Not implemented');

--- a/packages/jsonb-query/src/dialect-jsonpath.ts
+++ b/packages/jsonb-query/src/dialect-jsonpath.ts
@@ -1,6 +1,6 @@
 import type { JsonbScalarOperator, JsonbValue } from './types';
 import {
-  type ScalarDialect,
+  type JsonbQueryDialect,
   fieldSegments,
   assertScalarValue,
   assertArrayValue,
@@ -26,7 +26,7 @@ const COMPARATORS: Partial<Record<JsonbScalarOperator, string>> = {
   lte: '<=',
 };
 
-export const jsonpathDialect: ScalarDialect = {
+export const jsonpathDialect: JsonbQueryDialect = {
   render(column, field, dataType, operator, value, params) {
     // isnull/isnotnull are dialect-independent.
     if (operator === 'isnull' || operator === 'isnotnull') {
@@ -90,5 +90,11 @@ export const jsonpathDialect: ScalarDialect = {
       default:
         throw new Error(`Unsupported operator "${operator as string}"`);
     }
+  },
+  renderArray() {
+    throw new Error('Not implemented');
+  },
+  renderElemMatch() {
+    throw new Error('Not implemented');
   },
 };

--- a/packages/jsonb-query/src/dialect-jsonpath.ts
+++ b/packages/jsonb-query/src/dialect-jsonpath.ts
@@ -175,7 +175,11 @@ function groupPredicate(group: JsonbFilterGroup, sink: VarSink): string {
       return conditionPredicate(node, sink);
     })
     .filter((part) => part.length > 0);
-  return parts.join(group.logic === 'or' ? ' || ' : ' && ');
+  if (parts.length === 0) {
+    return '';
+  }
+  const joined = parts.join(group.logic === 'or' || group.logic === 'nor' ? ' || ' : ' && ');
+  return group.logic === 'not' || group.logic === 'nor' ? `!(${joined})` : joined;
 }
 
 function conditionPredicate(node: JsonbCondition, sink: VarSink): string {

--- a/packages/jsonb-query/src/dialect-jsonpath.ts
+++ b/packages/jsonb-query/src/dialect-jsonpath.ts
@@ -41,6 +41,8 @@ const COMPARATORS: Partial<Record<JsonbScalarOperator, string>> = {
 /** Allocates jsonpath variable names and collects their values. */
 interface VarSink {
   vars: Record<string, JsonbValue>;
+  /** Set when a date condition is rendered; switches to jsonb_path_exists_tz. */
+  tz: boolean;
   one(value: JsonbValue): string;
   pair(lo: JsonbValue, hi: JsonbValue): [string, string];
   many(values: JsonbValue[]): string[];
@@ -51,6 +53,7 @@ function namedSink(): VarSink {
   const vars: Record<string, JsonbValue> = {};
   return {
     vars,
+    tz: false,
     one(value) {
       vars.v = value;
       return 'v';
@@ -75,6 +78,16 @@ interface Predicate {
   compound: boolean;
 }
 
+/**
+ * PG's jsonpath `.datetime()` does not recognize the trailing `Z` that JS
+ * `Date#toISOString()` emits — normalize query-side values to an explicit
+ * `+00:00` offset. (Stored data is the caller's responsibility; see README.)
+ */
+function normalizeDateValue(value: JsonbValue): JsonbValue {
+  const text = value instanceof Date ? value.toISOString() : value;
+  return typeof text === 'string' ? text.replace(/Z$/, '+00:00') : text;
+}
+
 function scalarPredicate(
   acc: string,
   dataType: JsonbScalarType,
@@ -82,24 +95,32 @@ function scalarPredicate(
   value: JsonbValue | JsonbValue[] | undefined,
   sink: VarSink,
 ): Predicate {
-  const lhs = dataType === 'date' ? `${acc}.datetime()` : acc;
-  const rhs = (name: string) => (dataType === 'date' ? `$${name}.datetime()` : `$${name}`);
+  const isDate = dataType === 'date';
+  if (isDate) {
+    // .datetime() comparisons are timezone-dependent; the plain
+    // jsonb_path_exists() raises (and lax mode silently swallows) errors for
+    // cross-type comparisons, so date conditions use the _tz variant.
+    sink.tz = true;
+  }
+  const norm = (v: JsonbValue): JsonbValue => (isDate ? normalizeDateValue(v) : v);
+  const lhs = isDate ? `${acc}.datetime()` : acc;
+  const rhs = (name: string) => (isDate ? `$${name}.datetime()` : `$${name}`);
 
   const comparator = COMPARATORS[operator];
   if (comparator) {
-    const name = sink.one(assertScalarValue(operator, value));
+    const name = sink.one(norm(assertScalarValue(operator, value)));
     return { pred: `${lhs} ${comparator} ${rhs(name)}`, compound: false };
   }
 
   switch (operator) {
     case 'range': {
       const [lo, hi] = assertArrayValue(operator, value, 2);
-      const [a, b] = sink.pair(lo, hi);
+      const [a, b] = sink.pair(norm(lo), norm(hi));
       return { pred: `${lhs} >= ${rhs(a)} && ${lhs} <= ${rhs(b)}`, compound: true };
     }
     case 'terms': {
       const items = assertArrayValue(operator, value);
-      const names = sink.many(items);
+      const names = sink.many(items.map(norm));
       return {
         pred: names.map((name) => `${lhs} == ${rhs(name)}`).join(' || '),
         compound: items.length > 1,
@@ -133,18 +154,20 @@ function scalarPredicate(
   }
 }
 
-/** Emit jsonb_path_exists; omits the vars argument when no variables were used. */
+/** Emit jsonb_path_exists(_tz); omits the vars argument when no variables were used. */
 function pathExists(
   column: string,
   path: string,
   vars: Record<string, JsonbValue>,
   params: ParamBuilder,
+  tz: boolean,
 ): string {
+  const fn = tz ? 'jsonb_path_exists_tz' : 'jsonb_path_exists';
   const pParam = params.add(path);
   if (Object.keys(vars).length === 0) {
-    return `jsonb_path_exists(${column}, ${pParam}::jsonpath)`;
+    return `${fn}(${column}, ${pParam}::jsonpath)`;
   }
-  return `jsonb_path_exists(${column}, ${pParam}::jsonpath, ${params.add(vars)}::jsonb)`;
+  return `${fn}(${column}, ${pParam}::jsonpath, ${params.add(vars)}::jsonb)`;
 }
 
 /** Sequential naming (v0, v1, …) for predicates that merge many conditions. */
@@ -159,6 +182,7 @@ function sequentialSink(): VarSink {
   };
   return {
     vars,
+    tz: false,
     one: next,
     pair: (lo, hi) => [next(lo), next(hi)],
     many: (values) => values.map(next),
@@ -211,7 +235,7 @@ export const jsonpathDialect: JsonbQueryDialect = {
     }
     const sink = namedSink();
     const { pred } = scalarPredicate('@', dataType, operator, value, sink);
-    return pathExists(column, `${memberAccessor('$', field)} ? (${pred})`, sink.vars, params);
+    return pathExists(column, `${memberAccessor('$', field)} ? (${pred})`, sink.vars, params, sink.tz);
   },
   renderArray(column, condition, ctx) {
     const { params } = ctx;
@@ -224,7 +248,7 @@ export const jsonpathDialect: JsonbQueryDialect = {
     }
     const sink = namedSink();
     const { pred } = scalarPredicate('@', elementType, operator, value, sink);
-    return pathExists(column, `${memberAccessor('$', field)}[*] ? (${pred})`, sink.vars, params);
+    return pathExists(column, `${memberAccessor('$', field)}[*] ? (${pred})`, sink.vars, params, sink.tz);
   },
   renderElemMatch(column, condition, ctx) {
     const sink = sequentialSink();
@@ -237,6 +261,7 @@ export const jsonpathDialect: JsonbQueryDialect = {
       `${memberAccessor('$', condition.field)}[*] ? (${pred})`,
       sink.vars,
       ctx.params,
+      sink.tz,
     );
   },
 };

--- a/packages/jsonb-query/src/dialect-jsonpath.ts
+++ b/packages/jsonb-query/src/dialect-jsonpath.ts
@@ -1,9 +1,18 @@
-import type { JsonbScalarType, JsonbScalarOperator, JsonbValue } from './types';
+import type {
+  JsonbScalarType,
+  JsonbScalarOperator,
+  JsonbValue,
+  JsonbCondition,
+  JsonbFilterGroup,
+  JsonbScalarCondition,
+} from './types';
 import {
   type JsonbQueryDialect,
   fieldSegments,
   assertScalarValue,
   assertArrayValue,
+  assertCondition,
+  isFilterGroup,
   renderNullCheck,
   renderJsonbContains,
 } from './dialect';
@@ -138,6 +147,58 @@ function pathExists(
   return `jsonb_path_exists(${column}, ${pParam}::jsonpath, ${params.add(vars)}::jsonb)`;
 }
 
+/** Sequential naming (v0, v1, …) for predicates that merge many conditions. */
+function sequentialSink(): VarSink {
+  const vars: Record<string, JsonbValue> = {};
+  let n = 0;
+  const next = (value: JsonbValue) => {
+    const name = `v${n}`;
+    n += 1;
+    vars[name] = value;
+    return name;
+  };
+  return {
+    vars,
+    one: next,
+    pair: (lo, hi) => [next(lo), next(hi)],
+    many: (values) => values.map(next),
+  };
+}
+
+function groupPredicate(group: JsonbFilterGroup, sink: VarSink): string {
+  const parts = group.filters
+    .map((node) => {
+      if (isFilterGroup(node)) {
+        const inner = groupPredicate(node, sink);
+        return inner.length > 0 ? `(${inner})` : '';
+      }
+      return conditionPredicate(node, sink);
+    })
+    .filter((part) => part.length > 0);
+  return parts.join(group.logic === 'or' ? ' || ' : ' && ');
+}
+
+function conditionPredicate(node: JsonbCondition, sink: VarSink): string {
+  assertCondition(node, 'elemmatch');
+  if (node.dataType === 'array' && node.elementType === 'object') {
+    const inner = groupPredicate(node.filters, sink);
+    if (inner.length === 0) {
+      throw new Error('Operator "elemmatch" requires a filter group with at least one condition');
+    }
+    return `exists (${memberAccessor('@', node.field)}[*] ? (${inner}))`;
+  }
+  // assertCondition only lets scalar conditions through past this point.
+  const scalar = node as JsonbScalarCondition;
+  const { pred, compound } = scalarPredicate(
+    memberAccessor('@', scalar.field),
+    scalar.dataType,
+    scalar.operator,
+    scalar.value,
+    sink,
+  );
+  return compound ? `(${pred})` : pred;
+}
+
 export const jsonpathDialect: JsonbQueryDialect = {
   render(column, field, dataType, operator, value, params) {
     // isnull/isnotnull are dialect-independent.
@@ -161,7 +222,17 @@ export const jsonpathDialect: JsonbQueryDialect = {
     const { pred } = scalarPredicate('@', elementType, operator, value, sink);
     return pathExists(column, `${memberAccessor('$', field)}[*] ? (${pred})`, sink.vars, params);
   },
-  renderElemMatch() {
-    throw new Error('Not implemented');
+  renderElemMatch(column, condition, ctx) {
+    const sink = sequentialSink();
+    const pred = groupPredicate(condition.filters, sink);
+    if (pred.length === 0) {
+      throw new Error('Operator "elemmatch" requires a filter group with at least one condition');
+    }
+    return pathExists(
+      column,
+      `${memberAccessor('$', condition.field)}[*] ? (${pred})`,
+      sink.vars,
+      ctx.params,
+    );
   },
 };

--- a/packages/jsonb-query/src/dialect-jsonpath.ts
+++ b/packages/jsonb-query/src/dialect-jsonpath.ts
@@ -5,6 +5,7 @@ import {
   assertScalarValue,
   assertArrayValue,
   renderNullCheck,
+  renderJsonbContains,
 } from './dialect';
 import type { ParamBuilder } from './param-builder';
 import { escapeJsonpathString, escapeRegexLiteral } from './escape';
@@ -147,8 +148,18 @@ export const jsonpathDialect: JsonbQueryDialect = {
     const { pred } = scalarPredicate('@', dataType, operator, value, sink);
     return pathExists(column, `${memberAccessor('$', field)} ? (${pred})`, sink.vars, params);
   },
-  renderArray() {
-    throw new Error('Not implemented');
+  renderArray(column, condition, ctx) {
+    const { params } = ctx;
+    const { field, elementType, operator, value } = condition;
+    if (operator === 'isnull' || operator === 'isnotnull') {
+      return renderNullCheck(column, field, operator, params);
+    }
+    if (operator === 'containsall') {
+      return renderJsonbContains(column, field, assertArrayValue(operator, value), params);
+    }
+    const sink = namedSink();
+    const { pred } = scalarPredicate('@', elementType, operator, value, sink);
+    return pathExists(column, `${memberAccessor('$', field)}[*] ? (${pred})`, sink.vars, params);
   },
   renderElemMatch() {
     throw new Error('Not implemented');

--- a/packages/jsonb-query/src/dialect-legacy.spec.ts
+++ b/packages/jsonb-query/src/dialect-legacy.spec.ts
@@ -200,3 +200,36 @@ describe('legacyDialect.renderArray', () => {
     expect(b).toContain('as e2(v)');
   });
 });
+
+describe('legacyDialect.renderElemMatch', () => {
+  const cond = {
+    field: 'items',
+    dataType: 'array',
+    elementType: 'object',
+    operator: 'elemmatch',
+    filters: { logic: 'and', filters: [{ field: 'sku', dataType: 'string', operator: 'eq', value: 'x' }] },
+  } as const;
+
+  it('wraps the sub-group in EXISTS over jsonb_array_elements, rendered against the alias', () => {
+    const p = new ParamBuilder();
+    const seen: string[] = [];
+    const ctx = makeCtx(p, (_group, col) => {
+      seen.push(col);
+      return `<<sub:${col}>>`;
+    });
+    const where = legacyDialect.renderElemMatch('"data"', cond, ctx);
+    expect(where).toBe(
+      `(exists (select 1 from jsonb_array_elements(${GUARD('"data"', '$1')}) as e1 where <<sub:e1.value>>))`,
+    );
+    expect(seen).toEqual(['e1.value']);
+    expect(p.values).toEqual([['items']]);
+  });
+
+  it('throws when the sub-group renders empty', () => {
+    const p = new ParamBuilder();
+    const ctx = makeCtx(p, () => '');
+    expect(() => legacyDialect.renderElemMatch('"data"', cond, ctx)).toThrow(
+      /requires a filter group with at least one condition/i,
+    );
+  });
+});

--- a/packages/jsonb-query/src/dialect-legacy.spec.ts
+++ b/packages/jsonb-query/src/dialect-legacy.spec.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import { legacyDialect } from './dialect-legacy';
 import { ParamBuilder } from './param-builder';
+import type { RenderContext } from './dialect';
+import type { JsonbArrayCondition } from './types';
 
 function run(
   field: string,
@@ -116,5 +118,85 @@ describe('legacyDialect', () => {
 
   it('throws on an unknown operator', () => {
     expect(() => run('name', 'string', 'bogus' as never, 'x')).toThrow(/unsupported operator/i);
+  });
+});
+
+function makeCtx(
+  p: ParamBuilder,
+  renderGroup: RenderContext['renderGroup'] = () => {
+    throw new Error('renderGroup not stubbed');
+  },
+): RenderContext {
+  let n = 0;
+  return {
+    params: p,
+    nextAlias: () => {
+      n += 1;
+      return `e${n}`;
+    },
+    renderGroup,
+  };
+}
+
+const GUARD = (col: string, ph: string) =>
+  `case when jsonb_typeof(${col} #> ${ph}) = 'array' then ${col} #> ${ph} else '[]'::jsonb end`;
+
+describe('legacyDialect.renderArray', () => {
+  function runArray(cond: Omit<JsonbArrayCondition, 'dataType'>) {
+    const p = new ParamBuilder();
+    const ctx = makeCtx(p);
+    const where = legacyDialect.renderArray('"data"', { ...cond, dataType: 'array' }, ctx);
+    return { where, values: p.values, ctx };
+  }
+
+  it('element eq uses EXISTS over jsonb_array_elements_text with a typeof guard', () => {
+    expect(runArray({ field: 'tags', elementType: 'string', operator: 'eq', value: 'a' })).toMatchObject({
+      where: `(exists (select 1 from jsonb_array_elements_text(${GUARD('"data"', '$1')}) as e1(v) where (e1.v = $2)))`,
+      values: [['tags'], 'a'],
+    });
+  });
+
+  it('element gt casts the element', () => {
+    expect(runArray({ field: 'nums', elementType: 'numeric', operator: 'gt', value: 5 }).where).toBe(
+      `(exists (select 1 from jsonb_array_elements_text(${GUARD('"data"', '$1')}) as e1(v) where (e1.v::numeric > $2)))`,
+    );
+  });
+
+  it('element range / terms / string ops reuse the scalar operator rendering', () => {
+    expect(runArray({ field: 'nums', elementType: 'numeric', operator: 'range', value: [1, 9] }).where).toContain(
+      '(e1.v::numeric between $2 and $3)',
+    );
+    expect(runArray({ field: 'tags', elementType: 'string', operator: 'terms', value: ['a', 'b'] }).where).toContain(
+      '(e1.v = ANY($2::text[]))',
+    );
+    expect(runArray({ field: 'tags', elementType: 'string', operator: 'startswith', value: 'x' }).where).toContain(
+      '(left(e1.v, char_length($2)) = $2)',
+    );
+    expect(runArray({ field: 'dates', elementType: 'date', operator: 'gt', value: '2020-01-01' }).where).toContain(
+      '(e1.v::timestamptz > $2)',
+    );
+  });
+
+  it('containsall maps to @> with a JSON-stringified param', () => {
+    expect(runArray({ field: 'tags', elementType: 'string', operator: 'containsall', value: ['a', 'b'] })).toMatchObject({
+      where: '(("data" #> $1) @> $2::jsonb)',
+      values: [['tags'], '["a","b"]'],
+    });
+  });
+
+  it('isnull / isnotnull test the array field itself', () => {
+    expect(runArray({ field: 'tags', elementType: 'string', operator: 'isnull' })).toMatchObject({
+      where: '(("data" #>> $1) is null)',
+      values: [['tags']],
+    });
+  });
+
+  it('allocates unique aliases across calls sharing a context', () => {
+    const p = new ParamBuilder();
+    const ctx = makeCtx(p);
+    const a = legacyDialect.renderArray('"data"', { field: 'x', dataType: 'array', elementType: 'string', operator: 'eq', value: 'a' }, ctx);
+    const b = legacyDialect.renderArray('"data"', { field: 'y', dataType: 'array', elementType: 'string', operator: 'eq', value: 'b' }, ctx);
+    expect(a).toContain('as e1(v)');
+    expect(b).toContain('as e2(v)');
   });
 });

--- a/packages/jsonb-query/src/dialect-legacy.ts
+++ b/packages/jsonb-query/src/dialect-legacy.ts
@@ -5,6 +5,7 @@ import {
   assertScalarValue,
   assertArrayValue,
   renderNullCheck,
+  renderJsonbContains,
 } from './dialect';
 import type { ParamBuilder } from './param-builder';
 
@@ -73,8 +74,20 @@ export const legacyDialect: JsonbQueryDialect = {
     const F = `(${column} #>> ${params.add(fieldSegments(field))})`;
     return renderScalarOp(F, dataType, operator, value, params);
   },
-  renderArray() {
-    throw new Error('Not implemented');
+  renderArray(column, condition, ctx) {
+    const { params } = ctx;
+    const { field, elementType, operator, value } = condition;
+    if (operator === 'isnull' || operator === 'isnotnull') {
+      return renderNullCheck(column, field, operator, params);
+    }
+    if (operator === 'containsall') {
+      return renderJsonbContains(column, field, assertArrayValue(operator, value), params);
+    }
+    const fParam = params.add(fieldSegments(field));
+    const guarded = `case when jsonb_typeof(${column} #> ${fParam}) = 'array' then ${column} #> ${fParam} else '[]'::jsonb end`;
+    const alias = ctx.nextAlias();
+    const predicate = renderScalarOp(`${alias}.v`, elementType, operator, value, params);
+    return `(exists (select 1 from jsonb_array_elements_text(${guarded}) as ${alias}(v) where ${predicate}))`;
   },
   renderElemMatch() {
     throw new Error('Not implemented');

--- a/packages/jsonb-query/src/dialect-legacy.ts
+++ b/packages/jsonb-query/src/dialect-legacy.ts
@@ -1,6 +1,6 @@
 import type { JsonbScalarType } from './types';
 import {
-  type ScalarDialect,
+  type JsonbQueryDialect,
   fieldSegments,
   assertScalarValue,
   assertArrayValue,
@@ -21,7 +21,7 @@ const ARRAY_CASTS: Record<JsonbScalarType, string> = {
   boolean: '::boolean[]',
 };
 
-export const legacyDialect: ScalarDialect = {
+export const legacyDialect: JsonbQueryDialect = {
   render(column, field, dataType, operator, value, params) {
     if (operator === 'isnull' || operator === 'isnotnull') {
       return renderNullCheck(column, field, operator, params);
@@ -62,5 +62,11 @@ export const legacyDialect: ScalarDialect = {
       default:
         throw new Error(`Unsupported operator "${operator as string}"`);
     }
+  },
+  renderArray() {
+    throw new Error('Not implemented');
+  },
+  renderElemMatch() {
+    throw new Error('Not implemented');
   },
 };

--- a/packages/jsonb-query/src/dialect-legacy.ts
+++ b/packages/jsonb-query/src/dialect-legacy.ts
@@ -4,6 +4,7 @@ import {
   fieldSegments,
   assertScalarValue,
   assertArrayValue,
+  renderNullCheck,
 } from './dialect';
 
 const CASTS: Record<JsonbScalarType, string> = {
@@ -22,15 +23,14 @@ const ARRAY_CASTS: Record<JsonbScalarType, string> = {
 
 export const legacyDialect: ScalarDialect = {
   render(column, field, dataType, operator, value, params) {
+    if (operator === 'isnull' || operator === 'isnotnull') {
+      return renderNullCheck(column, field, operator, params);
+    }
     const fParam = params.add(fieldSegments(field));
     const F = `(${column} #>> ${fParam})`;
     const Fc = `${F}${CASTS[dataType]}`;
 
     switch (operator) {
-      case 'isnull':
-        return `(${F} is null)`;
-      case 'isnotnull':
-        return `(${F} is not null)`;
       case 'eq':
         return `(${Fc} = ${params.add(assertScalarValue(operator, value))})`;
       case 'neq':

--- a/packages/jsonb-query/src/dialect-legacy.ts
+++ b/packages/jsonb-query/src/dialect-legacy.ts
@@ -89,7 +89,14 @@ export const legacyDialect: JsonbQueryDialect = {
     const predicate = renderScalarOp(`${alias}.v`, elementType, operator, value, params);
     return `(exists (select 1 from jsonb_array_elements_text(${guarded}) as ${alias}(v) where ${predicate}))`;
   },
-  renderElemMatch() {
-    throw new Error('Not implemented');
+  renderElemMatch(column, condition, ctx) {
+    const fParam = ctx.params.add(fieldSegments(condition.field));
+    const guarded = `case when jsonb_typeof(${column} #> ${fParam}) = 'array' then ${column} #> ${fParam} else '[]'::jsonb end`;
+    const alias = ctx.nextAlias();
+    const sub = ctx.renderGroup(condition.filters, `${alias}.value`);
+    if (sub.length === 0) {
+      throw new Error('Operator "elemmatch" requires a filter group with at least one condition');
+    }
+    return `(exists (select 1 from jsonb_array_elements(${guarded}) as ${alias} where ${sub}))`;
   },
 };

--- a/packages/jsonb-query/src/dialect-legacy.ts
+++ b/packages/jsonb-query/src/dialect-legacy.ts
@@ -1,4 +1,4 @@
-import type { JsonbScalarType } from './types';
+import type { JsonbScalarType, JsonbScalarOperator, JsonbValue } from './types';
 import {
   type JsonbQueryDialect,
   fieldSegments,
@@ -6,6 +6,7 @@ import {
   assertArrayValue,
   renderNullCheck,
 } from './dialect';
+import type { ParamBuilder } from './param-builder';
 
 const CASTS: Record<JsonbScalarType, string> = {
   string: '',
@@ -21,47 +22,56 @@ const ARRAY_CASTS: Record<JsonbScalarType, string> = {
   boolean: '::boolean[]',
 };
 
+/** Render a scalar operator against `F`, a text-valued SQL expression. */
+function renderScalarOp(
+  F: string,
+  dataType: JsonbScalarType,
+  operator: JsonbScalarOperator,
+  value: JsonbValue | JsonbValue[] | undefined,
+  params: ParamBuilder,
+): string {
+  const Fc = `${F}${CASTS[dataType]}`;
+  switch (operator) {
+    case 'eq':
+      return `(${Fc} = ${params.add(assertScalarValue(operator, value))})`;
+    case 'neq':
+      return `(${Fc} <> ${params.add(assertScalarValue(operator, value))})`;
+    case 'gt':
+      return `(${Fc} > ${params.add(assertScalarValue(operator, value))})`;
+    case 'gte':
+      return `(${Fc} >= ${params.add(assertScalarValue(operator, value))})`;
+    case 'lt':
+      return `(${Fc} < ${params.add(assertScalarValue(operator, value))})`;
+    case 'lte':
+      return `(${Fc} <= ${params.add(assertScalarValue(operator, value))})`;
+    case 'range': {
+      const [lo, hi] = assertArrayValue(operator, value, 2);
+      return `(${Fc} between ${params.add(lo)} and ${params.add(hi)})`;
+    }
+    case 'terms':
+      return `(${Fc} = ANY(${params.add(assertArrayValue(operator, value))}${ARRAY_CASTS[dataType]}))`;
+    case 'contains':
+      return `(position(${params.add(assertScalarValue(operator, value))} in ${F}) > 0)`;
+    case 'startswith': {
+      const v = params.add(assertScalarValue(operator, value));
+      return `(left(${F}, char_length(${v})) = ${v})`;
+    }
+    case 'endswith': {
+      const v = params.add(assertScalarValue(operator, value));
+      return `(right(${F}, char_length(${v})) = ${v})`;
+    }
+    default:
+      throw new Error(`Unsupported operator "${operator as string}"`);
+  }
+}
+
 export const legacyDialect: JsonbQueryDialect = {
   render(column, field, dataType, operator, value, params) {
     if (operator === 'isnull' || operator === 'isnotnull') {
       return renderNullCheck(column, field, operator, params);
     }
-    const fParam = params.add(fieldSegments(field));
-    const F = `(${column} #>> ${fParam})`;
-    const Fc = `${F}${CASTS[dataType]}`;
-
-    switch (operator) {
-      case 'eq':
-        return `(${Fc} = ${params.add(assertScalarValue(operator, value))})`;
-      case 'neq':
-        return `(${Fc} <> ${params.add(assertScalarValue(operator, value))})`;
-      case 'gt':
-        return `(${Fc} > ${params.add(assertScalarValue(operator, value))})`;
-      case 'gte':
-        return `(${Fc} >= ${params.add(assertScalarValue(operator, value))})`;
-      case 'lt':
-        return `(${Fc} < ${params.add(assertScalarValue(operator, value))})`;
-      case 'lte':
-        return `(${Fc} <= ${params.add(assertScalarValue(operator, value))})`;
-      case 'range': {
-        const [lo, hi] = assertArrayValue(operator, value, 2);
-        return `(${Fc} between ${params.add(lo)} and ${params.add(hi)})`;
-      }
-      case 'terms':
-        return `(${Fc} = ANY(${params.add(assertArrayValue(operator, value))}${ARRAY_CASTS[dataType]}))`;
-      case 'contains':
-        return `(position(${params.add(assertScalarValue(operator, value))} in ${F}) > 0)`;
-      case 'startswith': {
-        const v = params.add(assertScalarValue(operator, value));
-        return `(left(${F}, char_length(${v})) = ${v})`;
-      }
-      case 'endswith': {
-        const v = params.add(assertScalarValue(operator, value));
-        return `(right(${F}, char_length(${v})) = ${v})`;
-      }
-      default:
-        throw new Error(`Unsupported operator "${operator as string}"`);
-    }
+    const F = `(${column} #>> ${params.add(fieldSegments(field))})`;
+    return renderScalarOp(F, dataType, operator, value, params);
   },
   renderArray() {
     throw new Error('Not implemented');

--- a/packages/jsonb-query/src/dialect.spec.ts
+++ b/packages/jsonb-query/src/dialect.spec.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { renderNullCheck, renderJsonbContains, isFilterGroup } from './dialect';
+import { ParamBuilder } from './param-builder';
+
+describe('renderNullCheck', () => {
+  it('renders is null / is not null with a parameterized path', () => {
+    const p1 = new ParamBuilder();
+    expect(renderNullCheck('"data"', 'a.b', 'isnull', p1)).toBe('(("data" #>> $1) is null)');
+    expect(p1.values).toEqual([['a', 'b']]);
+
+    const p2 = new ParamBuilder();
+    expect(renderNullCheck('"data"', 'x', 'isnotnull', p2)).toBe('(("data" #>> $1) is not null)');
+    expect(p2.values).toEqual([['x']]);
+  });
+});
+
+describe('renderJsonbContains', () => {
+  it('JSON-stringifies the value (node-postgres array-literal gotcha)', () => {
+    const p = new ParamBuilder();
+    expect(renderJsonbContains('"data"', 'tags', ['a', 'b'], p)).toBe(
+      '(("data" #> $1) @> $2::jsonb)',
+    );
+    expect(p.values).toEqual([['tags'], '["a","b"]']);
+  });
+});
+
+describe('isFilterGroup', () => {
+  it('discriminates groups from conditions', () => {
+    expect(isFilterGroup({ logic: 'and', filters: [] })).toBe(true);
+    expect(
+      isFilterGroup({ field: 'a', dataType: 'string', operator: 'eq', value: 'x' }),
+    ).toBe(false);
+  });
+});

--- a/packages/jsonb-query/src/dialect.spec.ts
+++ b/packages/jsonb-query/src/dialect.spec.ts
@@ -1,6 +1,13 @@
 import { describe, it, expect } from 'vitest';
-import { renderNullCheck, renderJsonbContains, isFilterGroup } from './dialect';
+import {
+  renderNullCheck,
+  renderJsonbContains,
+  isFilterGroup,
+  assertCondition,
+  assertObjectValue,
+} from './dialect';
 import { ParamBuilder } from './param-builder';
+import type { JsonbCondition } from './types';
 
 describe('renderNullCheck', () => {
   it('renders is null / is not null with a parameterized path', () => {
@@ -30,5 +37,75 @@ describe('isFilterGroup', () => {
     expect(
       isFilterGroup({ field: 'a', dataType: 'string', operator: 'eq', value: 'x' }),
     ).toBe(false);
+  });
+});
+
+describe('assertObjectValue', () => {
+  it('accepts a plain object', () => {
+    expect(assertObjectValue('eq', { a: 1 })).toEqual({ a: 1 });
+  });
+  it.each([null, undefined, [1], new Date(), 'x', 1])('rejects %p', (bad) => {
+    expect(() => assertObjectValue('eq', bad)).toThrow(/requires a plain object value/i);
+  });
+});
+
+describe('assertCondition', () => {
+  const c = (node: unknown) => () => assertCondition(node as JsonbCondition, 'root');
+  const e = (node: unknown) => () => assertCondition(node as JsonbCondition, 'elemmatch');
+
+  it('delegates scalar validation unchanged', () => {
+    expect(c({ field: 'x', dataType: 'boolean', operator: 'gt' })).toThrow(
+      /unsupported operator "gt" for type "boolean"/i,
+    );
+    expect(c({ field: 'x', dataType: 'string', operator: 'eq', value: 'a' })).not.toThrow();
+  });
+
+  it('validates object operators', () => {
+    expect(c({ field: 'p', dataType: 'object', operator: 'eq', value: {} })).not.toThrow();
+    expect(c({ field: 'p', dataType: 'object', operator: 'gt', value: {} })).toThrow(
+      /unsupported operator "gt" for type "object"/i,
+    );
+  });
+
+  it('validates array element operators per elementType', () => {
+    const arr = (elementType: string, operator: string) =>
+      c({ field: 'a', dataType: 'array', elementType, operator, value: 1 });
+    expect(arr('numeric', 'gt')).not.toThrow();
+    expect(arr('string', 'gt')).toThrow(/for array elements of type "string"/i);
+    expect(arr('numeric', 'startswith')).toThrow(/for array elements of type "numeric"/i);
+    expect(arr('string', 'neq')).toThrow(/unsupported operator "neq" for array elements/i);
+    expect(arr('boolean', 'terms')).toThrow(/for array elements of type "boolean"/i);
+    expect(arr('date', 'containsall')).toThrow(/for array elements of type "date"/i);
+    expect(arr('bogus', 'eq')).toThrow(/unsupported elementtype "bogus"/i);
+  });
+
+  it('requires elemmatch (with a non-empty group) for arrays of objects', () => {
+    const ok = {
+      field: 'items', dataType: 'array', elementType: 'object', operator: 'elemmatch',
+      filters: { logic: 'and', filters: [{ field: 's', dataType: 'string', operator: 'eq', value: 'x' }] },
+    };
+    expect(c(ok)).not.toThrow();
+    expect(c({ ...ok, operator: 'eq' })).toThrow(/use "elemmatch"/i);
+    expect(c({ ...ok, filters: { logic: 'and', filters: [] } })).toThrow(
+      /requires a filter group with at least one condition/i,
+    );
+    expect(c({ ...ok, filters: undefined })).toThrow(/requires a filter group/i);
+  });
+
+  it('rejects object and scalar-array conditions inside elemmatch', () => {
+    expect(e({ field: 'p', dataType: 'object', operator: 'eq', value: {} })).toThrow(
+      /object conditions are not supported inside elemmatch/i,
+    );
+    expect(
+      e({ field: 'a', dataType: 'array', elementType: 'string', operator: 'eq', value: 'x' }),
+    ).toThrow(/array conditions with scalar elements are not supported inside elemmatch/i);
+    // scalar + nested elemmatch ARE allowed inside elemmatch
+    expect(e({ field: 's', dataType: 'string', operator: 'eq', value: 'x' })).not.toThrow();
+    expect(
+      e({
+        field: 'sub', dataType: 'array', elementType: 'object', operator: 'elemmatch',
+        filters: { logic: 'and', filters: [{ field: 's', dataType: 'string', operator: 'eq', value: 'x' }] },
+      }),
+    ).not.toThrow();
   });
 });

--- a/packages/jsonb-query/src/dialect.ts
+++ b/packages/jsonb-query/src/dialect.ts
@@ -6,13 +6,23 @@ import type {
   JsonbFilterGroup,
   JsonbObjectOperator,
   JsonbObjectValue,
+  JsonbArrayCondition,
+  JsonbElemMatchCondition,
 } from './types';
 import type { ParamBuilder } from './param-builder';
 
-export interface ScalarDialect {
+export interface RenderContext {
+  params: ParamBuilder;
+  /** Allocate a unique table alias (e1, e2, …) for EXISTS subqueries. */
+  nextAlias(): string;
+  /** Render a nested filter group against an element expression (elemmatch scope). */
+  renderGroup(group: JsonbFilterGroup, column: string): string;
+}
+
+export interface JsonbQueryDialect {
   /**
-   * Render one condition into a SQL boolean expression, pushing any parameter
-   * values onto `params`.
+   * Render one scalar condition into a SQL boolean expression, pushing any
+   * parameter values onto `params`.
    * @param column already-quoted column SQL, e.g. `"data"`
    * @param field  raw dot path, e.g. "address.city"
    */
@@ -24,6 +34,10 @@ export interface ScalarDialect {
     value: JsonbValue | JsonbValue[] | undefined,
     params: ParamBuilder,
   ): string;
+  /** Render a scalar-element array condition (∃ semantics / containsall / null checks). */
+  renderArray(column: string, condition: JsonbArrayCondition, ctx: RenderContext): string;
+  /** Render an array-of-objects condition (all sub-conditions on the same element). */
+  renderElemMatch(column: string, condition: JsonbElemMatchCondition, ctx: RenderContext): string;
 }
 
 export function fieldSegments(field: string): string[] {

--- a/packages/jsonb-query/src/dialect.ts
+++ b/packages/jsonb-query/src/dialect.ts
@@ -2,6 +2,8 @@ import type {
   JsonbScalarType,
   JsonbScalarOperator,
   JsonbValue,
+  JsonbCondition,
+  JsonbFilterGroup,
 } from './types';
 import type { ParamBuilder } from './param-builder';
 
@@ -26,8 +28,39 @@ export function fieldSegments(field: string): string[] {
   return field.split('.');
 }
 
+export function isFilterGroup(
+  node: JsonbCondition | JsonbFilterGroup,
+): node is JsonbFilterGroup {
+  return 'logic' in node && 'filters' in node;
+}
+
+/** `field IS [NOT] NULL` via `#>>`: SQL null for both missing keys and JSON null. */
+export function renderNullCheck(
+  column: string,
+  field: string,
+  operator: 'isnull' | 'isnotnull',
+  params: ParamBuilder,
+): string {
+  const F = `(${column} #>> ${params.add(fieldSegments(field))})`;
+  return operator === 'isnull' ? `(${F} is null)` : `(${F} is not null)`;
+}
+
+/**
+ * JSONB containment (`@>`). `JSON.stringify` is required: node-postgres encodes
+ * raw JS arrays as Postgres array literals ('{a,b}'), which are not valid jsonb.
+ */
+export function renderJsonbContains(
+  column: string,
+  field: string,
+  value: unknown,
+  params: ParamBuilder,
+): string {
+  const fParam = params.add(fieldSegments(field));
+  return `((${column} #> ${fParam}) @> ${params.add(JSON.stringify(value))}::jsonb)`;
+}
+
 export function assertScalarValue(
-  operator: JsonbScalarOperator,
+  operator: string,
   value: JsonbValue | JsonbValue[] | undefined,
 ): JsonbValue {
   if (value === undefined || value === null || Array.isArray(value)) {
@@ -37,7 +70,7 @@ export function assertScalarValue(
 }
 
 export function assertArrayValue(
-  operator: JsonbScalarOperator,
+  operator: string,
   value: JsonbValue | JsonbValue[] | undefined,
   exactLength?: number,
 ): JsonbValue[] {

--- a/packages/jsonb-query/src/dialect.ts
+++ b/packages/jsonb-query/src/dialect.ts
@@ -4,6 +4,8 @@ import type {
   JsonbValue,
   JsonbCondition,
   JsonbFilterGroup,
+  JsonbObjectOperator,
+  JsonbObjectValue,
 } from './types';
 import type { ParamBuilder } from './param-builder';
 
@@ -101,4 +103,70 @@ export function assertOperatorForType(
   if (!OPERATORS_BY_TYPE[dataType]?.has(operator)) {
     throw new Error(`Unsupported operator "${operator}" for type "${dataType}"`);
   }
+}
+
+export function assertObjectValue(operator: string, value: unknown): JsonbObjectValue {
+  if (
+    typeof value !== 'object' ||
+    value === null ||
+    Array.isArray(value) ||
+    value instanceof Date
+  ) {
+    throw new Error(`Operator "${operator}" requires a plain object value`);
+  }
+  return value as JsonbObjectValue;
+}
+
+const OBJECT_OPERATORS: ReadonlySet<JsonbObjectOperator> = new Set([
+  'eq', 'neq', 'contains', 'isnull', 'isnotnull',
+]);
+
+const ARRAY_OPERATORS_BY_ELEMENT: Record<JsonbScalarType, ReadonlySet<string>> = {
+  string: new Set(['eq', 'contains', 'startswith', 'endswith', 'terms', 'containsall', 'isnull', 'isnotnull']),
+  numeric: new Set(['eq', 'gt', 'gte', 'lt', 'lte', 'range', 'terms', 'containsall', 'isnull', 'isnotnull']),
+  date: new Set(['eq', 'gt', 'gte', 'lt', 'lte', 'range', 'terms', 'isnull', 'isnotnull']),
+  boolean: new Set(['eq', 'isnull', 'isnotnull']),
+};
+
+export type ConditionScope = 'root' | 'elemmatch';
+
+export function assertCondition(node: JsonbCondition, scope: ConditionScope): void {
+  if (node.dataType === 'object') {
+    if (scope === 'elemmatch') {
+      throw new Error('Object conditions are not supported inside elemmatch');
+    }
+    if (!OBJECT_OPERATORS.has(node.operator)) {
+      throw new Error(`Unsupported operator "${node.operator as string}" for type "object"`);
+    }
+    return;
+  }
+  if (node.dataType === 'array') {
+    if (node.elementType === 'object') {
+      if ((node.operator as string) !== 'elemmatch') {
+        throw new Error(
+          `Unsupported operator "${node.operator as string}" for array of objects (use "elemmatch")`,
+        );
+      }
+      if (!node.filters || !Array.isArray(node.filters.filters) || node.filters.filters.length === 0) {
+        throw new Error('Operator "elemmatch" requires a filter group with at least one condition');
+      }
+      return;
+    }
+    if (scope === 'elemmatch') {
+      throw new Error('Array conditions with scalar elements are not supported inside elemmatch');
+    }
+    const ops = ARRAY_OPERATORS_BY_ELEMENT[node.elementType];
+    if (!ops) {
+      throw new Error(
+        `Unsupported elementType ${JSON.stringify(node.elementType)} for array condition`,
+      );
+    }
+    if (!ops.has(node.operator)) {
+      throw new Error(
+        `Unsupported operator "${node.operator as string}" for array elements of type "${node.elementType}"`,
+      );
+    }
+    return;
+  }
+  assertOperatorForType(node.dataType, node.operator);
 }

--- a/packages/jsonb-query/src/index.ts
+++ b/packages/jsonb-query/src/index.ts
@@ -2,4 +2,9 @@ export * from './types';
 export { buildJsonbQuery } from './build';
 export { quoteJsonbColumn } from './column';
 export { ParamBuilder } from './param-builder';
-export { toNamedParams, type NamedParamsResult } from './named-params';
+export {
+  buildNamedJsonbQuery,
+  toNamedParams,
+  type BuildNamedJsonbOptions,
+  type NamedParamsResult,
+} from './named-params';

--- a/packages/jsonb-query/src/index.ts
+++ b/packages/jsonb-query/src/index.ts
@@ -2,3 +2,4 @@ export * from './types';
 export { buildJsonbQuery } from './build';
 export { quoteJsonbColumn } from './column';
 export { ParamBuilder } from './param-builder';
+export { toNamedParams, type NamedParamsResult } from './named-params';

--- a/packages/jsonb-query/src/named-params.spec.ts
+++ b/packages/jsonb-query/src/named-params.spec.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { buildJsonbQuery } from './build';
+import { toNamedParams } from './named-params';
+import type { JsonbFilterGroup } from './types';
+
+const one = (f: JsonbFilterGroup['filters'][number]): JsonbFilterGroup => ({
+  logic: 'and',
+  filters: [f],
+});
+
+describe('toNamedParams', () => {
+  it('converts positional placeholders and the values array', () => {
+    const r = buildJsonbQuery('data', one({ field: 'name', dataType: 'string', operator: 'eq', value: 'bob' }));
+    expect(toNamedParams(r)).toEqual({
+      where: '(("data" #>> :p1) = :p2)',
+      params: { p1: ['name'], p2: 'bob' },
+    });
+  });
+
+  it('keeps repeated placeholder references pointing at one named param', () => {
+    const r = buildJsonbQuery('data', one({ field: 's', dataType: 'string', operator: 'startswith', value: 'x' }));
+    expect(toNamedParams(r)).toEqual({
+      where: '(left(("data" #>> :p1), char_length(:p2)) = :p2)',
+      params: { p1: ['s'], p2: 'x' },
+    });
+  });
+
+  it('detects paramOffset from the SQL text', () => {
+    const r = buildJsonbQuery(
+      'data',
+      one({ field: 'age', dataType: 'numeric', operator: 'gt', value: 18 }),
+      { paramOffset: 2 },
+    );
+    expect(toNamedParams(r)).toEqual({
+      where: '(("data" #>> :p3)::numeric > :p4)',
+      params: { p3: ['age'], p4: 18 },
+    });
+  });
+
+  it('converts jsonpath results (path strings are values, not SQL)', () => {
+    const r = buildJsonbQuery(
+      'data',
+      one({ field: 'tags', dataType: 'array', elementType: 'string', operator: 'eq', value: 'a' }),
+      { dialect: 'jsonpath' },
+    );
+    expect(toNamedParams(r)).toEqual({
+      where: 'jsonb_path_exists("data", :p1::jsonpath, :p2::jsonb)',
+      params: { p1: '$."tags"[*] ? (@ == $v)', p2: { v: 'a' } },
+    });
+  });
+
+  it('does not rewrite $ inside quoted identifiers', () => {
+    const r = buildJsonbQuery('t$1', one({ field: 'name', dataType: 'string', operator: 'eq', value: 'x' }));
+    expect(toNamedParams(r).where).toBe('(("t$1" #>> :p1) = :p2)');
+  });
+
+  it('supports a custom prefix and validates it', () => {
+    const r = buildJsonbQuery('data', one({ field: 'a', dataType: 'string', operator: 'eq', value: 'x' }));
+    expect(toNamedParams(r, 'q').where).toBe('(("data" #>> :q1) = :q2)');
+    expect(() => toNamedParams(r, '1bad')).toThrow(/prefix/i);
+    expect(() => toNamedParams(r, 'p-x')).toThrow(/prefix/i);
+  });
+
+  it('passes empty results through', () => {
+    expect(toNamedParams({ where: '', values: [], from: [] })).toEqual({ where: '', params: {} });
+  });
+
+  it('rejects results whose placeholders do not match the values array', () => {
+    expect(() => toNamedParams({ where: '($1 = $3)', values: ['a', 'b'], from: [] })).toThrow(
+      /placeholders do not match/i,
+    );
+    expect(() => toNamedParams({ where: '($1)', values: ['a', 'b'], from: [] })).toThrow(
+      /placeholders do not match/i,
+    );
+  });
+});

--- a/packages/jsonb-query/src/named-params.spec.ts
+++ b/packages/jsonb-query/src/named-params.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { buildJsonbQuery } from './build';
-import { toNamedParams } from './named-params';
+import { buildNamedJsonbQuery, toNamedParams } from './named-params';
 import type { JsonbFilterGroup } from './types';
 
 const one = (f: JsonbFilterGroup['filters'][number]): JsonbFilterGroup => ({
@@ -72,5 +72,40 @@ describe('toNamedParams', () => {
     expect(() => toNamedParams({ where: '($1)', values: ['a', 'b'], from: [] })).toThrow(
       /placeholders do not match/i,
     );
+  });
+});
+
+describe('buildNamedJsonbQuery', () => {
+  it('builds named output in one call', () => {
+    expect(
+      buildNamedJsonbQuery('data', one({ field: 'name', dataType: 'string', operator: 'eq', value: 'bob' })),
+    ).toEqual({
+      where: '(("data" #>> :p1) = :p2)',
+      params: { p1: ['name'], p2: 'bob' },
+    });
+  });
+
+  it('passes dialect/paramOffset through; the offset shifts the names', () => {
+    expect(
+      buildNamedJsonbQuery(
+        'data',
+        one({ field: 'tags', dataType: 'array', elementType: 'string', operator: 'eq', value: 'a' }),
+        { dialect: 'jsonpath', paramOffset: 4 },
+      ),
+    ).toEqual({
+      where: 'jsonb_path_exists("data", :p5::jsonpath, :p6::jsonb)',
+      params: { p5: '$."tags"[*] ? (@ == $v)', p6: { v: 'a' } },
+    });
+  });
+
+  it('honours a custom prefix (composable fragments without key collisions)', () => {
+    expect(
+      buildNamedJsonbQuery('data', one({ field: 'a', dataType: 'string', operator: 'eq', value: 'x' }), {
+        prefix: 'f',
+      }),
+    ).toEqual({
+      where: '(("data" #>> :f1) = :f2)',
+      params: { f1: ['a'], f2: 'x' },
+    });
   });
 });

--- a/packages/jsonb-query/src/named-params.ts
+++ b/packages/jsonb-query/src/named-params.ts
@@ -1,8 +1,14 @@
-import type { JsonbQueryResult } from './types';
+import type { BuildJsonbOptions, JsonbFilterGroup, JsonbQueryResult } from './types';
+import { buildJsonbQuery } from './build';
 
 export interface NamedParamsResult {
   where: string;
   params: Record<string, unknown>;
+}
+
+export interface BuildNamedJsonbOptions extends BuildJsonbOptions {
+  /** Named-parameter prefix (default `"p"`): `:p1`, `:p2`, … */
+  prefix?: string;
 }
 
 const PREFIX = /^[A-Za-z_][A-Za-z0-9_]*$/;
@@ -48,4 +54,19 @@ export function toNamedParams(result: JsonbQueryResult, prefix = 'p'): NamedPara
       result.values.map((value, i) => [`${prefix}${offset + i + 1}`, value]),
     ),
   };
+}
+
+/**
+ * One-call variant for named-binding query layers (TypeORM QueryBuilder,
+ * Knex): `buildJsonbQuery` + `toNamedParams`. `paramOffset` shifts the
+ * parameter *names* (`:p5`, …), which also avoids key collisions when
+ * composing several fragments into one query.
+ */
+export function buildNamedJsonbQuery(
+  column: string,
+  filter: JsonbFilterGroup,
+  options: BuildNamedJsonbOptions = {},
+): NamedParamsResult {
+  const { prefix, ...buildOptions } = options;
+  return toNamedParams(buildJsonbQuery(column, filter, buildOptions), prefix);
 }

--- a/packages/jsonb-query/src/named-params.ts
+++ b/packages/jsonb-query/src/named-params.ts
@@ -1,0 +1,51 @@
+import type { JsonbQueryResult } from './types';
+
+export interface NamedParamsResult {
+  where: string;
+  params: Record<string, unknown>;
+}
+
+const PREFIX = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+/**
+ * Convert a positional result (`$N` + values array) into named-parameter form
+ * (`:pN` + params object) for query layers with named bindings (TypeORM
+ * QueryBuilder, Knex). The core output stays positional — PostgreSQL's native
+ * form — and this helper is opt-in.
+ *
+ * Placeholder numbering is detected from the SQL text, so results built with
+ * `paramOffset` map correctly. Named form also keeps repeated placeholder
+ * references (e.g. `startswith` reuses its value) pointing at a single param,
+ * which naive positional-`?` conversion cannot express.
+ */
+export function toNamedParams(result: JsonbQueryResult, prefix = 'p'): NamedParamsResult {
+  if (!PREFIX.test(prefix)) {
+    throw new Error(`Invalid named-parameter prefix: ${JSON.stringify(prefix)}`);
+  }
+
+  // The lookbehind keeps `$` inside quoted identifiers (e.g. "t$1") from being
+  // rewritten: real placeholders are never preceded by an identifier
+  // character or a double quote. Values never appear in the SQL text, so no
+  // user data can be affected by this rewrite.
+  const seen = new Set<number>();
+  const where = result.where.replace(/(?<![A-Za-z0-9_$"])\$(\d+)/g, (_match, n: string) => {
+    seen.add(Number(n));
+    return `:${prefix}${n}`;
+  });
+
+  const numbers = [...seen].sort((a, b) => a - b);
+  const offset = (numbers[0] ?? 1) - 1;
+  const contiguous =
+    numbers.length === result.values.length &&
+    numbers.every((n, i) => n === offset + i + 1);
+  if (!contiguous) {
+    throw new Error('toNamedParams: placeholders do not match the values array');
+  }
+
+  return {
+    where,
+    params: Object.fromEntries(
+      result.values.map((value, i) => [`${prefix}${offset + i + 1}`, value]),
+    ),
+  };
+}

--- a/packages/jsonb-query/src/object-condition.spec.ts
+++ b/packages/jsonb-query/src/object-condition.spec.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { renderObjectCondition } from './object-condition';
+import { ParamBuilder } from './param-builder';
+import type { JsonbObjectCondition } from './types';
+
+function run(cond: Omit<JsonbObjectCondition, 'dataType'>) {
+  const p = new ParamBuilder();
+  const where = renderObjectCondition('"data"', { ...cond, dataType: 'object' }, p);
+  return { where, values: p.values };
+}
+
+describe('renderObjectCondition', () => {
+  it('eq compares via #> against a jsonb param (structural equality)', () => {
+    expect(run({ field: 'profile', operator: 'eq', value: { vip: true } })).toEqual({
+      where: '(("data" #> $1) = $2::jsonb)',
+      values: [['profile'], '{"vip":true}'],
+    });
+  });
+
+  it('neq uses <>', () => {
+    expect(run({ field: 'profile', operator: 'neq', value: { vip: true } })).toEqual({
+      where: '(("data" #> $1) <> $2::jsonb)',
+      values: [['profile'], '{"vip":true}'],
+    });
+  });
+
+  it('contains uses @> and supports dot paths', () => {
+    expect(run({ field: 'meta.flags', operator: 'contains', value: { beta: true } })).toEqual({
+      where: '(("data" #> $1) @> $2::jsonb)',
+      values: [['meta', 'flags'], '{"beta":true}'],
+    });
+  });
+
+  it('isnull / isnotnull use the shared #>> null check', () => {
+    expect(run({ field: 'profile', operator: 'isnull' })).toEqual({
+      where: '(("data" #>> $1) is null)',
+      values: [['profile']],
+    });
+    expect(run({ field: 'profile', operator: 'isnotnull' })).toEqual({
+      where: '(("data" #>> $1) is not null)',
+      values: [['profile']],
+    });
+  });
+
+  it('rejects non-object values', () => {
+    expect(() => run({ field: 'p', operator: 'eq', value: [1] as never })).toThrow(
+      /requires a plain object value/i,
+    );
+  });
+
+  it('keeps hostile values in params, never in SQL', () => {
+    const { where, values } = run({
+      field: 'p', operator: 'eq', value: { name: "x'; DROP TABLE t; --" },
+    });
+    expect(where).toBe('(("data" #> $1) = $2::jsonb)');
+    expect(values[1]).toBe('{"name":"x\'; DROP TABLE t; --"}');
+  });
+});

--- a/packages/jsonb-query/src/object-condition.ts
+++ b/packages/jsonb-query/src/object-condition.ts
@@ -1,0 +1,37 @@
+import type { JsonbObjectCondition } from './types';
+import type { ParamBuilder } from './param-builder';
+import {
+  fieldSegments,
+  assertObjectValue,
+  renderNullCheck,
+  renderJsonbContains,
+} from './dialect';
+
+/**
+ * Object conditions render the same SQL in both dialects: SQL/JSON path
+ * predicates cannot compare or contain non-scalar values, so the jsonpath
+ * dialect falls back to `#>` / `@>` (both GIN-indexable). jsonb `=` is
+ * structural equality (key order and whitespace insensitive).
+ */
+export function renderObjectCondition(
+  column: string,
+  condition: JsonbObjectCondition,
+  params: ParamBuilder,
+): string {
+  const { field, operator, value } = condition;
+  switch (operator) {
+    case 'isnull':
+    case 'isnotnull':
+      return renderNullCheck(column, field, operator, params);
+    case 'contains':
+      return renderJsonbContains(column, field, assertObjectValue(operator, value), params);
+    case 'eq':
+    case 'neq': {
+      const obj = assertObjectValue(operator, value);
+      const F = `(${column} #> ${params.add(fieldSegments(field))})`;
+      return `(${F} ${operator === 'eq' ? '=' : '<>'} ${params.add(JSON.stringify(obj))}::jsonb)`;
+    }
+    default:
+      throw new Error(`Unsupported operator "${operator as string}" for type "object"`);
+  }
+}

--- a/packages/jsonb-query/src/types.ts
+++ b/packages/jsonb-query/src/types.ts
@@ -2,7 +2,12 @@ export type JsonbDialect = 'legacy' | 'jsonpath';
 
 export type JsonbScalarType = 'string' | 'numeric' | 'date' | 'boolean';
 
+export type JsonbDataType = JsonbScalarType | 'object' | 'array';
+
 export type JsonbValue = string | number | boolean | Date;
+
+/** Value for object-typed conditions: a plain JSON-serializable object. */
+export type JsonbObjectValue = Record<string, unknown>;
 
 export type JsonbLogicalOperator = 'and' | 'or';
 
@@ -21,12 +26,58 @@ export type JsonbScalarOperator =
   | 'range'
   | 'terms';
 
-export interface JsonbCondition {
+export type JsonbObjectOperator = 'eq' | 'neq' | 'contains' | 'isnull' | 'isnotnull';
+
+/**
+ * Operators on arrays of scalars. Scalar operators use "some element matches"
+ * (∃) semantics; `isnull`/`isnotnull` test the array field itself;
+ * `containsall` requires every listed value to be present. `neq` is excluded:
+ * its exists-vs-forall meaning is ambiguous on arrays.
+ */
+export type JsonbArrayOperator = Exclude<JsonbScalarOperator, 'neq'> | 'containsall';
+
+export interface JsonbScalarCondition {
   field: string;
   dataType: JsonbScalarType;
   operator: JsonbScalarOperator;
   value?: JsonbValue | JsonbValue[];
+  elementType?: never;
+  filters?: never;
 }
+
+export interface JsonbObjectCondition {
+  field: string;
+  dataType: 'object';
+  operator: JsonbObjectOperator;
+  value?: JsonbObjectValue;
+  elementType?: never;
+  filters?: never;
+}
+
+export interface JsonbArrayCondition {
+  field: string;
+  dataType: 'array';
+  elementType: JsonbScalarType;
+  operator: JsonbArrayOperator;
+  value?: JsonbValue | JsonbValue[];
+  filters?: never;
+}
+
+export interface JsonbElemMatchCondition {
+  field: string;
+  dataType: 'array';
+  elementType: 'object';
+  operator: 'elemmatch';
+  /** Conditions applied per element; each `field` is relative to the element. */
+  filters: JsonbFilterGroup;
+  value?: never;
+}
+
+export type JsonbCondition =
+  | JsonbScalarCondition
+  | JsonbObjectCondition
+  | JsonbArrayCondition
+  | JsonbElemMatchCondition;
 
 export interface JsonbFilterGroup {
   logic: JsonbLogicalOperator;
@@ -36,7 +87,7 @@ export interface JsonbFilterGroup {
 export interface JsonbQueryResult {
   where: string;
   values: unknown[];
-  /** FROM-clause fragments. Always `[]` in Phase 1. Reserved for Phase 2 (non-scalar types). */
+  /** Always `[]`. Array queries render as EXISTS subqueries inside `where`; reserved. */
   from: string[];
 }
 

--- a/packages/jsonb-query/src/types.ts
+++ b/packages/jsonb-query/src/types.ts
@@ -9,7 +9,12 @@ export type JsonbValue = string | number | boolean | Date;
 /** Value for object-typed conditions: a plain JSON-serializable object. */
 export type JsonbObjectValue = Record<string, unknown>;
 
-export type JsonbLogicalOperator = 'and' | 'or';
+/**
+ * Group logic, aligned with `@rfjs/data-filter`'s `LogicalOperator`:
+ * `and` = all children match; `or` = any child matches;
+ * `not` = NOT(all children match); `nor` = NOT(any child matches).
+ */
+export type JsonbLogicalOperator = 'and' | 'or' | 'nor' | 'not';
 
 export type JsonbScalarOperator =
   | 'eq'

--- a/packages/jsonb-query/test/jsonb-query.e2e.spec.ts
+++ b/packages/jsonb-query/test/jsonb-query.e2e.spec.ts
@@ -1,0 +1,502 @@
+/**
+ * E2E tests against real PostgreSQL instances. Self-skips when PG_E2E_URLS is
+ * not set, so it is safe to run anywhere (never wired into CI).
+ *
+ * Start the instances:
+ *   docker run -d --name jsonb-e2e-pg11 -e POSTGRES_PASSWORD=e2e -p 54311:5432 postgres:11.16
+ *   docker run -d --name jsonb-e2e-pg16 -e POSTGRES_PASSWORD=e2e -p 54316:5432 postgres:16-alpine
+ *
+ * Run:
+ *   PG_E2E_URLS="postgres://postgres:e2e@localhost:54311/postgres,postgres://postgres:e2e@localhost:54316/postgres" \
+ *     pnpm -F @rfjs/jsonb-query vitest:e2e:run
+ *
+ * Version gates: legacy dialect runs on every version; jsonpath needs PG 12+
+ * (PostgreSQL 11.16 — the production target — runs the legacy suite only);
+ * jsonpath date comparisons (.datetime()) need PG 13+.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { Client } from 'pg';
+import { buildJsonbQuery } from '../src';
+import type { BuildJsonbOptions, JsonbDialect, JsonbFilterGroup } from '../src';
+
+const URLS = (process.env.PG_E2E_URLS ?? '')
+  .split(',')
+  .map((s) => s.trim())
+  .filter(Boolean);
+
+const INJECTION = "x'; drop table e2e_t; --";
+
+const SEED: Array<[number, unknown]> = [
+  [
+    1,
+    {
+      name: 'bob',
+      age: 30,
+      vip: true,
+      joined: '2020-01-15T08:30:00Z',
+      profile: { vip: true, level: 3 },
+      tags: ['a', 'b'],
+      nums: [1, 5, 9],
+      items: [
+        { sku: 'x', qty: 2, ship: '2020-02-01T00:00:00+00:00' },
+        { sku: 'y', qty: 10, ship: '2021-02-01T00:00:00+00:00' },
+      ],
+      orders: [{ status: 'open', lines: [{ sku: 'x' }] }],
+    },
+  ],
+  [
+    2,
+    {
+      name: 'alice',
+      age: 18,
+      vip: false,
+      joined: '2021-03-20T00:00:00Z',
+      profile: { vip: false },
+      tags: ['b', 'c'],
+      nums: [10, 20],
+      items: [{ sku: 'y', qty: 1 }],
+    },
+  ],
+  // JSON null age; everything else missing.
+  [3, { name: 'carol', age: null }],
+  // Malformed shapes: tags is a scalar, items is an object (not an array).
+  [4, { name: 'dave', tags: 'a', items: { sku: 'x', qty: 99 } }],
+  // Regex metacharacters + hostile value stored as data.
+  [5, { name: 'a.b', memo: INJECTION }],
+  [6, { name: 'axb' }],
+  // Date-only format (vs the full ISO timestamps above).
+  [7, { joined: '2021-03-20' }],
+  // PG-friendly offset format (jsonpath .datetime() rejects the 'Z' suffix).
+  [8, { joined: '2020-01-15T08:30:00+00:00' }],
+];
+
+describe.skipIf(URLS.length === 0)('jsonb-query e2e', () => {
+  describe.each(URLS.map((url) => [url.replace(/\/\/.*@/, '//***@'), url]))(
+    '%s',
+    (_label, url) => {
+      let client: Client;
+      let version = 0; // server_version_num, e.g. 110016 / 160014
+
+      const dialects = (): JsonbDialect[] =>
+        version >= 120000 ? ['legacy', 'jsonpath'] : ['legacy'];
+
+      async function ids(
+        filter: JsonbFilterGroup,
+        options?: BuildJsonbOptions,
+      ): Promise<number[]> {
+        const { where, values } = buildJsonbQuery('data', filter, options);
+        const res = await client.query(
+          `select id from e2e_t where ${where} order by id`,
+          values,
+        );
+        return res.rows.map((r: { id: number }) => Number(r.id));
+      }
+
+      /** Assert the same row set for every dialect available on this server. */
+      async function expectIds(
+        filter: JsonbFilterGroup,
+        expected: number[],
+      ): Promise<void> {
+        for (const dialect of dialects()) {
+          expect(await ids(filter, { dialect }), dialect).toEqual(expected);
+        }
+      }
+
+      /** Assert per-dialect row sets where the dialects intentionally diverge. */
+      async function expectPerDialect(
+        filter: JsonbFilterGroup,
+        expected: Partial<Record<JsonbDialect, number[]>>,
+      ): Promise<void> {
+        for (const dialect of dialects()) {
+          expect(await ids(filter, { dialect }), dialect).toEqual(expected[dialect]);
+        }
+      }
+
+      beforeAll(async () => {
+        client = new Client({ connectionString: url });
+        await client.connect();
+        await client.query("set timezone to 'UTC'");
+        version = Number(
+          (await client.query('show server_version_num')).rows[0].server_version_num,
+        );
+        await client.query('drop table if exists e2e_t');
+        await client.query('create table e2e_t (id int primary key, data jsonb)');
+        for (const [id, data] of SEED) {
+          await client.query('insert into e2e_t values ($1, $2::jsonb)', [
+            id,
+            JSON.stringify(data),
+          ]);
+        }
+      });
+
+      afterAll(async () => {
+        await client?.end();
+      });
+
+      describe('scalar conditions', () => {
+        const one = (f: JsonbFilterGroup['filters'][number]): JsonbFilterGroup => ({
+          logic: 'and',
+          filters: [f],
+        });
+
+        it('eq / neq string', async () => {
+          await expectIds(one({ field: 'name', dataType: 'string', operator: 'eq', value: 'bob' }), [1]);
+          // neq: rows with a missing field yield SQL NULL and never match.
+          await expectIds(one({ field: 'name', dataType: 'string', operator: 'neq', value: 'bob' }), [2, 3, 4, 5, 6]);
+        });
+
+        it('numeric gt / range / terms', async () => {
+          await expectIds(one({ field: 'age', dataType: 'numeric', operator: 'gt', value: 20 }), [1]);
+          await expectIds(one({ field: 'age', dataType: 'numeric', operator: 'range', value: [10, 40] }), [1, 2]);
+          await expectIds(one({ field: 'name', dataType: 'string', operator: 'terms', value: ['bob', 'alice'] }), [1, 2]);
+        });
+
+        it('boolean eq', async () => {
+          await expectIds(one({ field: 'vip', dataType: 'boolean', operator: 'eq', value: true }), [1]);
+        });
+
+        it('isnull treats JSON null and missing keys alike', async () => {
+          await expectIds(one({ field: 'age', dataType: 'numeric', operator: 'isnull' }), [3, 4, 5, 6, 7, 8]);
+          await expectIds(one({ field: 'age', dataType: 'numeric', operator: 'isnotnull' }), [1, 2]);
+        });
+
+        it('date eq — stored "Z" suffix is invisible to jsonpath .datetime()', async () => {
+          // ids 1 and 8 store the same instant: id 1 as '...Z' (JS
+          // toISOString style), id 8 as '...+00:00'. The query value's 'Z' is
+          // normalized by the builder, but stored 'Z' strings fail
+          // .datetime() parsing and lax mode swallows the error -> jsonpath
+          // only sees id 8. Use the legacy dialect for 'Z'-suffixed data.
+          await expectPerDialect(
+            one({ field: 'joined', dataType: 'date', operator: 'eq', value: '2020-01-15T08:30:00Z' }),
+            { legacy: [1, 8], jsonpath: [8] },
+          );
+        });
+
+        it('date gt — mixed stored formats (timestamp vs date-only)', async () => {
+          // id 2 stores '...Z'; id 7 stores a date-only string.
+          // legacy ::timestamptz casts both -> [2, 7].
+          // jsonpath: jsonb_path_exists_tz lets the date-only value (7)
+          // compare against the timestamptz query value, but id 2's stored
+          // 'Z' suffix still fails .datetime() parsing -> [7] only.
+          await expectPerDialect(
+            one({ field: 'joined', dataType: 'date', operator: 'gt', value: '2020-06-01T00:00:00Z' }),
+            { legacy: [2, 7], jsonpath: [7] },
+          );
+        });
+
+        it('contains escapes regex metacharacters (a.b must not match axb)', async () => {
+          await expectIds(one({ field: 'name', dataType: 'string', operator: 'contains', value: 'a.b' }), [5]);
+          await expectIds(one({ field: 'name', dataType: 'string', operator: 'startswith', value: 'bo' }), [1]);
+          await expectIds(one({ field: 'name', dataType: 'string', operator: 'endswith', value: 'ce' }), [2]);
+        });
+      });
+
+      describe('object conditions', () => {
+        it('eq is structural (key order insensitive)', async () => {
+          await expectIds(
+            {
+              logic: 'and',
+              filters: [{ field: 'profile', dataType: 'object', operator: 'eq', value: { level: 3, vip: true } }],
+            },
+            [1],
+          );
+        });
+
+        it('contains / isnull', async () => {
+          await expectIds(
+            { logic: 'and', filters: [{ field: 'profile', dataType: 'object', operator: 'contains', value: { vip: false } }] },
+            [2],
+          );
+          await expectIds(
+            { logic: 'and', filters: [{ field: 'profile', dataType: 'object', operator: 'isnull' }] },
+            [3, 4, 5, 6, 7, 8],
+          );
+        });
+      });
+
+      describe('scalar-array conditions', () => {
+        const one = (f: JsonbFilterGroup['filters'][number]): JsonbFilterGroup => ({
+          logic: 'and',
+          filters: [f],
+        });
+
+        it('element eq (∃ semantics)', async () => {
+          await expectIds(
+            one({ field: 'tags', dataType: 'array', elementType: 'string', operator: 'eq', value: 'b' }),
+            [1, 2],
+          );
+        });
+
+        it('malformed shape divergence: scalar stored where an array is expected', async () => {
+          // id 4 stores tags: "a" (scalar). legacy's typeof guard treats it as
+          // an empty array; jsonpath lax mode auto-wraps it -> matches.
+          await expectPerDialect(
+            one({ field: 'tags', dataType: 'array', elementType: 'string', operator: 'eq', value: 'a' }),
+            { legacy: [1], jsonpath: [1, 4] },
+          );
+        });
+
+        it('element gt / range / terms', async () => {
+          await expectIds(
+            one({ field: 'nums', dataType: 'array', elementType: 'numeric', operator: 'gt', value: 15 }),
+            [2],
+          );
+          await expectIds(
+            one({ field: 'nums', dataType: 'array', elementType: 'numeric', operator: 'range', value: [4, 6] }),
+            [1],
+          );
+          await expectIds(
+            one({ field: 'tags', dataType: 'array', elementType: 'string', operator: 'terms', value: ['c', 'z'] }),
+            [2],
+          );
+        });
+
+        it('containsall', async () => {
+          await expectIds(
+            one({ field: 'tags', dataType: 'array', elementType: 'string', operator: 'containsall', value: ['a', 'b'] }),
+            [1],
+          );
+        });
+
+        it('isnull on the array field itself', async () => {
+          await expectIds(
+            one({ field: 'tags', dataType: 'array', elementType: 'string', operator: 'isnull' }),
+            [3, 5, 6, 7, 8],
+          );
+        });
+      });
+
+      describe('elemmatch', () => {
+        it('binds all sub-conditions to the same element', async () => {
+          // id 1: {y,10} satisfies both; id 2: {y,1} fails qty.
+          await expectIds(
+            {
+              logic: 'and',
+              filters: [
+                {
+                  field: 'items', dataType: 'array', elementType: 'object', operator: 'elemmatch',
+                  filters: {
+                    logic: 'and',
+                    filters: [
+                      { field: 'sku', dataType: 'string', operator: 'eq', value: 'y' },
+                      { field: 'qty', dataType: 'numeric', operator: 'gt', value: 5 },
+                    ],
+                  },
+                },
+              ],
+            },
+            [1],
+          );
+        });
+
+        it('malformed shape divergence: object stored where an array is expected', async () => {
+          // id 4 stores items as a single object. legacy's guard -> no match;
+          // jsonpath lax mode wraps it into a one-element array -> matches.
+          await expectPerDialect(
+            {
+              logic: 'and',
+              filters: [
+                {
+                  field: 'items', dataType: 'array', elementType: 'object', operator: 'elemmatch',
+                  filters: {
+                    logic: 'and',
+                    filters: [
+                      { field: 'sku', dataType: 'string', operator: 'eq', value: 'x' },
+                      { field: 'qty', dataType: 'numeric', operator: 'gt', value: 5 },
+                    ],
+                  },
+                },
+              ],
+            },
+            { legacy: [], jsonpath: [4] },
+          );
+        });
+
+        it('nested or-groups inside elemmatch', async () => {
+          await expectIds(
+            {
+              logic: 'and',
+              filters: [
+                {
+                  field: 'items', dataType: 'array', elementType: 'object', operator: 'elemmatch',
+                  filters: {
+                    logic: 'and',
+                    filters: [
+                      { field: 'sku', dataType: 'string', operator: 'eq', value: 'y' },
+                      {
+                        logic: 'or',
+                        filters: [
+                          { field: 'qty', dataType: 'numeric', operator: 'gt', value: 5 },
+                          { field: 'qty', dataType: 'numeric', operator: 'lt', value: 2 },
+                        ],
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+            [1, 2],
+          );
+        });
+
+        it('nested elemmatch', async () => {
+          await expectIds(
+            {
+              logic: 'and',
+              filters: [
+                {
+                  field: 'orders', dataType: 'array', elementType: 'object', operator: 'elemmatch',
+                  filters: {
+                    logic: 'and',
+                    filters: [
+                      { field: 'status', dataType: 'string', operator: 'eq', value: 'open' },
+                      {
+                        field: 'lines', dataType: 'array', elementType: 'object', operator: 'elemmatch',
+                        filters: {
+                          logic: 'and',
+                          filters: [{ field: 'sku', dataType: 'string', operator: 'eq', value: 'x' }],
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+            [1],
+          );
+        });
+
+        it('isnull inside elemmatch covers missing members in both dialects', async () => {
+          await expectIds(
+            {
+              logic: 'and',
+              filters: [
+                {
+                  field: 'items', dataType: 'array', elementType: 'object', operator: 'elemmatch',
+                  filters: {
+                    logic: 'and',
+                    filters: [
+                      { field: 'sku', dataType: 'string', operator: 'eq', value: 'y' },
+                      { field: 'note', dataType: 'string', operator: 'isnull' },
+                    ],
+                  },
+                },
+              ],
+            },
+            [1, 2],
+          );
+        });
+
+        it('date comparison inside elemmatch (jsonpath needs PG 13+)', async () => {
+          const filter: JsonbFilterGroup = {
+            logic: 'and',
+            filters: [
+              {
+                field: 'items', dataType: 'array', elementType: 'object', operator: 'elemmatch',
+                filters: {
+                  logic: 'and',
+                  filters: [
+                    { field: 'sku', dataType: 'string', operator: 'eq', value: 'y' },
+                    { field: 'ship', dataType: 'date', operator: 'gt', value: '2020-12-31T00:00:00Z' },
+                  ],
+                },
+              },
+            ],
+          };
+          for (const dialect of dialects()) {
+            if (dialect === 'jsonpath' && version < 130000) continue;
+            expect(await ids(filter, { dialect }), dialect).toEqual([1]);
+          }
+        });
+      });
+
+      describe('nor / not groups', () => {
+        it('not over an array condition = "does not contain" consistently', async () => {
+          // Missing tags (3,5,6,7) and the malformed scalar "a" (4, which is
+          // not "b" even after lax wrapping) all count as "does not contain".
+          await expectIds(
+            {
+              logic: 'not',
+              filters: [
+                { field: 'tags', dataType: 'array', elementType: 'string', operator: 'eq', value: 'b' },
+              ],
+            },
+            [3, 4, 5, 6, 7, 8],
+          );
+        });
+
+        it('not over a scalar condition diverges on missing fields (three-valued logic)', async () => {
+          // id 7 has no name. legacy: not(NULL) is NULL -> excluded.
+          // jsonpath: jsonb_path_exists() returns false for the missing field,
+          // so not(false) -> included.
+          await expectPerDialect(
+            {
+              logic: 'not',
+              filters: [{ field: 'name', dataType: 'string', operator: 'eq', value: 'bob' }],
+            },
+            { legacy: [2, 3, 4, 5, 6], jsonpath: [2, 3, 4, 5, 6, 7, 8] },
+          );
+        });
+
+        it('nor (NOT any) follows the same per-dialect null semantics', async () => {
+          // Matching rows must fail BOTH conditions. age is missing on 4,5,6,7
+          // and JSON null on 3: legacy NULL-poisons the disjunction; jsonpath
+          // just sees false.
+          await expectPerDialect(
+            {
+              logic: 'nor',
+              filters: [
+                { field: 'name', dataType: 'string', operator: 'eq', value: 'bob' },
+                { field: 'age', dataType: 'numeric', operator: 'gt', value: 25 },
+              ],
+            },
+            { legacy: [2], jsonpath: [2, 3, 4, 5, 6, 7, 8] },
+          );
+        });
+      });
+
+      describe('safety', () => {
+        it('round-trips a hostile value through parameters', async () => {
+          await expectIds(
+            { logic: 'and', filters: [{ field: 'memo', dataType: 'string', operator: 'eq', value: INJECTION }] },
+            [5],
+          );
+          await expectIds(
+            { logic: 'and', filters: [{ field: 'name', dataType: 'string', operator: 'eq', value: INJECTION }] },
+            [],
+          );
+          // The table survived.
+          expect((await client.query('select count(*) from e2e_t')).rows[0].count).toBe('8');
+        });
+
+        it('treats hostile field names as data, not SQL/jsonpath', async () => {
+          await expectIds(
+            {
+              logic: 'and',
+              filters: [
+                { field: 'nope"; drop table e2e_t; --', dataType: 'string', operator: 'eq', value: 'x' },
+              ],
+            },
+            [],
+          );
+          expect((await client.query('select count(*) from e2e_t')).rows[0].count).toBe('8');
+        });
+      });
+
+      it('honours paramOffset when embedded after existing parameters', async () => {
+        for (const dialect of dialects()) {
+          const { where, values } = buildJsonbQuery(
+            'data',
+            { logic: 'and', filters: [{ field: 'name', dataType: 'string', operator: 'eq', value: 'bob' }] },
+            { dialect, paramOffset: 1 },
+          );
+          const res = await client.query(
+            `select id from e2e_t where id > $1 and ${where} order by id`,
+            [0, ...values],
+          );
+          expect(res.rows.map((r: { id: number }) => Number(r.id)), dialect).toEqual([1]);
+        }
+      });
+    },
+  );
+});

--- a/packages/jsonb-query/test/jsonb-query.e2e.spec.ts
+++ b/packages/jsonb-query/test/jsonb-query.e2e.spec.ts
@@ -113,8 +113,24 @@ describe.skipIf(URLS.length === 0)('jsonb-query e2e', () => {
       }
 
       beforeAll(async () => {
-        client = new Client({ connectionString: url });
-        await client.connect();
+        // Retry the initial connection: CI service containers may accept TCP
+        // before PG is actually ready to serve queries.
+        let lastError: unknown;
+        for (let attempt = 0; attempt < 30; attempt += 1) {
+          client = new Client({ connectionString: url });
+          try {
+            await client.connect();
+            lastError = undefined;
+            break;
+          } catch (error) {
+            lastError = error;
+            await client.end().catch(() => undefined);
+            await new Promise((resolve) => setTimeout(resolve, 1000));
+          }
+        }
+        if (lastError) {
+          throw lastError;
+        }
         await client.query("set timezone to 'UTC'");
         version = Number(
           (await client.query('show server_version_num')).rows[0].server_version_num,

--- a/packages/jsonb-query/vitest.config.e2e.mts
+++ b/packages/jsonb-query/vitest.config.e2e.mts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['test/**/*.e2e.test.(ts|js)', 'test/**/*.e2e.spec.(ts|js)'],
+    reporters: ['verbose'],
+    // Suites self-skip when PG_E2E_URLS is not set, so this config is safe to
+    // run anywhere; real runs need the docker instances described in
+    // test/jsonb-query.e2e.spec.ts.
+    testTimeout: 30_000,
+    hookTimeout: 60_000,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -833,6 +833,9 @@ importers:
       '@eslint/js':
         specifier: ^9.20.0
         version: 9.39.1
+      '@types/pg':
+        specifier: ^8.16.0
+        version: 8.16.0
       '@vitest/coverage-istanbul':
         specifier: ^3.2.3
         version: 3.2.4(vitest@3.2.4)
@@ -848,6 +851,9 @@ importers:
       npm-run-all:
         specifier: ^4.1.5
         version: 4.1.5
+      pg:
+        specifier: ^8.16.3
+        version: 8.16.3
       prettier:
         specifier: ^3.5.1
         version: 3.5.3
@@ -3126,9 +3132,6 @@ packages:
 
   '@types/node@22.13.0':
     resolution: {integrity: sha512-ClIbNe36lawluuvq3+YYhnIN2CELi+6q8NpnM7PYp4hBn/TatfboPgVSm2rwKRfnV2M+Ty9GWDFI64KEe+kysA==}
-
-  '@types/node@24.0.3':
-    resolution: {integrity: sha512-R4I/kzCYAdRLzfiCabn9hxWfbuHS573x+r0dJMkkzThEa7pbrcDWK+9zu3e7aBOouf+rQAciqPFMnxwr0aWgKg==}
 
   '@types/node@25.9.1':
     resolution: {integrity: sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==}
@@ -7080,9 +7083,6 @@ packages:
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
-  undici-types@7.8.0:
-    resolution: {integrity: sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==}
-
   unicorn-magic@0.1.0:
     resolution: {integrity: sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==}
     engines: {node: '>=18'}
@@ -9441,10 +9441,6 @@ snapshots:
     dependencies:
       undici-types: 6.20.0
 
-  '@types/node@24.0.3':
-    dependencies:
-      undici-types: 7.8.0
-
   '@types/node@25.9.1':
     dependencies:
       undici-types: 7.24.6
@@ -9455,7 +9451,7 @@ snapshots:
 
   '@types/pg@8.16.0':
     dependencies:
-      '@types/node': 24.0.3
+      '@types/node': 22.13.0
       pg-protocol: 1.10.3
       pg-types: 2.2.0
 
@@ -13966,8 +13962,6 @@ snapshots:
   undici-types@6.20.0: {}
 
   undici-types@7.24.6: {}
-
-  undici-types@7.8.0: {}
 
   unicorn-magic@0.1.0: {}
 


### PR DESCRIPTION
## Summary

Phase 2 of `@rfjs/jsonb-query` (held-back package, preparing first publish 0.1.0):

### Features
- **Nested object conditions** — `dataType: 'object'`: `eq`/`neq` (structural jsonb equality), `contains` (`@>`), `isnull`/`isnotnull`; identical SQL in both dialects (GIN-indexable)
- **Scalar-array conditions** — `dataType: 'array'` + `elementType`: scalar operators with ∃ (some-element) semantics, `containsall`, field-level null checks; legacy renders guarded `EXISTS (jsonb_array_elements_text …)`, jsonpath renders `$."f"[*] ? (…)`
- **Arrays of objects** — `elemmatch`: all sub-conditions bind to the **same element**; nested and/or groups and nested elemmatch supported; legacy = `EXISTS` recursion, jsonpath = single merged path predicate with sequential vars
- **`nor`/`not` group logic** — aligned with `@rfjs/data-filter`'s `LogicalOperator`; `not` + array condition expresses "does not contain" (∀) consistently in both dialects
- **Named-parameter support** — `buildNamedJsonbQuery` (one-call) + `toNamedParams` (transformer) for TypeORM QueryBuilder / Knex; positional `$N` core output unchanged

### Fixes found by E2E
- PG's jsonpath `.datetime()` rejects the trailing `Z` that JS `toISOString()` emits, and lax mode swallows the error silently — all jsonpath date comparisons returned empty. Query-side values are now normalized (`Z` → `+00:00`), date conditions render `jsonb_path_exists_tz` (PG 13+, same floor as `.datetime()`); the stored-`"…Z"` limitation is pinned by e2e and documented in both READMEs

### Quality gates
- **124 unit tests** (string-shape assertions; Phase 1 expectations byte-identical)
- **52 E2E tests × 2 PostgreSQL versions** — 11.16 (production target, legacy-only; jsonpath auto-skips) and 16 (both dialects); covers malformed-shape guards, lax-mode divergences, three-valued-logic edges, injection round-trips
- **ORM compatibility verified live**: TypeORM QB + Knex named bindings against PG 16, including `:p1::jsonpath` cast adjacency (12/12)
- **Tarball verified**: clean contents, CJS/ESM smoke-tested from a clean install, types resolve under `bundler` and `node16`
- CI: path-filtered `ci-e2e-jsonb-query.yml` (PR / push main / manual) with PG service containers; local one-shot `pnpm -F @rfjs/jsonb-query test:e2e`

### Release guardrails (intentionally untouched)
`packages/jsonb-query/package.json` keeps `"private": true` and the package stays in the changeset `ignore` list — zero diff vs main. Release wiring (changeset → un-private → un-ignore → release flow, first publish 0.1.0) is a separate follow-up after this PR merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
