### PR TITLE
feat(jsonb-query): operator expansion — key-existence, case-insensitive text, array emptiness

### DIFF
--- a/.changeset/jsonb-query-operator-expansion.md
+++ b/.changeset/jsonb-query-operator-expansion.md
@@ -1,0 +1,13 @@
+---
+'@rfjs/jsonb-query': minor
+---
+
+Add three operator families.
+
+**Added**
+- Key-existence object operators `haskey` / `hasanykey` / `hasallkeys` (jsonb
+  `?` / `?|` / `?&`), distinct from `isnull`/`isnotnull` (which test the value).
+- Case-insensitive text operators `icontains` / `istartswith` / `iendswith` /
+  `ieq` / `ineq` for `string` conditions.
+- Array emptiness operators `isempty` / `isnotempty` for scalar-element arrays.
+- README "Indexing" section mapping operators to GIN / expression indexes.

--- a/docs/superpowers/plans/2026-06-13-jsonb-query-operator-expansion.md
+++ b/docs/superpowers/plans/2026-06-13-jsonb-query-operator-expansion.md
@@ -1,0 +1,701 @@
+# jsonb-query Operator Expansion Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add three operator families to `@rfjs/jsonb-query` — key-existence (`haskey`/`hasanykey`/`hasallkeys`), case-insensitive text (`icontains`/`istartswith`/`iendswith`/`ieq`/`ineq`), and array emptiness (`isempty`/`isnotempty`) — plus a GIN indexing guide, across both dialects.
+
+**Architecture:** Filter metadata renders to a parameterized PostgreSQL `WHERE` via two dialects (`legacy` `#>>`, `jsonpath` `jsonb_path_exists`). Validation lives in `src/dialect/base.ts` (`assertCondition` + operator sets + value guards). Object conditions render dialect-independently (`src/object-condition.ts`); scalar conditions render per-dialect (`legacy.ts` `renderScalarOp`, `jsonpath.ts` `scalarPredicate`); scalar-array conditions short-circuit `isnull`/`containsall`/etc. in each dialect's `renderArray`. We extend each of these following the existing patterns. **No new error codes** — value guards reuse `INVALID_SCALAR_VALUE` / `INVALID_ARRAY_VALUE`.
+
+**Tech Stack:** TypeScript 5.7, Vitest (co-located `src/**/*.spec.ts`), pnpm + Turborepo, Changesets.
+
+**Spec:** `docs/superpowers/specs/2026-06-13-jsonb-query-operator-expansion-design.md`
+
+**Working directory:** `packages/jsonb-query` inside the `feat/jsonb-query-operators` worktree (already created off the post-Phase-2 main). Commands assume repo root unless noted. Per-file test run: `pnpm -F @rfjs/jsonb-query vitest:run <path>`. Full gate: `pnpm -F @rfjs/jsonb-query lint && pnpm -F @rfjs/jsonb-query typecheck && pnpm -F @rfjs/jsonb-query test`.
+
+---
+
+## File Structure
+
+**Modified:**
+- `src/types.ts` — widen `JsonbObjectOperator`, `JsonbScalarOperator`, `JsonbArrayOperator`; widen `JsonbObjectCondition.value`.
+- `src/dialect/base.ts` — `OBJECT_OPERATORS`, `OPERATORS_BY_TYPE.string`, `ARRAY_OPERATORS_BY_ELEMENT`; new `assertKeyValue` / `assertKeyArray` / `renderArrayEmptiness`; extend `conditionNeedsSqlFallback`.
+- `src/object-condition.ts` — `haskey`/`hasanykey`/`hasallkeys` render cases.
+- `src/dialect/legacy.ts` — `renderScalarOp` case-insensitive cases; `renderArray` emptiness short-circuit.
+- `src/dialect/jsonpath.ts` — `scalarPredicate` case-insensitive cases; `renderArray` emptiness short-circuit.
+- Test specs co-located: `object-condition.spec.ts`, `dialect/legacy.spec.ts`, `dialect/jsonpath.spec.ts`, `dialect/base.spec.ts`, `build.spec.ts`.
+- `README.md`; `.changeset/<slug>.md` (new).
+- `test/jsonb-query.e2e.spec.ts`.
+
+**Build order:** K (objects) → I (case-insensitive scalars) → S (array emptiness) → docs/changeset → E2E. Each task is independently green and committed.
+
+---
+
+## Task 1: K — key-existence operators (`haskey` / `hasanykey` / `hasallkeys`)
+
+**Files:**
+- Modify: `src/types.ts`
+- Modify: `src/dialect/base.ts`
+- Modify: `src/object-condition.ts`
+- Test: `src/object-condition.spec.ts`, `src/dialect/base.spec.ts`
+
+- [ ] **Step 1: Write the failing render tests**
+
+Append to `src/object-condition.spec.ts` (inside the `describe('renderObjectCondition', …)` block):
+
+```ts
+  it('haskey uses the jsonb ? operator', () => {
+    expect(run({ field: 'profile', operator: 'haskey', value: 'vip' })).toEqual({
+      where: '(("data" #> $1) ? $2)',
+      values: [['profile'], 'vip'],
+    });
+  });
+
+  it('hasanykey / hasallkeys use ?| / ?& with a text[] param', () => {
+    expect(run({ field: 'profile', operator: 'hasanykey', value: ['vip', 'premium'] })).toEqual({
+      where: '(("data" #> $1) ?| $2::text[])',
+      values: [['profile'], ['vip', 'premium']],
+    });
+    expect(run({ field: 'profile', operator: 'hasallkeys', value: ['vip', 'level'] })).toEqual({
+      where: '(("data" #> $1) ?& $2::text[])',
+      values: [['profile'], ['vip', 'level']],
+    });
+  });
+
+  it('rejects bad key arguments', () => {
+    expect(() => run({ field: 'p', operator: 'haskey', value: ['x'] as never })).toThrow(
+      /requires a single string key/i,
+    );
+    expect(() => run({ field: 'p', operator: 'hasanykey', value: [] as never })).toThrow(
+      /requires a non-empty array of string keys/i,
+    );
+    expect(() => run({ field: 'p', operator: 'hasallkeys', value: [1] as never })).toThrow(
+      /requires a non-empty array of string keys/i,
+    );
+  });
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pnpm -F @rfjs/jsonb-query vitest:run src/object-condition.spec.ts`
+Expected: FAIL — `haskey`/`hasanykey`/`hasallkeys` hit the `default` throw (`Unsupported operator … for type "object"`), and the types reject the operator/value.
+
+- [ ] **Step 3: Widen types in `src/types.ts`**
+
+Replace:
+```ts
+export type JsonbObjectOperator = 'eq' | 'neq' | 'contains' | 'isnull' | 'isnotnull';
+```
+with:
+```ts
+export type JsonbObjectOperator =
+  | 'eq'
+  | 'neq'
+  | 'contains'
+  | 'isnull'
+  | 'isnotnull'
+  | 'haskey'
+  | 'hasanykey'
+  | 'hasallkeys';
+```
+
+Replace the `JsonbObjectCondition.value` line:
+```ts
+  value?: JsonbObjectValue;
+```
+with:
+```ts
+  /** Object value for eq/neq/contains; a string key for haskey; a string[] for hasanykey/hasallkeys. */
+  value?: JsonbObjectValue | string | string[];
+```
+
+- [ ] **Step 4: Add operator-set membership + key guards in `src/dialect/base.ts`**
+
+Replace `OBJECT_OPERATORS`:
+```ts
+const OBJECT_OPERATORS: ReadonlySet<JsonbObjectOperator> = new Set([
+  'eq', 'neq', 'contains', 'isnull', 'isnotnull', 'haskey', 'hasanykey', 'hasallkeys',
+]);
+```
+
+Add two guards next to `assertObjectValue`:
+```ts
+export function assertKeyValue(operator: string, value: unknown): string {
+  if (typeof value !== 'string') {
+    throw new JsonbQueryError(`Operator "${operator}" requires a single string key`, 'INVALID_SCALAR_VALUE');
+  }
+  return value;
+}
+
+export function assertKeyArray(operator: string, value: unknown): string[] {
+  if (!Array.isArray(value) || value.length === 0 || !value.every((k) => typeof k === 'string')) {
+    throw new JsonbQueryError(
+      `Operator "${operator}" requires a non-empty array of string keys`,
+      'INVALID_ARRAY_VALUE',
+    );
+  }
+  return value as string[];
+}
+```
+
+- [ ] **Step 5: Render in `src/object-condition.ts`**
+
+Add `assertKeyValue, assertKeyArray` to the import from `'./dialect'`:
+```ts
+import {
+  fieldSegments,
+  assertObjectValue,
+  assertKeyValue,
+  assertKeyArray,
+  renderNullCheck,
+  renderJsonbContains,
+} from './dialect';
+```
+
+Add cases to the `switch (operator)` before `default`:
+```ts
+    case 'haskey': {
+      const key = assertKeyValue(operator, value);
+      return `((${column} #> ${params.add(fieldSegments(field))}) ? ${params.add(key)})`;
+    }
+    case 'hasanykey':
+    case 'hasallkeys': {
+      const keys = assertKeyArray(operator, value);
+      const op = operator === 'hasanykey' ? '?|' : '?&';
+      return `((${column} #> ${params.add(fieldSegments(field))}) ${op} ${params.add(keys)}::text[])`;
+    }
+```
+
+- [ ] **Step 6: Run render tests to verify they pass**
+
+Run: `pnpm -F @rfjs/jsonb-query vitest:run src/object-condition.spec.ts`
+Expected: PASS.
+
+- [ ] **Step 7: Add validation test in `src/dialect/base.spec.ts`**
+
+In the `describe('assertCondition', …)` block, extend the `validates object operators` test (or add a new `it`):
+```ts
+  it('accepts key-existence object operators', () => {
+    expect(c({ field: 'p', dataType: 'object', operator: 'haskey', value: 'vip' })).not.toThrow();
+    expect(c({ field: 'p', dataType: 'object', operator: 'hasanykey', value: ['a'] })).not.toThrow();
+    expect(c({ field: 'p', dataType: 'object', operator: 'hasallkeys', value: ['a', 'b'] })).not.toThrow();
+  });
+```
+(`c` is the existing 1-arg helper: `const c = (node) => () => assertCondition(node as JsonbCondition)`.)
+
+- [ ] **Step 8: Verify gate**
+
+Run: `pnpm -F @rfjs/jsonb-query vitest:run src/object-condition.spec.ts src/dialect/base.spec.ts && pnpm -F @rfjs/jsonb-query typecheck && pnpm -F @rfjs/jsonb-query lint`
+Expected: PASS, clean.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add packages/jsonb-query/src
+git commit -m "feat(jsonb-query): add key-existence object operators (haskey/hasanykey/hasallkeys)"
+```
+
+---
+
+## Task 2: I — case-insensitive text operators
+
+`icontains` / `istartswith` / `iendswith` / `ieq` / `ineq`, valid for `string` only. legacy uses `lower()` on both sides (literal, no `LIKE` metachar pitfalls); jsonpath uses `like_regex … flag "i"`.
+
+**Files:**
+- Modify: `src/types.ts`
+- Modify: `src/dialect/base.ts`
+- Modify: `src/dialect/legacy.ts`
+- Modify: `src/dialect/jsonpath.ts`
+- Test: `src/dialect/legacy.spec.ts`, `src/dialect/jsonpath.spec.ts`, `src/dialect/base.spec.ts`
+
+- [ ] **Step 1: Write the failing legacy + jsonpath tests**
+
+Append to `src/dialect/legacy.spec.ts` inside `describe('legacyDialect', …)` (the `run` helper there is `run(field, dataType, operator, value)`):
+```ts
+  it('case-insensitive operators lower() both sides (literal, no LIKE)', () => {
+    expect(run('name', 'string', 'ieq', 'Bob')).toEqual({
+      where: '(lower(("data" #>> $1)) = lower($2))',
+      values: [['name'], 'Bob'],
+    });
+    expect(run('name', 'string', 'ineq', 'Bob').where).toBe('(lower(("data" #>> $1)) <> lower($2))');
+    expect(run('name', 'string', 'icontains', 'Bo').where).toBe(
+      '(position(lower($2) in lower(("data" #>> $1))) > 0)',
+    );
+    expect(run('name', 'string', 'istartswith', 'Bo').where).toBe(
+      '(left(lower(("data" #>> $1)), char_length($2)) = lower($2))',
+    );
+    expect(run('name', 'string', 'iendswith', 'ob').where).toBe(
+      '(right(lower(("data" #>> $1)), char_length($2)) = lower($2))',
+    );
+  });
+```
+
+Append to `src/dialect/jsonpath.spec.ts` inside `describe('jsonpathDialect', …)` (its `run` helper returns `{ where, values }` from `jsonpathDialect.render`):
+```ts
+  it('case-insensitive operators use like_regex with flag "i"', () => {
+    expect(run('name', 'string', 'icontains', 'Bo').values[0]).toBe('$."name" ? (@ like_regex "Bo" flag "i")');
+    expect(run('name', 'string', 'istartswith', 'Bo').values[0]).toBe('$."name" ? (@ like_regex "^Bo" flag "i")');
+    expect(run('name', 'string', 'iendswith', 'ob').values[0]).toBe('$."name" ? (@ like_regex "ob$" flag "i")');
+    expect(run('name', 'string', 'ieq', 'Bob').values[0]).toBe('$."name" ? (@ like_regex "^Bob$" flag "i")');
+    expect(run('name', 'string', 'ineq', 'Bob').values[0]).toBe('$."name" ? (!(@ like_regex "^Bob$" flag "i"))');
+  });
+
+  it('icontains regex-escapes the literal', () => {
+    expect(run('name', 'string', 'icontains', 'a.b').values[0]).toBe('$."name" ? (@ like_regex "a\\\\.b" flag "i")');
+  });
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `pnpm -F @rfjs/jsonb-query vitest:run src/dialect/legacy.spec.ts src/dialect/jsonpath.spec.ts`
+Expected: FAIL — the operators hit the `default` `Unsupported operator` throw in `renderScalarOp` / `scalarPredicate`, and the types reject them.
+
+- [ ] **Step 3: Widen the scalar operator union in `src/types.ts`**
+
+Replace the `JsonbScalarOperator` union's closing lines:
+```ts
+  | 'range'
+  | 'terms';
+```
+with:
+```ts
+  | 'range'
+  | 'terms'
+  | 'icontains'
+  | 'istartswith'
+  | 'iendswith'
+  | 'ieq'
+  | 'ineq';
+```
+
+- [ ] **Step 4: Allow the operators for `string` in `src/dialect/base.ts`**
+
+Replace the `string` line of `OPERATORS_BY_TYPE`:
+```ts
+  string: new Set(['eq', 'neq', 'isnull', 'isnotnull', 'contains', 'startswith', 'endswith', 'terms']),
+```
+with:
+```ts
+  string: new Set(['eq', 'neq', 'isnull', 'isnotnull', 'contains', 'startswith', 'endswith', 'terms', 'icontains', 'istartswith', 'iendswith', 'ieq', 'ineq']),
+```
+
+- [ ] **Step 5: Render in `src/dialect/legacy.ts` `renderScalarOp`**
+
+Add these cases before the `default` in the `switch (operator)`:
+```ts
+    case 'ieq':
+      return `(lower(${F}) = lower(${params.add(assertScalarValue(operator, value))}))`;
+    case 'ineq':
+      return `(lower(${F}) <> lower(${params.add(assertScalarValue(operator, value))}))`;
+    case 'icontains':
+      return `(position(lower(${params.add(assertScalarValue(operator, value))}) in lower(${F})) > 0)`;
+    case 'istartswith': {
+      const v = params.add(assertScalarValue(operator, value));
+      return `(left(lower(${F}), char_length(${v})) = lower(${v}))`;
+    }
+    case 'iendswith': {
+      const v = params.add(assertScalarValue(operator, value));
+      return `(right(lower(${F}), char_length(${v})) = lower(${v}))`;
+    }
+```
+(`F` is the uncast `#>>` text expression; case-insensitive operators are string-only so no cast applies.)
+
+- [ ] **Step 6: Render in `src/dialect/jsonpath.ts` `scalarPredicate`**
+
+Add these cases before the `default` in the `switch (operator)` (the file already imports `escapeJsonpathString, escapeRegexLiteral`):
+```ts
+    case 'icontains': {
+      const lit = escapeJsonpathString(escapeRegexLiteral(String(assertScalarValue(operator, value))));
+      return { pred: `${acc} like_regex "${lit}" flag "i"`, compound: false };
+    }
+    case 'istartswith': {
+      const lit = escapeJsonpathString('^' + escapeRegexLiteral(String(assertScalarValue(operator, value))));
+      return { pred: `${acc} like_regex "${lit}" flag "i"`, compound: false };
+    }
+    case 'iendswith': {
+      const lit = escapeJsonpathString(escapeRegexLiteral(String(assertScalarValue(operator, value))) + '$');
+      return { pred: `${acc} like_regex "${lit}" flag "i"`, compound: false };
+    }
+    case 'ieq': {
+      const lit = escapeJsonpathString('^' + escapeRegexLiteral(String(assertScalarValue(operator, value))) + '$');
+      return { pred: `${acc} like_regex "${lit}" flag "i"`, compound: false };
+    }
+    case 'ineq': {
+      const lit = escapeJsonpathString('^' + escapeRegexLiteral(String(assertScalarValue(operator, value))) + '$');
+      return { pred: `!(${acc} like_regex "${lit}" flag "i")`, compound: true };
+    }
+```
+
+- [ ] **Step 7: Run render tests to verify they pass**
+
+Run: `pnpm -F @rfjs/jsonb-query vitest:run src/dialect/legacy.spec.ts src/dialect/jsonpath.spec.ts`
+Expected: PASS.
+
+- [ ] **Step 8: Add membership test in `src/dialect/base.spec.ts`**
+
+In `describe('assertCondition', …)`:
+```ts
+  it('accepts case-insensitive operators only for string', () => {
+    expect(c({ field: 'x', dataType: 'string', operator: 'icontains', value: 'a' })).not.toThrow();
+    expect(c({ field: 'x', dataType: 'string', operator: 'ieq', value: 'a' })).not.toThrow();
+    expect(c({ field: 'x', dataType: 'numeric', operator: 'icontains', value: 1 })).toThrow(
+      /unsupported operator "icontains" for type "numeric"/i,
+    );
+  });
+```
+
+- [ ] **Step 9: Verify gate**
+
+Run: `pnpm -F @rfjs/jsonb-query vitest:run src/dialect/legacy.spec.ts src/dialect/jsonpath.spec.ts src/dialect/base.spec.ts && pnpm -F @rfjs/jsonb-query typecheck && pnpm -F @rfjs/jsonb-query lint`
+Expected: PASS, clean.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add packages/jsonb-query/src
+git commit -m "feat(jsonb-query): add case-insensitive text operators (icontains/istartswith/iendswith/ieq/ineq)"
+```
+
+---
+
+## Task 3: S — array emptiness operators (`isempty` / `isnotempty`)
+
+Value-less operators on scalar-element arrays, rendered dialect-independently via a shared helper (like `containsall`). Inside `elemmatch` they force the SQL fallback (also like `containsall`).
+
+**Files:**
+- Modify: `src/types.ts`
+- Modify: `src/dialect/base.ts`
+- Modify: `src/dialect/legacy.ts`
+- Modify: `src/dialect/jsonpath.ts`
+- Test: `src/dialect/legacy.spec.ts`, `src/build.spec.ts`, `src/dialect/base.spec.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `src/dialect/legacy.spec.ts` inside `describe('legacyDialect.renderArray', …)` (its `runArray` helper takes `Omit<JsonbArrayCondition, 'dataType'>`):
+```ts
+  it('isempty / isnotempty test the array length (dialect-independent)', () => {
+    expect(runArray({ field: 'tags', elementType: 'string', operator: 'isempty' })).toMatchObject({
+      where: "(jsonb_typeof(\"data\" #> $1) = 'array' and jsonb_array_length(\"data\" #> $1) = 0)",
+      values: [['tags']],
+    });
+    expect(runArray({ field: 'tags', elementType: 'string', operator: 'isnotempty' }).where).toBe(
+      "(jsonb_typeof(\"data\" #> $1) = 'array' and jsonb_array_length(\"data\" #> $1) > 0)",
+    );
+  });
+```
+
+Append to `src/build.spec.ts` (top-level, e.g. after the array-neq describe — uses `buildJsonbQuery`):
+```ts
+describe('buildJsonbQuery — array emptiness', () => {
+  const one = (f: JsonbFilterGroup['filters'][number]): JsonbFilterGroup => ({ logic: 'and', filters: [f] });
+
+  it('isempty renders identical SQL in both dialects', () => {
+    const filter = one({ field: 'tags', dataType: 'array', elementType: 'string', operator: 'isempty' });
+    const expected = "(jsonb_typeof(\"data\" #> $1) = 'array' and jsonb_array_length(\"data\" #> $1) = 0)";
+    expect(buildJsonbQuery('data', filter).where).toBe(expected);
+    expect(buildJsonbQuery('data', filter, { dialect: 'jsonpath' }).where).toBe(expected);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `pnpm -F @rfjs/jsonb-query vitest:run src/dialect/legacy.spec.ts src/build.spec.ts`
+Expected: FAIL — `isempty`/`isnotempty` are rejected by `assertCondition` (not in `ARRAY_OPERATORS_BY_ELEMENT`) and not rendered.
+
+- [ ] **Step 3: Widen the array operator union in `src/types.ts`**
+
+Replace:
+```ts
+export type JsonbArrayOperator = JsonbScalarOperator | 'containsall';
+```
+with:
+```ts
+export type JsonbArrayOperator = JsonbScalarOperator | 'containsall' | 'isempty' | 'isnotempty';
+```
+
+- [ ] **Step 4: Allow + render-helper in `src/dialect/base.ts`**
+
+Add `isempty`/`isnotempty` to every element set in `ARRAY_OPERATORS_BY_ELEMENT`:
+```ts
+const ARRAY_OPERATORS_BY_ELEMENT: Record<JsonbScalarType, ReadonlySet<string>> = {
+  string: new Set(['eq', 'neq', 'contains', 'startswith', 'endswith', 'terms', 'containsall', 'isnull', 'isnotnull', 'isempty', 'isnotempty']),
+  numeric: new Set(['eq', 'neq', 'gt', 'gte', 'lt', 'lte', 'range', 'terms', 'containsall', 'isnull', 'isnotnull', 'isempty', 'isnotempty']),
+  date: new Set(['eq', 'neq', 'gt', 'gte', 'lt', 'lte', 'range', 'terms', 'isnull', 'isnotnull', 'isempty', 'isnotempty']),
+  boolean: new Set(['eq', 'neq', 'isnull', 'isnotnull', 'isempty', 'isnotempty']),
+};
+```
+
+Add the shared render helper (next to `renderNullCheck`):
+```ts
+/** Array emptiness via jsonb_array_length, dialect-independent. Missing / non-array → both false. */
+export function renderArrayEmptiness(
+  column: string,
+  field: string,
+  operator: 'isempty' | 'isnotempty',
+  params: ParamBuilder,
+): string {
+  const arr = `${column} #> ${params.add(fieldSegments(field))}`;
+  const cmp = operator === 'isempty' ? '= 0' : '> 0';
+  return `(jsonb_typeof(${arr}) = 'array' and jsonb_array_length(${arr}) ${cmp})`;
+}
+```
+
+Extend `conditionNeedsSqlFallback` so an emptiness leaf inside `elemmatch` forces the SQL fallback (like `containsall`):
+```ts
+  if (node.dataType === 'array') {
+    if (node.elementType === 'object') {
+      return groupNeedsSqlFallback(node.filters);
+    }
+    return node.operator === 'containsall' || node.operator === 'isempty' || node.operator === 'isnotempty';
+  }
+```
+
+- [ ] **Step 5: Short-circuit in both dialects' `renderArray`**
+
+In `src/dialect/legacy.ts`, import the helper (add to the `'./base'` import): `renderArrayEmptiness`. Then in `renderArray`, add after the `isnull`/`isnotnull` block:
+```ts
+    if (operator === 'isempty' || operator === 'isnotempty') {
+      return renderArrayEmptiness(column, field, operator, params);
+    }
+```
+
+In `src/dialect/jsonpath.ts`, import `renderArrayEmptiness` from `'./base'`, and add the same short-circuit in `renderArray` after the `isnull`/`isnotnull` block:
+```ts
+    if (operator === 'isempty' || operator === 'isnotempty') {
+      return renderArrayEmptiness(column, field, operator, params);
+    }
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `pnpm -F @rfjs/jsonb-query vitest:run src/dialect/legacy.spec.ts src/build.spec.ts`
+Expected: PASS.
+
+- [ ] **Step 7: Add membership + elemmatch-fallback tests in `src/dialect/base.spec.ts`**
+
+In `describe('assertCondition', …)`:
+```ts
+  it('accepts isempty / isnotempty for every array element type', () => {
+    for (const elementType of ['string', 'numeric', 'date', 'boolean'] as const) {
+      expect(c({ field: 'a', dataType: 'array', elementType, operator: 'isempty' })).not.toThrow();
+      expect(c({ field: 'a', dataType: 'array', elementType, operator: 'isnotempty' })).not.toThrow();
+    }
+  });
+```
+
+In `describe('groupNeedsSqlFallback', …)`, extend the "true" case:
+```ts
+  it('isempty / isnotempty force the SQL fallback', () => {
+    expect(groupNeedsSqlFallback(g([{ field: 't', dataType: 'array', elementType: 'string', operator: 'isempty' }]))).toBe(true);
+    expect(groupNeedsSqlFallback(g([{ field: 't', dataType: 'array', elementType: 'string', operator: 'isnotempty' }]))).toBe(true);
+  });
+```
+(`g` is the existing helper `(filters) => ({ logic: 'and', filters })`.)
+
+- [ ] **Step 8: Verify gate**
+
+Run: `pnpm -F @rfjs/jsonb-query test && pnpm -F @rfjs/jsonb-query typecheck && pnpm -F @rfjs/jsonb-query lint`
+Expected: PASS (full suite), clean.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add packages/jsonb-query/src
+git commit -m "feat(jsonb-query): add array emptiness operators (isempty/isnotempty)"
+```
+
+---
+
+## Task 4: README + changeset
+
+**Files:**
+- Modify: `packages/jsonb-query/README.md`
+- Create: `.changeset/jsonb-query-operator-expansion.md`
+
+- [ ] **Step 1: Update the operator table in `README.md`**
+
+In the "## Supported types & operators" table:
+- `string` row — append the case-insensitive operators:
+```
+| `string`                          | `eq` `neq` `isnull` `isnotnull` `contains` `startswith` `endswith` `terms` `icontains` `istartswith` `iendswith` `ieq` `ineq` |
+```
+- `object` row — append the key-existence operators:
+```
+| `object`                          | `eq` `neq` `contains` `isnull` `isnotnull` `haskey` `hasanykey` `hasallkeys`               |
+```
+- `array` + scalar `elementType` row — append emptiness:
+```
+| `array` + scalar `elementType`    | element ops (`neq` = value not present) + `containsall` + `isempty` `isnotempty` + `isnull` `isnotnull` |
+```
+
+- [ ] **Step 2: Add operator explanations to `README.md`**
+
+After the "### Nested objects" section, add:
+```
+### Key existence (object)
+
+`haskey` / `hasanykey` / `hasallkeys` test for the presence of object **keys**
+(jsonb `?` / `?|` / `?&`), regardless of the value at that key — distinct from
+`isnotnull`, which tests the value (a key present with a JSON `null` value is
+`haskey: true` but `isnotnull: false`). All three are GIN-indexable.
+
+```typescript
+{ field: 'profile', dataType: 'object', operator: 'haskey', value: 'vip' }
+//  (("data" #> $1) ? $2)              values: [['profile'], 'vip']
+{ field: 'profile', dataType: 'object', operator: 'hasanykey', value: ['vip','premium'] }
+//  (("data" #> $1) ?| $2::text[])
+{ field: 'profile', dataType: 'object', operator: 'hasallkeys', value: ['vip','level'] }
+//  (("data" #> $1) ?& $2::text[])
+```
+
+### Case-insensitive text
+
+`icontains` / `istartswith` / `iendswith` / `ieq` / `ineq` match strings
+case-insensitively. The legacy dialect lowercases both sides (`lower()`); the
+jsonpath dialect uses `like_regex … flag "i"`.
+
+> Case folding differs slightly between dialects on non-ASCII text: `lower()`
+> follows the database `LC_CTYPE`, while jsonpath `flag "i"` uses its own Unicode
+> rules. ASCII text matches identically.
+
+### Array emptiness
+
+`isempty` / `isnotempty` test whether a scalar-element array field has zero /
+at least one element (`jsonb_array_length`). A missing field or non-array value
+is **neither** (both operators return false). They render identical SQL in both
+dialects.
+```
+
+- [ ] **Step 3: Add the indexing section to `README.md`**
+
+Before "## Safety", add:
+```
+## Indexing
+
+| Operators | Index that helps |
+| --- | --- |
+| object `contains`/`containsall` (`@>`), `haskey`/`hasanykey`/`hasallkeys` (`?`/`?|`/`?&`) | default `GIN (col jsonb_ops)` |
+| `jsonpath` dialect predicates (`@?` / `@@`) | `GIN (col jsonb_path_ops)` |
+| `legacy` scalar comparisons on a hot path | b-tree **expression** index, e.g. `CREATE INDEX ON t ((data #>> '{status}'))` |
+
+`contains` / `icontains` / `startswith` / `istartswith` / `endswith` /
+`iendswith` are **not** index-served (they scan); for heavy substring search use
+a `pg_trgm` GIN index. The jsonpath `elemmatch` SQL-fallback fragment (object or
+`containsall` leaf) is not served by a `jsonb_path_ops` GIN index.
+```
+
+- [ ] **Step 4: Create the changeset**
+
+Create `.changeset/jsonb-query-operator-expansion.md`:
+```md
+---
+'@rfjs/jsonb-query': minor
+---
+
+Add three operator families.
+
+**Added**
+- Key-existence object operators `haskey` / `hasanykey` / `hasallkeys` (jsonb
+  `?` / `?|` / `?&`), distinct from `isnull`/`isnotnull` (which test the value).
+- Case-insensitive text operators `icontains` / `istartswith` / `iendswith` /
+  `ieq` / `ineq` for `string` conditions.
+- Array emptiness operators `isempty` / `isnotempty` for scalar-element arrays.
+- README "Indexing" section mapping operators to GIN / expression indexes.
+```
+
+- [ ] **Step 5: Verify build + full suite**
+
+Run: `pnpm -F @rfjs/jsonb-query test && pnpm -F @rfjs/jsonb-query build`
+Expected: PASS, build succeeds.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/jsonb-query/README.md .changeset/jsonb-query-operator-expansion.md
+git commit -m "docs(jsonb-query): document key-existence, case-insensitive, emptiness operators + indexing"
+```
+
+---
+
+## Task 5: E2E result-asserting cases
+
+Add cases to the self-skipping E2E suite (skips entirely without `PG_E2E_URLS`). Assert query *results*, never SQL text.
+
+**Files:**
+- Modify: `packages/jsonb-query/test/jsonb-query.e2e.spec.ts`
+
+- [ ] **Step 1: Extend the seed and add cases**
+
+The existing `SEED` (id 1 `bob`, id 2 `alice`, id 3 `carol` with JSON-null age, id 4 `dave` malformed, …). To exercise `haskey` vs `isnotnull`, ensure a row has a key whose value is JSON null. Change id 3's seed object to include an explicit null-valued key under a `profile`:
+```ts
+  // JSON null age; profile present with a null-valued key (for haskey vs isnotnull).
+  [3, { name: 'carol', age: null, profile: { vip: null } }],
+```
+
+Add a new describe block (top level inside the per-URL describe, alongside the others):
+```ts
+      describe('operator expansion', () => {
+        const one = (f: JsonbFilterGroup['filters'][number]): JsonbFilterGroup => ({ logic: 'and', filters: [f] });
+
+        it('haskey detects a null-valued key that isnotnull misses', async () => {
+          // id 3 has profile.vip = null: the KEY exists (haskey) but the VALUE is null (isnotnull false).
+          await expectIds(one({ field: 'profile', dataType: 'object', operator: 'haskey', value: 'vip' }), [1, 2, 3]);
+          await expectIds(one({ field: 'profile.vip', dataType: 'boolean', operator: 'isnotnull' }), [1, 2]);
+        });
+
+        it('hasanykey / hasallkeys', async () => {
+          await expectIds(one({ field: 'profile', dataType: 'object', operator: 'hasallkeys', value: ['vip', 'level'] }), [1]);
+          await expectIds(one({ field: 'profile', dataType: 'object', operator: 'hasanykey', value: ['level', 'nope'] }), [1]);
+        });
+
+        it('case-insensitive contains matches regardless of case', async () => {
+          await expectIds(one({ field: 'name', dataType: 'string', operator: 'icontains', value: 'BO' }), [1]);
+          await expectIds(one({ field: 'name', dataType: 'string', operator: 'ieq', value: 'ALICE' }), [2]);
+        });
+
+        it('isempty / isnotempty on the tags array', async () => {
+          // id 1 tags:[a,b], id 2 tags:[b,c] → isnotempty [1,2]; none seeded with [] → isempty [].
+          await expectIds(one({ field: 'tags', dataType: 'array', elementType: 'string', operator: 'isnotempty' }), [1, 2]);
+          await expectIds(one({ field: 'tags', dataType: 'array', elementType: 'string', operator: 'isempty' }), []);
+        });
+      });
+```
+> Verify the actual seed values for `profile`/`name`/`tags` when implementing and adjust the expected id arrays to match the real seed; the assertion is on *results*, so it must reflect the committed seed.
+
+- [ ] **Step 2: Verify it self-skips without a DB**
+
+Run: `pnpm -F @rfjs/jsonb-query vitest:e2e:run`
+Expected: PASS, all suites skipped (no `PG_E2E_URLS`).
+
+- [ ] **Step 3 (optional, if Docker available): run against real PG**
+
+Run:
+```bash
+cd packages/jsonb-query && bash scripts/e2e.sh
+```
+Expected: PASS on PG 11.16 (legacy) and PG 16 (legacy + jsonpath). If Docker is unavailable, skip and note it.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/jsonb-query/test/jsonb-query.e2e.spec.ts
+git commit -m "test(jsonb-query): e2e for key-existence, case-insensitive, emptiness operators"
+```
+
+---
+
+## Final verification
+
+- [ ] From repo root: `pnpm -F @rfjs/jsonb-query lint && pnpm -F @rfjs/jsonb-query typecheck && pnpm -F @rfjs/jsonb-query test && pnpm -F @rfjs/jsonb-query build` — all PASS.
+- [ ] Confirm the public surface: `JsonbObjectOperator` includes `haskey`/`hasanykey`/`hasallkeys`; `JsonbScalarOperator` includes the five `i*`; `JsonbArrayOperator` includes `isempty`/`isnotempty`.
+- [ ] Open a PR `feat/jsonb-query-operators → main` once the user approves.
+
+---
+
+## Self-Review (filled in during planning)
+
+**Spec coverage:** K → Task 1 (types, OBJECT_OPERATORS, guards, render). I → Task 2 (union, OPERATORS_BY_TYPE.string, legacy + jsonpath render). S → Task 3 (union, ARRAY_OPERATORS_BY_ELEMENT, shared `renderArrayEmptiness`, both dialects, `conditionNeedsSqlFallback`). D → Task 4 (README Indexing). Docs/changeset → Task 4; E2E → Task 5. No new error codes (spec confirmed) — guards reuse `INVALID_SCALAR_VALUE`/`INVALID_ARRAY_VALUE`.
+
+**Placeholder scan:** none — every code/test step shows complete code; the E2E step flags that expected id arrays must match the real committed seed (an instruction, not a placeholder).
+
+**Type consistency:** `assertKeyValue`/`assertKeyArray`/`renderArrayEmptiness` names match across base.ts, object-condition.ts, both dialects, and tests; operator spellings (`hasanykey`, `hasallkeys`, `istartswith`, `iendswith`, `isnotempty`) are identical in types, operator sets, render switches, and tests; `JsonbArrayOperator = JsonbScalarOperator | 'containsall' | 'isempty' | 'isnotempty'` matches the operator-set additions and the `conditionNeedsSqlFallback` extension.

--- a/docs/superpowers/specs/2026-06-13-jsonb-query-operator-expansion-design.md
+++ b/docs/superpowers/specs/2026-06-13-jsonb-query-operator-expansion-design.md
@@ -1,0 +1,244 @@
+# @rfjs/jsonb-query — Operator expansion (key-existence, case-insensitive text, array emptiness, GIN docs)
+
+**Date:** 2026-06-13
+**Branch:** `feat/jsonb-query-operators`
+**Status:** approved (brainstorming)
+**Builds on:** Phase 2 (`JsonbQueryError`, elemmatch nesting, array `neq`, empty-group identity — merged to main via #142)
+
+## Context
+
+`@rfjs/jsonb-query` renders filter metadata to a parameterized PostgreSQL `WHERE`
+expression across two dialects (`legacy` `#>>`, `jsonpath` `jsonb_path_exists`).
+This round adds three operator families plus indexing docs. Parity with
+`@rfjs/data-filter`'s operator set is **explicitly not a goal** — the two
+packages serve different surfaces (in-memory filtering vs SQL generation).
+
+All additions follow the established pattern: extend the operator union + the
+runtime operator set, render in both dialects, co-locate tests, update README.
+**No new error codes** are introduced (existing value guards / codes are reused).
+
+## Scope
+
+- **K — key-existence:** `haskey` / `hasanykey` / `hasallkeys` on `object`
+  conditions, rendered dialect-independently with jsonb `?` / `?|` / `?&`.
+- **I — case-insensitive text:** `icontains` / `istartswith` / `iendswith` /
+  `ieq` / `ineq` on `string` conditions.
+- **S — array emptiness:** `isempty` / `isnotempty` on scalar-element `array`
+  conditions, rendered dialect-independently.
+- **D — GIN index guide:** a README section mapping operators to index types.
+
+Out of scope: `isempty`/`isnotempty` on arrays of objects (needs a type change —
+deferred); projection/SELECT builder; ORDER BY (separate spec).
+
+---
+
+## K — Key-existence operators
+
+### Semantics
+
+`haskey` tests whether a jsonb **object** contains a key (or a jsonb **array**
+contains a string element), regardless of the value at that key. This differs
+from `isnotnull`, which tests the *value*: a key present with a JSON `null`
+value (`{"vip": null}`) is `haskey: true` but `isnotnull: false`.
+
+### Type changes (`src/types.ts`)
+
+```ts
+export type JsonbObjectOperator =
+  | 'eq' | 'neq' | 'contains' | 'isnull' | 'isnotnull'
+  | 'haskey' | 'hasanykey' | 'hasallkeys';
+```
+
+`JsonbObjectCondition.value` widens to carry key arguments:
+
+```ts
+export interface JsonbObjectCondition {
+  field: string;
+  dataType: 'object';
+  operator: JsonbObjectOperator;
+  value?: JsonbObjectValue | string | string[];
+  elementType?: never;
+  filters?: never;
+}
+```
+
+> **Type-design tradeoff:** a discriminated variant per operator would be more
+> precise, but the package already uses loose value typing on conditions
+> (`JsonbScalarCondition.value?: JsonbValue | JsonbValue[]`) with runtime guards.
+> We follow that convention: widen the union, enforce per-operator at runtime.
+
+### Validation (`src/dialect/base.ts`)
+
+- Add the three operators to `OBJECT_OPERATORS`.
+- `haskey` requires a single **string** → new guard `assertKeyValue` (reuses
+  `INVALID_SCALAR_VALUE` with message `Operator "haskey" requires a single
+  string key`).
+- `hasanykey` / `hasallkeys` require a **non-empty string[]** → reuse
+  `assertArrayValue` (non-empty) plus a string-element check (reuses
+  `INVALID_ARRAY_VALUE`, message `Operator "<op>" requires a non-empty array of
+  string keys`).
+
+### Rendering (`src/object-condition.ts`, both dialects)
+
+Object conditions already render identically in both dialects via
+`renderObjectCondition`. Key-existence joins them:
+
+```ts
+{ field: 'profile', dataType: 'object', operator: 'haskey', value: 'vip' }
+// (("data" #> $1) ? $2)                values: [['profile'], 'vip']
+
+{ field: 'profile', dataType: 'object', operator: 'hasanykey', value: ['vip','premium'] }
+// (("data" #> $1) ?| $2::text[])       values: [['profile'], ['vip','premium']]
+
+{ field: 'profile', dataType: 'object', operator: 'hasallkeys', value: ['vip','level'] }
+// (("data" #> $1) ?& $2::text[])       values: [['profile'], ['vip','level']]
+```
+
+Keys are parameterized (never interpolated). `?` / `?|` / `?&` are served by the
+default `jsonb_ops` GIN index.
+
+> **node-postgres note:** `?` is the placeholder character in some drivers, but
+> node-postgres uses `$N` exclusively, so a literal `?` in SQL is safe. The
+> README will warn that query layers using `?` placeholders (e.g. some Knex
+> configs) must use the named variant or escape — same caveat that already
+> applies to any literal `?`.
+
+---
+
+## I — Case-insensitive text operators
+
+### Type changes (`src/types.ts`)
+
+```ts
+export type JsonbScalarOperator =
+  | 'eq' | 'neq' | 'isnull' | 'isnotnull'
+  | 'contains' | 'startswith' | 'endswith'
+  | 'gt' | 'gte' | 'lt' | 'lte' | 'range' | 'terms'
+  | 'icontains' | 'istartswith' | 'iendswith' | 'ieq' | 'ineq';
+```
+
+Only valid for `string` — added to `OPERATORS_BY_TYPE.string` only (the type
+union is shared across scalar types, gated at runtime, exactly as `contains`
+already is).
+
+### Rendering — legacy (`src/dialect/legacy.ts` `renderScalarOp`)
+
+Both sides lowered with `lower()`; literal matching (no `LIKE`, so value
+metacharacters like `%`/`_` are never interpreted):
+
+```ts
+case 'ieq':        return `(lower(${F}) = lower(${v}))`;
+case 'ineq':       return `(lower(${F}) <> lower(${v}))`;
+case 'icontains':  return `(position(lower(${v}) in lower(${F})) > 0)`;
+case 'istartswith':return `(left(lower(${F}), char_length(${v})) = lower(${v}))`;
+case 'iendswith':  return `(right(lower(${F}), char_length(${v})) = lower(${v}))`;
+```
+
+(`v = params.add(assertScalarValue(operator, value))`, added once per op.)
+
+### Rendering — jsonpath (`src/dialect/jsonpath.ts` `scalarPredicate`)
+
+`like_regex` with `flag "i"` (PG 12+, which jsonpath already requires). The value
+is regex-escaped (`escapeRegexLiteral`) then jsonpath-string-escaped
+(`escapeJsonpathString`), exactly as `contains`/`endswith` do today:
+
+```ts
+case 'icontains':   return { pred: `${acc} like_regex "${lit}" flag "i"`, compound: false };
+case 'istartswith': return { pred: `${acc} like_regex "^${lit}" flag "i"`, compound: false };
+case 'iendswith':   return { pred: `${acc} like_regex "${lit}$" flag "i"`, compound: false };
+case 'ieq':         return { pred: `${acc} like_regex "^${lit}$" flag "i"`, compound: false };
+case 'ineq':        return { pred: `!(${acc} like_regex "^${lit}$" flag "i")`, compound: true };
+```
+
+These are string predicates: they operate on the text accessor (`acc`), never
+`.datetime()`.
+
+> **Divergence note (documented):** `lower()` (legacy) is locale/`LC_CTYPE`
+> dependent; jsonpath `flag "i"` uses its own Unicode case-folding. For ASCII
+> text they agree; for some non-ASCII characters they may differ. README will
+> note this alongside the existing dialect-divergence caveats.
+
+---
+
+## S — Array emptiness operators
+
+### Type changes (`src/types.ts`)
+
+```ts
+export type JsonbArrayOperator = JsonbScalarOperator | 'containsall' | 'isempty' | 'isnotempty';
+```
+
+Added to all four element sets in `ARRAY_OPERATORS_BY_ELEMENT`. They take **no
+value** (like `isnull`/`isnotnull`).
+
+### Rendering (dialect-independent, like `containsall`)
+
+A shared helper (`renderArrayEmptiness` in `src/dialect/base.ts`), called from
+both dialects' `renderArray` before the element-predicate path (next to the
+existing `isnull`/`isnotnull` and `containsall` short-circuits):
+
+```ts
+// isempty
+(jsonb_typeof("data" #> $1) = 'array' and jsonb_array_length("data" #> $1) = 0)
+// isnotempty
+(jsonb_typeof("data" #> $1) = 'array' and jsonb_array_length("data" #> $1) > 0)
+```
+
+A missing field or non-array value has `jsonb_typeof <> 'array'` → both operators
+are **false** (it is neither an empty array nor a non-empty array). The field
+path is parameterized once and reused.
+
+---
+
+## D — GIN index guide (README)
+
+A new "## Indexing" section, concise and practical:
+
+| Operator(s) | Index that helps |
+|---|---|
+| `object` `contains` / `containsall` (`@>`), `haskey`/`hasanykey`/`hasallkeys` (`?`/`?|`/`?&`) | default `GIN (col jsonb_ops)` |
+| `jsonpath` dialect predicates (`@?` / `@@`) | `GIN (col jsonb_path_ops)` |
+| `legacy` scalar comparisons (`(col #>> '{path}')::type`) | b-tree **expression** index per path |
+| `eq`/`terms` on a hot scalar path | expression index, e.g. `CREATE INDEX ON t ((data #>> '{status}'))` |
+
+Note that `icontains`/`istartswith`/`iendswith` (and `contains` family) are
+**not** index-served (they scan); recommend `pg_trgm` GIN for heavy substring
+search. Note the hybrid-fallback elemmatch fragment loses `jsonb_path_ops` GIN
+(already documented in Phase 2).
+
+---
+
+## Testing
+
+- **Unit (co-located `*.spec.ts`):**
+  - `object-condition.spec.ts` — `haskey`/`hasanykey`/`hasallkeys` SQL + params;
+    value guards (haskey non-string → `INVALID_SCALAR_VALUE`; hasany/hasall
+    empty or non-string-element → `INVALID_ARRAY_VALUE`).
+  - `legacy.spec.ts` — the five `i*` operators render with `lower()`; `isempty`/
+    `isnotempty` render the typeof+length guard.
+  - `jsonpath.spec.ts` — the five `i*` operators render `like_regex … flag "i"`
+    (escaped); `ineq` negates; `isempty`/`isnotempty` render the same SQL as
+    legacy (dialect-independent).
+  - `base.spec.ts` — operator-set membership: `i*` valid only for `string`;
+    `isempty`/`isnotempty` valid for every element type; `haskey` family valid
+    for `object`; invalid combinations still throw the right codes.
+  - `build.spec.ts` — end-to-end through `buildJsonbQuery` for one operator of
+    each family in both dialects, with contiguous params + `paramOffset`.
+- **E2E (`test/jsonb-query.e2e.spec.ts`, self-skips):** add result-asserting
+  cases — `haskey` distinguishes a JSON-null-valued key from a missing key;
+  `icontains` matches case-insensitively; `isempty` vs `isnotempty` on present /
+  empty / missing / malformed-shape rows. Assert query *results*, not SQL text.
+
+## Docs & release
+
+- README: operator table rows for the new operators; the new "## Indexing"
+  section; case-insensitivity locale caveat; key-existence vs `isnotnull` note.
+- Changeset: **minor** (additive operators). Body lists K / I / S under "Added".
+
+## Build sequence (for the implementation plan)
+
+1. K — object key-existence (types, `OBJECT_OPERATORS`, guards, render).
+2. I — case-insensitive (types, `OPERATORS_BY_TYPE.string`, legacy + jsonpath render).
+3. S — array emptiness (types, operator sets, shared `renderArrayEmptiness`, both dialects).
+4. README (operator table, Indexing section, caveats) + changeset.
+5. E2E cases.

--- a/docs/superpowers/specs/2026-06-13-jsonb-query-order-by-design.md
+++ b/docs/superpowers/specs/2026-06-13-jsonb-query-order-by-design.md
@@ -1,0 +1,214 @@
+# @rfjs/jsonb-query — ORDER BY builder
+
+**Date:** 2026-06-13
+**Branch:** `feat/jsonb-query-order-by` (separate from `feat/jsonb-query-operators`; its own PR, started after the operator-expansion work merges so it can reuse the shared CAST/named-rewrite refactors)
+**Status:** approved (brainstorming)
+**Builds on:** Phase 2 + Operator expansion (shares `quoteJsonbColumn`, `ParamBuilder`, the scalar CAST map, and `toNamedParams`)
+
+## Context
+
+`@rfjs/jsonb-query` currently produces only `WHERE` fragments. Real consumers
+(admin tables, list endpoints) send **sort** metadata alongside filters and need
+a matching `ORDER BY` fragment that reuses the same path-extraction and casting
+logic. This spec adds a small, isolated ORDER BY builder.
+
+`ORDER BY` is inherently **dialect-independent**: you always order by an
+extracted scalar (`(col #>> '{path}')::type`); the `jsonpath` dialect has no
+ordering construct. So there is no `dialect` option.
+
+## Scope
+
+- `buildJsonbOrderBy(column, sorts, options?)` — positional `$N` output.
+- `buildNamedJsonbOrderBy(column, sorts, options?)` — `:pN` output for named-
+  binding query layers (TypeORM QueryBuilder, Knex).
+- Per-column `direction` (default `asc`) and optional `nulls` (`first`/`last`).
+- A small shared refactor: extract the scalar CAST map so legacy and order-by
+  share one source of truth.
+
+Out of scope: computed/expression sort keys, sorting by array/object values,
+sort over `jsonb_path_query` results.
+
+---
+
+## New module `src/order-by.ts`
+
+### Types
+
+```ts
+export type JsonbSortDirection = 'asc' | 'desc';
+export type JsonbNullsOrder = 'first' | 'last';
+
+export interface JsonbSortSpec {
+  field: string;
+  /** Only scalar types are orderable. */
+  dataType: JsonbScalarType;
+  /** Default 'asc'. */
+  direction?: JsonbSortDirection;
+  /** Omit to use PostgreSQL's default (NULLS LAST for asc, NULLS FIRST for desc). */
+  nulls?: JsonbNullsOrder;
+}
+
+export interface JsonbOrderByResult {
+  orderBy: string;
+  values: unknown[];
+}
+
+export interface BuildJsonbOrderByOptions {
+  paramOffset?: number;
+}
+```
+
+### `buildJsonbOrderBy`
+
+```ts
+export function buildJsonbOrderBy(
+  column: string,
+  sorts: JsonbSortSpec[],
+  options: BuildJsonbOrderByOptions = {},
+): JsonbOrderByResult;
+```
+
+- Validates `column` via `quoteJsonbColumn` (reused).
+- For each spec, renders:
+  `(${quoted} #>> ${params.add(fieldSegments(field))})${SCALAR_CASTS[dataType]} ${direction}${nulls ? ` nulls ${nulls}` : ''}`
+- Joins specs with `', '`.
+- Empty `sorts` → `{ orderBy: '', values: [] }` (the consumer simply omits
+  `ORDER BY` — unlike `WHERE`, an empty `ORDER BY` string needs no sentinel).
+- `paramOffset` shifts the first `$N` so the fragment composes after `WHERE`
+  values.
+
+Worked example:
+
+```ts
+const { where, values } = buildJsonbQuery('data', filter);     // values.length = 2
+const ob = buildJsonbOrderBy('data', [
+  { field: 'age',  dataType: 'numeric', direction: 'desc', nulls: 'last' },
+  { field: 'name', dataType: 'string' },
+], { paramOffset: values.length });
+// ob.orderBy: '("data" #>> $3)::numeric desc nulls last, ("data" #>> $4) asc'
+// ob.values:  [['age'], ['name']]
+await client.query(
+  `SELECT * FROM t WHERE ${where} ORDER BY ${ob.orderBy}`,
+  [...values, ...ob.values],
+);
+```
+
+### `buildNamedJsonbOrderBy`
+
+```ts
+export interface BuildNamedJsonbOrderByOptions extends BuildJsonbOrderByOptions {
+  /** Named-parameter prefix (default "p"). */
+  prefix?: string;
+}
+export interface NamedOrderByResult {
+  orderBy: string;
+  params: Record<string, unknown>;
+}
+export function buildNamedJsonbOrderBy(
+  column: string,
+  sorts: JsonbSortSpec[],
+  options?: BuildNamedJsonbOrderByOptions,
+): NamedOrderByResult;
+```
+
+Builds the positional result, then converts via the shared positional→named
+rewrite (see refactor). `paramOffset` shifts the parameter *names* (`:p5`, …),
+matching `buildNamedJsonbQuery`.
+
+```ts
+const { orderBy, params } = buildNamedJsonbOrderBy('data', [
+  { field: 'age', dataType: 'numeric', direction: 'desc' },
+], { prefix: 'o' });
+// orderBy: '("data" #>> :o1)::numeric desc'
+// params:  { o1: ['age'] }
+qb.addOrderBy(orderBy).setParameters(params);
+```
+
+### Validation
+
+TS types constrain `direction`/`dataType`, but untyped callers can pass garbage:
+
+- Unknown `dataType` (not in the scalar CAST map) → throw `JsonbQueryError(..,
+  'INVALID_SORT')`.
+- `direction` other than `asc`/`desc` (when provided) → `INVALID_SORT`.
+- `nulls` other than `first`/`last` (when provided) → `INVALID_SORT`.
+- Invalid `column` → `INVALID_COLUMN` (via `quoteJsonbColumn`).
+
+**New error code** added to the union in `src/errors.ts`:
+
+```ts
+export type JsonbQueryErrorCode =
+  | /* …existing 10… */
+  | 'INVALID_SORT';        // sort spec has an invalid dataType / direction / nulls
+```
+
+---
+
+## Shared refactor — scalar CAST map
+
+`src/dialect/legacy.ts` currently owns:
+
+```ts
+const CASTS: Record<JsonbScalarType, string> = {
+  string: '', numeric: '::numeric', date: '::timestamptz', boolean: '::boolean',
+};
+```
+
+Extract it to `src/dialect/base.ts` as an exported `SCALAR_CASTS`, have
+`legacy.ts` import it, and `order-by.ts` import it too — one source of truth for
+the extract-and-cast convention. (`ARRAY_CASTS` stays in `legacy.ts`; it is
+legacy-only.)
+
+## Shared refactor — positional→named rewrite
+
+`src/named-params.ts` `toNamedParams` currently inlines the `$N`→`:pN` regex
+rewrite over a `JsonbQueryResult` (`{ where, values, from }`). Extract the core
+into a private helper:
+
+```ts
+function positionalToNamed(
+  sql: string,
+  values: unknown[],
+  prefix: string,
+): { sql: string; params: Record<string, unknown> };
+```
+
+`toNamedParams` keeps its exact public signature/behavior (wraps the helper,
+maps `sql`→`where`, keeps the contiguity check). `buildNamedJsonbOrderBy` uses
+the same helper (maps `sql`→`orderBy`). No public API change to `toNamedParams`.
+
+---
+
+## Testing
+
+- **Unit `src/order-by.spec.ts`:**
+  - single column asc (default direction), each `dataType` cast.
+  - `desc` + `nulls first`/`last`; omitted `nulls` emits no `NULLS` clause.
+  - multi-column comma join; contiguous `$N`; `paramOffset` shift.
+  - empty `sorts` → `{ orderBy: '', values: [] }`.
+  - invalid `dataType`/`direction`/`nulls` → `JsonbQueryError` code `INVALID_SORT`;
+    invalid column → `INVALID_COLUMN`.
+  - `buildNamedJsonbOrderBy`: `:pN` output, params object, custom prefix,
+    `paramOffset` shifts names.
+- **Regression:** existing `named-params.spec.ts` and `legacy.spec.ts` stay green
+  after the two refactors (behavior-preserving).
+- **E2E (`test/jsonb-query.e2e.spec.ts`):** one combined
+  `WHERE ${where} ORDER BY ${ob.orderBy}` query asserting row order (numeric desc
+  with nulls last over the seed); assert the *ordering*, not SQL text.
+
+## Docs & release
+
+- README: new "## Sorting" section with both usage examples, the dialect-
+  independence note, and the NULLS-default note.
+- Changeset: **minor** (new public functions). Body lists `buildJsonbOrderBy` /
+  `buildNamedJsonbOrderBy` under "Added".
+
+## Build sequence (for the implementation plan)
+
+1. Refactor: extract `SCALAR_CASTS` to `base.ts`; extract `positionalToNamed`
+   in `named-params.ts` (both behavior-preserving; existing tests stay green).
+2. `INVALID_SORT` error code.
+3. `order-by.ts` types + `buildJsonbOrderBy` + validation.
+4. `buildNamedJsonbOrderBy` via the shared rewrite.
+5. Barrel exports + README "## Sorting" + changeset.
+6. E2E ordering case.

--- a/packages/jsonb-query/README.md
+++ b/packages/jsonb-query/README.md
@@ -102,6 +102,19 @@ try {
 }
 ```
 
+## Indexing
+
+| Operators | Index that helps |
+| --- | --- |
+| object `contains`/`containsall` (`@>`), `haskey`/`hasanykey`/`hasallkeys` (`?`/`?|`/`?&`) | default `GIN (col jsonb_ops)` |
+| `jsonpath` dialect predicates (`@?` / `@@`) | `GIN (col jsonb_path_ops)` |
+| `legacy` scalar comparisons on a hot path | b-tree **expression** index, e.g. `CREATE INDEX ON t ((data #>> '{status}'))` |
+
+`contains` / `icontains` / `startswith` / `istartswith` / `endswith` /
+`iendswith` are **not** index-served (they scan); for heavy substring search use
+a `pg_trgm` GIN index. The jsonpath `elemmatch` SQL-fallback fragment (object or
+`containsall` leaf) is not served by a `jsonb_path_ops` GIN index.
+
 ## Safety
 
 Condition **values** and **field paths** are always parameterized — never
@@ -119,12 +132,12 @@ is not a plain (optionally qualified) column reference is rejected.
 
 | dataType                          | operators                                                                  |
 | --------------------------------- | -------------------------------------------------------------------------- |
-| `string`                          | `eq` `neq` `isnull` `isnotnull` `contains` `startswith` `endswith` `terms` |
+| `string`                          | `eq` `neq` `isnull` `isnotnull` `contains` `startswith` `endswith` `terms` `icontains` `istartswith` `iendswith` `ieq` `ineq` |
 | `numeric`                         | `eq` `neq` `isnull` `isnotnull` `gt` `gte` `lt` `lte` `range` `terms`      |
 | `date`                            | `eq` `neq` `isnull` `isnotnull` `gt` `gte` `lt` `lte` `range` `terms`      |
 | `boolean`                         | `eq` `neq` `isnull` `isnotnull`                                            |
-| `object`                          | `eq` `neq` `contains` `isnull` `isnotnull`                                 |
-| `array` + scalar `elementType`    | element ops (`neq` = value not present) + `containsall` + `isnull` `isnotnull` |
+| `object`                          | `eq` `neq` `contains` `isnull` `isnotnull` `haskey` `hasanykey` `hasallkeys`               |
+| `array` + scalar `elementType`    | element ops (`neq` = value not present) + `containsall` + `isempty` `isnotempty` + `isnull` `isnotnull` |
 | `array` + `elementType: 'object'` | `elemmatch`                                                                |
 
 `range` takes a 2-element `[lo, hi]` value; `terms` takes a non-empty array.
@@ -142,6 +155,39 @@ jsonb containment (`@>`):
 
 Object conditions render the same SQL in both dialects (SQL/JSON path predicates
 cannot compare non-scalar values), and `@>` is GIN-indexable.
+
+### Key existence (object)
+
+`haskey` / `hasanykey` / `hasallkeys` test for the presence of object **keys**
+(jsonb `?` / `?|` / `?&`), regardless of the value at that key — distinct from
+`isnotnull`, which tests the value (a key present with a JSON `null` value is
+`haskey: true` but `isnotnull: false`). All three are GIN-indexable.
+
+```typescript
+{ field: 'profile', dataType: 'object', operator: 'haskey', value: 'vip' }
+//  (("data" #> $1) ? $2)              values: [['profile'], 'vip']
+{ field: 'profile', dataType: 'object', operator: 'hasanykey', value: ['vip','premium'] }
+//  (("data" #> $1) ?| $2::text[])
+{ field: 'profile', dataType: 'object', operator: 'hasallkeys', value: ['vip','level'] }
+//  (("data" #> $1) ?& $2::text[])
+```
+
+### Case-insensitive text
+
+`icontains` / `istartswith` / `iendswith` / `ieq` / `ineq` match strings
+case-insensitively. The legacy dialect lowercases both sides (`lower()`); the
+jsonpath dialect uses `like_regex … flag "i"`.
+
+> Case folding differs slightly between dialects on non-ASCII text: `lower()`
+> follows the database `LC_CTYPE`, while jsonpath `flag "i"` uses its own Unicode
+> rules. ASCII text matches identically.
+
+### Array emptiness
+
+`isempty` / `isnotempty` test whether a scalar-element array field has zero /
+at least one element (`jsonb_array_length`). A missing field or non-array value
+is **neither** (both operators return false). They render identical SQL in both
+dialects.
 
 ### JSON arrays (scalar elements)
 

--- a/packages/jsonb-query/README.md
+++ b/packages/jsonb-query/README.md
@@ -172,6 +172,12 @@ cannot compare non-scalar values), and `@>` is GIN-indexable.
 //  (("data" #> $1) ?& $2::text[])
 ```
 
+> **`?` placeholder collision:** these operators emit a literal `?` / `?|` / `?&`
+> in the SQL. node-postgres uses `$N` placeholders, so this is safe there. Query
+> layers that treat `?` as a bind placeholder (e.g. Knex `whereRaw`) will
+> misparse it — use `buildNamedJsonbQuery` (`:pN` output) with those, or a driver
+> that uses `$N`.
+
 ### Case-insensitive text
 
 `icontains` / `istartswith` / `iendswith` / `ieq` / `ineq` match strings

--- a/packages/jsonb-query/src/build.spec.ts
+++ b/packages/jsonb-query/src/build.spec.ts
@@ -552,7 +552,8 @@ describe('buildJsonbQuery — array emptiness', () => {
 
   it('isempty renders identical SQL in both dialects', () => {
     const filter = one({ field: 'tags', dataType: 'array', elementType: 'string', operator: 'isempty' });
-    const expected = "(jsonb_typeof(\"data\" #> $1) = 'array' and jsonb_array_length(\"data\" #> $1) = 0)";
+    const expected =
+      "(case when jsonb_typeof(\"data\" #> $1) = 'array' then jsonb_array_length(\"data\" #> $1) = 0 else false end)";
     expect(buildJsonbQuery('data', filter).where).toBe(expected);
     expect(buildJsonbQuery('data', filter, { dialect: 'jsonpath' }).where).toBe(expected);
   });

--- a/packages/jsonb-query/src/build.spec.ts
+++ b/packages/jsonb-query/src/build.spec.ts
@@ -546,3 +546,14 @@ describe('buildJsonbQuery — array element neq', () => {
     });
   });
 });
+
+describe('buildJsonbQuery — array emptiness', () => {
+  const one = (f: JsonbFilterGroup['filters'][number]): JsonbFilterGroup => ({ logic: 'and', filters: [f] });
+
+  it('isempty renders identical SQL in both dialects', () => {
+    const filter = one({ field: 'tags', dataType: 'array', elementType: 'string', operator: 'isempty' });
+    const expected = "(jsonb_typeof(\"data\" #> $1) = 'array' and jsonb_array_length(\"data\" #> $1) = 0)";
+    expect(buildJsonbQuery('data', filter).where).toBe(expected);
+    expect(buildJsonbQuery('data', filter, { dialect: 'jsonpath' }).where).toBe(expected);
+  });
+});

--- a/packages/jsonb-query/src/build.spec.ts
+++ b/packages/jsonb-query/src/build.spec.ts
@@ -558,3 +558,28 @@ describe('buildJsonbQuery — array emptiness', () => {
     expect(buildJsonbQuery('data', filter, { dialect: 'jsonpath' }).where).toBe(expected);
   });
 });
+
+describe('buildJsonbQuery — key existence & case-insensitive end-to-end', () => {
+  const one = (f: JsonbFilterGroup['filters'][number]): JsonbFilterGroup => ({ logic: 'and', filters: [f] });
+
+  it('haskey renders identical SQL in both dialects', () => {
+    const filter = one({ field: 'profile', dataType: 'object', operator: 'haskey', value: 'vip' });
+    const expected = { where: '(("data" #> $1) ? $2)', values: [['profile'], 'vip'], from: [] };
+    expect(buildJsonbQuery('data', filter)).toEqual(expected);
+    expect(buildJsonbQuery('data', filter, { dialect: 'jsonpath' })).toEqual(expected);
+  });
+
+  it('icontains renders per-dialect (lower() vs like_regex flag "i")', () => {
+    const filter = one({ field: 'name', dataType: 'string', operator: 'icontains', value: 'Bob' });
+    expect(buildJsonbQuery('data', filter)).toEqual({
+      where: '(position(lower($2) in lower(("data" #>> $1))) > 0)',
+      values: [['name'], 'Bob'],
+      from: [],
+    });
+    expect(buildJsonbQuery('data', filter, { dialect: 'jsonpath' })).toEqual({
+      where: 'jsonb_path_exists("data", $1::jsonpath)',
+      values: ['$."name" ? (@ like_regex "Bob" flag "i")'],
+      from: [],
+    });
+  });
+});

--- a/packages/jsonb-query/src/dialect/base.spec.ts
+++ b/packages/jsonb-query/src/dialect/base.spec.ts
@@ -67,6 +67,12 @@ describe('assertCondition', () => {
     );
   });
 
+  it('accepts key-existence object operators', () => {
+    expect(c({ field: 'p', dataType: 'object', operator: 'haskey', value: 'vip' })).not.toThrow();
+    expect(c({ field: 'p', dataType: 'object', operator: 'hasanykey', value: ['a'] })).not.toThrow();
+    expect(c({ field: 'p', dataType: 'object', operator: 'hasallkeys', value: ['a', 'b'] })).not.toThrow();
+  });
+
   it('validates array element operators per elementType', () => {
     const arr = (elementType: string, operator: string) =>
       c({ field: 'a', dataType: 'array', elementType, operator, value: 1 });

--- a/packages/jsonb-query/src/dialect/base.spec.ts
+++ b/packages/jsonb-query/src/dialect/base.spec.ts
@@ -73,6 +73,14 @@ describe('assertCondition', () => {
     expect(c({ field: 'p', dataType: 'object', operator: 'hasallkeys', value: ['a', 'b'] })).not.toThrow();
   });
 
+  it('accepts case-insensitive operators only for string', () => {
+    expect(c({ field: 'x', dataType: 'string', operator: 'icontains', value: 'a' })).not.toThrow();
+    expect(c({ field: 'x', dataType: 'string', operator: 'ieq', value: 'a' })).not.toThrow();
+    expect(c({ field: 'x', dataType: 'numeric', operator: 'icontains', value: 1 })).toThrow(
+      /unsupported operator "icontains" for type "numeric"/i,
+    );
+  });
+
   it('validates array element operators per elementType', () => {
     const arr = (elementType: string, operator: string) =>
       c({ field: 'a', dataType: 'array', elementType, operator, value: 1 });

--- a/packages/jsonb-query/src/dialect/base.spec.ts
+++ b/packages/jsonb-query/src/dialect/base.spec.ts
@@ -116,6 +116,13 @@ describe('assertCondition', () => {
       /unsupported operator "gt" for type "object"/i,
     );
   });
+
+  it('accepts isempty / isnotempty for every array element type', () => {
+    for (const elementType of ['string', 'numeric', 'date', 'boolean'] as const) {
+      expect(c({ field: 'a', dataType: 'array', elementType, operator: 'isempty' })).not.toThrow();
+      expect(c({ field: 'a', dataType: 'array', elementType, operator: 'isnotempty' })).not.toThrow();
+    }
+  });
 });
 
 describe('groupNeedsSqlFallback', () => {
@@ -148,5 +155,10 @@ describe('groupNeedsSqlFallback', () => {
       } as never,
     ]);
     expect(groupNeedsSqlFallback(nestedElemScalar)).toBe(false);
+  });
+
+  it('isempty / isnotempty force the SQL fallback', () => {
+    expect(groupNeedsSqlFallback(g([{ field: 't', dataType: 'array', elementType: 'string', operator: 'isempty' }]))).toBe(true);
+    expect(groupNeedsSqlFallback(g([{ field: 't', dataType: 'array', elementType: 'string', operator: 'isnotempty' }]))).toBe(true);
   });
 });

--- a/packages/jsonb-query/src/dialect/base.ts
+++ b/packages/jsonb-query/src/dialect/base.ts
@@ -132,8 +132,25 @@ export function assertObjectValue(operator: string, value: unknown): JsonbObject
   return value as JsonbObjectValue;
 }
 
+export function assertKeyValue(operator: string, value: unknown): string {
+  if (typeof value !== 'string') {
+    throw new JsonbQueryError(`Operator "${operator}" requires a single string key`, 'INVALID_SCALAR_VALUE');
+  }
+  return value;
+}
+
+export function assertKeyArray(operator: string, value: unknown): string[] {
+  if (!Array.isArray(value) || value.length === 0 || !value.every((k) => typeof k === 'string')) {
+    throw new JsonbQueryError(
+      `Operator "${operator}" requires a non-empty array of string keys`,
+      'INVALID_ARRAY_VALUE',
+    );
+  }
+  return value;
+}
+
 const OBJECT_OPERATORS: ReadonlySet<JsonbObjectOperator> = new Set([
-  'eq', 'neq', 'contains', 'isnull', 'isnotnull',
+  'eq', 'neq', 'contains', 'isnull', 'isnotnull', 'haskey', 'hasanykey', 'hasallkeys',
 ]);
 
 const ARRAY_OPERATORS_BY_ELEMENT: Record<JsonbScalarType, ReadonlySet<string>> = {

--- a/packages/jsonb-query/src/dialect/base.ts
+++ b/packages/jsonb-query/src/dialect/base.ts
@@ -105,7 +105,7 @@ export function assertArrayValue(
 }
 
 const OPERATORS_BY_TYPE: Record<JsonbScalarType, ReadonlySet<JsonbScalarOperator>> = {
-  string: new Set(['eq', 'neq', 'isnull', 'isnotnull', 'contains', 'startswith', 'endswith', 'terms']),
+  string: new Set(['eq', 'neq', 'isnull', 'isnotnull', 'contains', 'startswith', 'endswith', 'terms', 'icontains', 'istartswith', 'iendswith', 'ieq', 'ineq']),
   numeric: new Set(['eq', 'neq', 'isnull', 'isnotnull', 'gt', 'gte', 'lt', 'lte', 'range', 'terms']),
   date: new Set(['eq', 'neq', 'isnull', 'isnotnull', 'gt', 'gte', 'lt', 'lte', 'range', 'terms']),
   boolean: new Set(['eq', 'neq', 'isnull', 'isnotnull']),

--- a/packages/jsonb-query/src/dialect/base.ts
+++ b/packages/jsonb-query/src/dialect/base.ts
@@ -62,6 +62,18 @@ export function renderNullCheck(
   return operator === 'isnull' ? `(${F} is null)` : `(${F} is not null)`;
 }
 
+/** Array emptiness via jsonb_array_length, dialect-independent. Missing / non-array → both false. */
+export function renderArrayEmptiness(
+  column: string,
+  field: string,
+  operator: 'isempty' | 'isnotempty',
+  params: ParamBuilder,
+): string {
+  const arr = `${column} #> ${params.add(fieldSegments(field))}`;
+  const cmp = operator === 'isempty' ? '= 0' : '> 0';
+  return `(jsonb_typeof(${arr}) = 'array' and jsonb_array_length(${arr}) ${cmp})`;
+}
+
 /**
  * JSONB containment (`@>`). `JSON.stringify` is required: node-postgres encodes
  * raw JS arrays as Postgres array literals ('{a,b}'), which are not valid jsonb.
@@ -154,10 +166,10 @@ const OBJECT_OPERATORS: ReadonlySet<JsonbObjectOperator> = new Set([
 ]);
 
 const ARRAY_OPERATORS_BY_ELEMENT: Record<JsonbScalarType, ReadonlySet<string>> = {
-  string: new Set(['eq', 'neq', 'contains', 'startswith', 'endswith', 'terms', 'containsall', 'isnull', 'isnotnull']),
-  numeric: new Set(['eq', 'neq', 'gt', 'gte', 'lt', 'lte', 'range', 'terms', 'containsall', 'isnull', 'isnotnull']),
-  date: new Set(['eq', 'neq', 'gt', 'gte', 'lt', 'lte', 'range', 'terms', 'isnull', 'isnotnull']),
-  boolean: new Set(['eq', 'neq', 'isnull', 'isnotnull']),
+  string: new Set(['eq', 'neq', 'contains', 'startswith', 'endswith', 'terms', 'containsall', 'isnull', 'isnotnull', 'isempty', 'isnotempty']),
+  numeric: new Set(['eq', 'neq', 'gt', 'gte', 'lt', 'lte', 'range', 'terms', 'containsall', 'isnull', 'isnotnull', 'isempty', 'isnotempty']),
+  date: new Set(['eq', 'neq', 'gt', 'gte', 'lt', 'lte', 'range', 'terms', 'isnull', 'isnotnull', 'isempty', 'isnotempty']),
+  boolean: new Set(['eq', 'neq', 'isnull', 'isnotnull', 'isempty', 'isnotempty']),
 };
 
 export function assertCondition(node: JsonbCondition): void {
@@ -225,7 +237,7 @@ function conditionNeedsSqlFallback(node: JsonbCondition): boolean {
     if (node.elementType === 'object') {
       return groupNeedsSqlFallback(node.filters);
     }
-    return node.operator === 'containsall';
+    return node.operator === 'containsall' || node.operator === 'isempty' || node.operator === 'isnotempty';
   }
   return false;
 }

--- a/packages/jsonb-query/src/dialect/base.ts
+++ b/packages/jsonb-query/src/dialect/base.ts
@@ -71,7 +71,9 @@ export function renderArrayEmptiness(
 ): string {
   const arr = `${column} #> ${params.add(fieldSegments(field))}`;
   const cmp = operator === 'isempty' ? '= 0' : '> 0';
-  return `(jsonb_typeof(${arr}) = 'array' and jsonb_array_length(${arr}) ${cmp})`;
+  // CASE (not AND): Postgres does not guarantee AND short-circuits, so
+  // jsonb_array_length must never reach a non-array value (it errors on scalars).
+  return `(case when jsonb_typeof(${arr}) = 'array' then jsonb_array_length(${arr}) ${cmp} else false end)`;
 }
 
 /**

--- a/packages/jsonb-query/src/dialect/jsonpath.spec.ts
+++ b/packages/jsonb-query/src/dialect/jsonpath.spec.ts
@@ -125,6 +125,13 @@ describe('jsonpathDialect', () => {
   it('icontains regex-escapes the literal', () => {
     expect(run('name', 'string', 'icontains', 'a.b').values[0]).toBe('$."name" ? (@ like_regex "a\\\\.b" flag "i")');
   });
+
+  it('anchored case-insensitive operators regex-escape the literal too', () => {
+    expect(run('name', 'string', 'istartswith', 'a.b').values[0]).toBe('$."name" ? (@ like_regex "^a\\\\.b" flag "i")');
+    expect(run('name', 'string', 'iendswith', 'a.b').values[0]).toBe('$."name" ? (@ like_regex "a\\\\.b$" flag "i")');
+    expect(run('name', 'string', 'ieq', 'a.b').values[0]).toBe('$."name" ? (@ like_regex "^a\\\\.b$" flag "i")');
+    expect(run('name', 'string', 'ineq', 'a.b').values[0]).toBe('$."name" ? (!(@ like_regex "^a\\\\.b$" flag "i"))');
+  });
 });
 
 describe('jsonpathDialect.renderArray', () => {

--- a/packages/jsonb-query/src/dialect/jsonpath.spec.ts
+++ b/packages/jsonb-query/src/dialect/jsonpath.spec.ts
@@ -113,6 +113,18 @@ describe('jsonpathDialect', () => {
   it('throws on an unknown operator', () => {
     expect(() => run('name', 'string', 'bogus' as never, 'x')).toThrow(/unsupported operator/i);
   });
+
+  it('case-insensitive operators use like_regex with flag "i"', () => {
+    expect(run('name', 'string', 'icontains', 'Bo').values[0]).toBe('$."name" ? (@ like_regex "Bo" flag "i")');
+    expect(run('name', 'string', 'istartswith', 'Bo').values[0]).toBe('$."name" ? (@ like_regex "^Bo" flag "i")');
+    expect(run('name', 'string', 'iendswith', 'ob').values[0]).toBe('$."name" ? (@ like_regex "ob$" flag "i")');
+    expect(run('name', 'string', 'ieq', 'Bob').values[0]).toBe('$."name" ? (@ like_regex "^Bob$" flag "i")');
+    expect(run('name', 'string', 'ineq', 'Bob').values[0]).toBe('$."name" ? (!(@ like_regex "^Bob$" flag "i"))');
+  });
+
+  it('icontains regex-escapes the literal', () => {
+    expect(run('name', 'string', 'icontains', 'a.b').values[0]).toBe('$."name" ? (@ like_regex "a\\\\.b" flag "i")');
+  });
 });
 
 describe('jsonpathDialect.renderArray', () => {

--- a/packages/jsonb-query/src/dialect/jsonpath.ts
+++ b/packages/jsonb-query/src/dialect/jsonpath.ts
@@ -151,6 +151,26 @@ function scalarPredicate(
       return { pred: `!exists (${acc}) || ${acc} == null`, compound: true };
     case 'isnotnull':
       return { pred: `exists (${acc}) && ${acc} != null`, compound: true };
+    case 'icontains': {
+      const lit = escapeJsonpathString(escapeRegexLiteral(String(assertScalarValue(operator, value))));
+      return { pred: `${acc} like_regex "${lit}" flag "i"`, compound: false };
+    }
+    case 'istartswith': {
+      const lit = escapeJsonpathString('^' + escapeRegexLiteral(String(assertScalarValue(operator, value))));
+      return { pred: `${acc} like_regex "${lit}" flag "i"`, compound: false };
+    }
+    case 'iendswith': {
+      const lit = escapeJsonpathString(escapeRegexLiteral(String(assertScalarValue(operator, value))) + '$');
+      return { pred: `${acc} like_regex "${lit}" flag "i"`, compound: false };
+    }
+    case 'ieq': {
+      const lit = escapeJsonpathString('^' + escapeRegexLiteral(String(assertScalarValue(operator, value))) + '$');
+      return { pred: `${acc} like_regex "${lit}" flag "i"`, compound: false };
+    }
+    case 'ineq': {
+      const lit = escapeJsonpathString('^' + escapeRegexLiteral(String(assertScalarValue(operator, value))) + '$');
+      return { pred: `!(${acc} like_regex "${lit}" flag "i")`, compound: true };
+    }
     default:
       throw new JsonbQueryError(`Unsupported operator "${operator as string}"`, 'UNSUPPORTED_OPERATOR');
   }

--- a/packages/jsonb-query/src/dialect/jsonpath.ts
+++ b/packages/jsonb-query/src/dialect/jsonpath.ts
@@ -14,6 +14,7 @@ import {
   isFilterGroup,
   renderNullCheck,
   renderJsonbContains,
+  renderArrayEmptiness,
   groupNeedsSqlFallback,
 } from './base';
 import { legacyDialect } from './legacy';
@@ -295,6 +296,9 @@ export const jsonpathDialect: JsonbQueryDialect = {
     const { field, elementType, operator, value } = condition;
     if (operator === 'isnull' || operator === 'isnotnull') {
       return renderNullCheck(column, field, operator, params);
+    }
+    if (operator === 'isempty' || operator === 'isnotempty') {
+      return renderArrayEmptiness(column, field, operator, params);
     }
     if (operator === 'containsall') {
       return renderJsonbContains(column, field, assertArrayValue(operator, value), params);

--- a/packages/jsonb-query/src/dialect/legacy.spec.ts
+++ b/packages/jsonb-query/src/dialect/legacy.spec.ts
@@ -217,11 +217,12 @@ describe('legacyDialect.renderArray', () => {
 
   it('isempty / isnotempty test the array length (dialect-independent)', () => {
     expect(runArray({ field: 'tags', elementType: 'string', operator: 'isempty' })).toMatchObject({
-      where: "(jsonb_typeof(\"data\" #> $1) = 'array' and jsonb_array_length(\"data\" #> $1) = 0)",
+      where:
+        "(case when jsonb_typeof(\"data\" #> $1) = 'array' then jsonb_array_length(\"data\" #> $1) = 0 else false end)",
       values: [['tags']],
     });
     expect(runArray({ field: 'tags', elementType: 'string', operator: 'isnotempty' }).where).toBe(
-      "(jsonb_typeof(\"data\" #> $1) = 'array' and jsonb_array_length(\"data\" #> $1) > 0)",
+      "(case when jsonb_typeof(\"data\" #> $1) = 'array' then jsonb_array_length(\"data\" #> $1) > 0 else false end)",
     );
   });
 

--- a/packages/jsonb-query/src/dialect/legacy.spec.ts
+++ b/packages/jsonb-query/src/dialect/legacy.spec.ts
@@ -130,10 +130,10 @@ describe('legacyDialect', () => {
       '(position(lower($2) in lower(("data" #>> $1))) > 0)',
     );
     expect(run('name', 'string', 'istartswith', 'Bo').where).toBe(
-      '(left(lower(("data" #>> $1)), char_length($2)) = lower($2))',
+      '(left(lower(("data" #>> $1)), char_length(lower($2))) = lower($2))',
     );
     expect(run('name', 'string', 'iendswith', 'ob').where).toBe(
-      '(right(lower(("data" #>> $1)), char_length($2)) = lower($2))',
+      '(right(lower(("data" #>> $1)), char_length(lower($2))) = lower($2))',
     );
   });
 });

--- a/packages/jsonb-query/src/dialect/legacy.spec.ts
+++ b/packages/jsonb-query/src/dialect/legacy.spec.ts
@@ -215,6 +215,16 @@ describe('legacyDialect.renderArray', () => {
     });
   });
 
+  it('isempty / isnotempty test the array length (dialect-independent)', () => {
+    expect(runArray({ field: 'tags', elementType: 'string', operator: 'isempty' })).toMatchObject({
+      where: "(jsonb_typeof(\"data\" #> $1) = 'array' and jsonb_array_length(\"data\" #> $1) = 0)",
+      values: [['tags']],
+    });
+    expect(runArray({ field: 'tags', elementType: 'string', operator: 'isnotempty' }).where).toBe(
+      "(jsonb_typeof(\"data\" #> $1) = 'array' and jsonb_array_length(\"data\" #> $1) > 0)",
+    );
+  });
+
   it('allocates unique aliases across calls sharing a context', () => {
     const p = new ParamBuilder();
     const ctx = makeCtx(p);

--- a/packages/jsonb-query/src/dialect/legacy.spec.ts
+++ b/packages/jsonb-query/src/dialect/legacy.spec.ts
@@ -119,6 +119,23 @@ describe('legacyDialect', () => {
   it('throws on an unknown operator', () => {
     expect(() => run('name', 'string', 'bogus' as never, 'x')).toThrow(/unsupported operator/i);
   });
+
+  it('case-insensitive operators lower() both sides (literal, no LIKE)', () => {
+    expect(run('name', 'string', 'ieq', 'Bob')).toEqual({
+      where: '(lower(("data" #>> $1)) = lower($2))',
+      values: [['name'], 'Bob'],
+    });
+    expect(run('name', 'string', 'ineq', 'Bob').where).toBe('(lower(("data" #>> $1)) <> lower($2))');
+    expect(run('name', 'string', 'icontains', 'Bo').where).toBe(
+      '(position(lower($2) in lower(("data" #>> $1))) > 0)',
+    );
+    expect(run('name', 'string', 'istartswith', 'Bo').where).toBe(
+      '(left(lower(("data" #>> $1)), char_length($2)) = lower($2))',
+    );
+    expect(run('name', 'string', 'iendswith', 'ob').where).toBe(
+      '(right(lower(("data" #>> $1)), char_length($2)) = lower($2))',
+    );
+  });
 });
 
 function makeCtx(

--- a/packages/jsonb-query/src/dialect/legacy.ts
+++ b/packages/jsonb-query/src/dialect/legacy.ts
@@ -6,6 +6,7 @@ import {
   assertArrayValue,
   renderNullCheck,
   renderJsonbContains,
+  renderArrayEmptiness,
 } from './base';
 import type { ParamBuilder } from '../param-builder';
 import { JsonbQueryError } from '../errors';
@@ -94,6 +95,9 @@ export const legacyDialect: JsonbQueryDialect = {
     const { field, elementType, operator, value } = condition;
     if (operator === 'isnull' || operator === 'isnotnull') {
       return renderNullCheck(column, field, operator, params);
+    }
+    if (operator === 'isempty' || operator === 'isnotempty') {
+      return renderArrayEmptiness(column, field, operator, params);
     }
     if (operator === 'containsall') {
       return renderJsonbContains(column, field, assertArrayValue(operator, value), params);

--- a/packages/jsonb-query/src/dialect/legacy.ts
+++ b/packages/jsonb-query/src/dialect/legacy.ts
@@ -62,6 +62,20 @@ function renderScalarOp(
       const v = params.add(assertScalarValue(operator, value));
       return `(right(${F}, char_length(${v})) = ${v})`;
     }
+    case 'ieq':
+      return `(lower(${F}) = lower(${params.add(assertScalarValue(operator, value))}))`;
+    case 'ineq':
+      return `(lower(${F}) <> lower(${params.add(assertScalarValue(operator, value))}))`;
+    case 'icontains':
+      return `(position(lower(${params.add(assertScalarValue(operator, value))}) in lower(${F})) > 0)`;
+    case 'istartswith': {
+      const v = params.add(assertScalarValue(operator, value));
+      return `(left(lower(${F}), char_length(${v})) = lower(${v}))`;
+    }
+    case 'iendswith': {
+      const v = params.add(assertScalarValue(operator, value));
+      return `(right(lower(${F}), char_length(${v})) = lower(${v}))`;
+    }
     default:
       throw new JsonbQueryError(`Unsupported operator "${operator as string}"`, 'UNSUPPORTED_OPERATOR');
   }

--- a/packages/jsonb-query/src/dialect/legacy.ts
+++ b/packages/jsonb-query/src/dialect/legacy.ts
@@ -71,11 +71,11 @@ function renderScalarOp(
       return `(position(lower(${params.add(assertScalarValue(operator, value))}) in lower(${F})) > 0)`;
     case 'istartswith': {
       const v = params.add(assertScalarValue(operator, value));
-      return `(left(lower(${F}), char_length(${v})) = lower(${v}))`;
+      return `(left(lower(${F}), char_length(lower(${v}))) = lower(${v}))`;
     }
     case 'iendswith': {
       const v = params.add(assertScalarValue(operator, value));
-      return `(right(lower(${F}), char_length(${v})) = lower(${v}))`;
+      return `(right(lower(${F}), char_length(lower(${v}))) = lower(${v}))`;
     }
     default:
       throw new JsonbQueryError(`Unsupported operator "${operator as string}"`, 'UNSUPPORTED_OPERATOR');

--- a/packages/jsonb-query/src/object-condition.spec.ts
+++ b/packages/jsonb-query/src/object-condition.spec.ts
@@ -55,4 +55,34 @@ describe('renderObjectCondition', () => {
     expect(where).toBe('(("data" #> $1) = $2::jsonb)');
     expect(values[1]).toBe('{"name":"x\'; DROP TABLE t; --"}');
   });
+
+  it('haskey uses the jsonb ? operator', () => {
+    expect(run({ field: 'profile', operator: 'haskey', value: 'vip' })).toEqual({
+      where: '(("data" #> $1) ? $2)',
+      values: [['profile'], 'vip'],
+    });
+  });
+
+  it('hasanykey / hasallkeys use ?| / ?& with a text[] param', () => {
+    expect(run({ field: 'profile', operator: 'hasanykey', value: ['vip', 'premium'] })).toEqual({
+      where: '(("data" #> $1) ?| $2::text[])',
+      values: [['profile'], ['vip', 'premium']],
+    });
+    expect(run({ field: 'profile', operator: 'hasallkeys', value: ['vip', 'level'] })).toEqual({
+      where: '(("data" #> $1) ?& $2::text[])',
+      values: [['profile'], ['vip', 'level']],
+    });
+  });
+
+  it('rejects bad key arguments', () => {
+    expect(() => run({ field: 'p', operator: 'haskey', value: ['x'] as never })).toThrow(
+      /requires a single string key/i,
+    );
+    expect(() => run({ field: 'p', operator: 'hasanykey', value: [] as never })).toThrow(
+      /requires a non-empty array of string keys/i,
+    );
+    expect(() => run({ field: 'p', operator: 'hasallkeys', value: [1] as never })).toThrow(
+      /requires a non-empty array of string keys/i,
+    );
+  });
 });

--- a/packages/jsonb-query/src/object-condition.ts
+++ b/packages/jsonb-query/src/object-condition.ts
@@ -3,6 +3,8 @@ import type { ParamBuilder } from './param-builder';
 import {
   fieldSegments,
   assertObjectValue,
+  assertKeyValue,
+  assertKeyArray,
   renderNullCheck,
   renderJsonbContains,
 } from './dialect';
@@ -31,6 +33,16 @@ export function renderObjectCondition(
       const obj = assertObjectValue(operator, value);
       const F = `(${column} #> ${params.add(fieldSegments(field))})`;
       return `(${F} ${operator === 'eq' ? '=' : '<>'} ${params.add(JSON.stringify(obj))}::jsonb)`;
+    }
+    case 'haskey': {
+      const key = assertKeyValue(operator, value);
+      return `((${column} #> ${params.add(fieldSegments(field))}) ? ${params.add(key)})`;
+    }
+    case 'hasanykey':
+    case 'hasallkeys': {
+      const keys = assertKeyArray(operator, value);
+      const op = operator === 'hasanykey' ? '?|' : '?&';
+      return `((${column} #> ${params.add(fieldSegments(field))}) ${op} ${params.add(keys)}::text[])`;
     }
     default:
       throw new JsonbQueryError(`Unsupported operator "${operator as string}" for type "object"`, 'UNSUPPORTED_OPERATOR');

--- a/packages/jsonb-query/src/types.ts
+++ b/packages/jsonb-query/src/types.ts
@@ -31,7 +31,15 @@ export type JsonbScalarOperator =
   | 'range'
   | 'terms';
 
-export type JsonbObjectOperator = 'eq' | 'neq' | 'contains' | 'isnull' | 'isnotnull';
+export type JsonbObjectOperator =
+  | 'eq'
+  | 'neq'
+  | 'contains'
+  | 'isnull'
+  | 'isnotnull'
+  | 'haskey'
+  | 'hasanykey'
+  | 'hasallkeys';
 
 /**
  * Operators on arrays of scalars. Scalar operators use "some element matches"
@@ -54,7 +62,8 @@ export interface JsonbObjectCondition {
   field: string;
   dataType: 'object';
   operator: JsonbObjectOperator;
-  value?: JsonbObjectValue;
+  /** Object value for eq/neq/contains; a string key for haskey; a string[] for hasanykey/hasallkeys. */
+  value?: JsonbObjectValue | string | string[];
   elementType?: never;
   filters?: never;
 }

--- a/packages/jsonb-query/src/types.ts
+++ b/packages/jsonb-query/src/types.ts
@@ -52,7 +52,7 @@ export type JsonbObjectOperator =
  * `containsall` requires every listed value to be present. `neq` means "value
  * not present" (∀ element ≠ value) — the negation of `eq`'s ∃-present.
  */
-export type JsonbArrayOperator = JsonbScalarOperator | 'containsall';
+export type JsonbArrayOperator = JsonbScalarOperator | 'containsall' | 'isempty' | 'isnotempty';
 
 export interface JsonbScalarCondition {
   field: string;

--- a/packages/jsonb-query/src/types.ts
+++ b/packages/jsonb-query/src/types.ts
@@ -29,7 +29,12 @@ export type JsonbScalarOperator =
   | 'lt'
   | 'lte'
   | 'range'
-  | 'terms';
+  | 'terms'
+  | 'icontains'
+  | 'istartswith'
+  | 'iendswith'
+  | 'ieq'
+  | 'ineq';
 
 export type JsonbObjectOperator =
   | 'eq'

--- a/packages/jsonb-query/test/jsonb-query.e2e.spec.ts
+++ b/packages/jsonb-query/test/jsonb-query.e2e.spec.ts
@@ -36,6 +36,7 @@ const SEED: Array<[number, unknown]> = [
       joined: '2020-01-15T08:30:00Z',
       profile: { vip: true, level: 3 },
       tags: ['a', 'b'],
+      roles: [], // empty array — exercises isempty (no other test touches `roles`)
       nums: [1, 5, 9],
       items: [
         { sku: 'x', qty: 2, ship: '2020-02-01T00:00:00+00:00', meta: { vip: true } },
@@ -53,6 +54,7 @@ const SEED: Array<[number, unknown]> = [
       joined: '2021-03-20T00:00:00Z',
       profile: { vip: false },
       tags: ['b', 'c'],
+      roles: ['admin'], // non-empty array — exercises isnotempty
       nums: [10, 20],
       items: [{ sku: 'y', qty: 1 }],
     },
@@ -550,10 +552,12 @@ describe.skipIf(URLS.length === 0)('jsonb-query e2e', () => {
           await expectIds(one({ field: 'name', dataType: 'string', operator: 'ieq', value: 'ALICE' }), [2]);
         });
 
-        it('isempty / isnotempty on the tags array', async () => {
-          // id 1 tags:[a,b], id 2 tags:[b,c] → isnotempty [1,2]; none seeded with [] → isempty [].
+        it('isempty / isnotempty distinguish empty, non-empty, and missing arrays', async () => {
+          // id 1 roles:[] (empty), id 2 roles:['admin'] (non-empty); no other row has `roles`.
+          await expectIds(one({ field: 'roles', dataType: 'array', elementType: 'string', operator: 'isempty' }), [1]);
+          await expectIds(one({ field: 'roles', dataType: 'array', elementType: 'string', operator: 'isnotempty' }), [2]);
+          // tags present and non-empty on 1 and 2; missing/scalar elsewhere → not non-empty.
           await expectIds(one({ field: 'tags', dataType: 'array', elementType: 'string', operator: 'isnotempty' }), [1, 2]);
-          await expectIds(one({ field: 'tags', dataType: 'array', elementType: 'string', operator: 'isempty' }), []);
         });
       });
 

--- a/packages/jsonb-query/test/jsonb-query.e2e.spec.ts
+++ b/packages/jsonb-query/test/jsonb-query.e2e.spec.ts
@@ -57,8 +57,8 @@ const SEED: Array<[number, unknown]> = [
       items: [{ sku: 'y', qty: 1 }],
     },
   ],
-  // JSON null age; everything else missing.
-  [3, { name: 'carol', age: null }],
+  // JSON null age; profile present with a null-valued key (for haskey vs isnotnull).
+  [3, { name: 'carol', age: null, profile: { vip: null } }],
   // Malformed shapes: tags is a scalar, items is an object (not an array).
   [4, { name: 'dave', tags: 'a', items: { sku: 'x', qty: 99 } }],
   // Regex metacharacters + hostile value stored as data.
@@ -228,8 +228,9 @@ describe.skipIf(URLS.length === 0)('jsonb-query e2e', () => {
             [2],
           );
           await expectIds(
+            // id 3 now seeds profile: { vip: null }, so it is no longer null.
             { logic: 'and', filters: [{ field: 'profile', dataType: 'object', operator: 'isnull' }] },
-            [3, 4, 5, 6, 7, 8],
+            [4, 5, 6, 7, 8],
           );
         });
       });
@@ -527,6 +528,32 @@ describe.skipIf(URLS.length === 0)('jsonb-query e2e', () => {
             },
             { legacy: [2], jsonpath: [2, 3, 4, 5, 6, 7, 8] },
           );
+        });
+      });
+
+      describe('operator expansion', () => {
+        const one = (f: JsonbFilterGroup['filters'][number]): JsonbFilterGroup => ({ logic: 'and', filters: [f] });
+
+        it('haskey detects a null-valued key that isnotnull misses', async () => {
+          // id 3 has profile.vip = null: the KEY exists (haskey) but the VALUE is null (isnotnull false).
+          await expectIds(one({ field: 'profile', dataType: 'object', operator: 'haskey', value: 'vip' }), [1, 2, 3]);
+          await expectIds(one({ field: 'profile.vip', dataType: 'boolean', operator: 'isnotnull' }), [1, 2]);
+        });
+
+        it('hasanykey / hasallkeys', async () => {
+          await expectIds(one({ field: 'profile', dataType: 'object', operator: 'hasallkeys', value: ['vip', 'level'] }), [1]);
+          await expectIds(one({ field: 'profile', dataType: 'object', operator: 'hasanykey', value: ['level', 'nope'] }), [1]);
+        });
+
+        it('case-insensitive contains matches regardless of case', async () => {
+          await expectIds(one({ field: 'name', dataType: 'string', operator: 'icontains', value: 'BO' }), [1]);
+          await expectIds(one({ field: 'name', dataType: 'string', operator: 'ieq', value: 'ALICE' }), [2]);
+        });
+
+        it('isempty / isnotempty on the tags array', async () => {
+          // id 1 tags:[a,b], id 2 tags:[b,c] → isnotempty [1,2]; none seeded with [] → isempty [].
+          await expectIds(one({ field: 'tags', dataType: 'array', elementType: 'string', operator: 'isnotempty' }), [1, 2]);
+          await expectIds(one({ field: 'tags', dataType: 'array', elementType: 'string', operator: 'isempty' }), []);
         });
       });
 


### PR DESCRIPTION
## Summary

Adds three operator families to `@rfjs/jsonb-query`, across both the `legacy` and `jsonpath` dialects. From an approved brainstorming spec + TDD plan (committed under `docs/superpowers/`), implemented task-by-task with a multi-lens adversarial review pass. Parity with `@rfjs/data-filter`'s operator set is intentionally **not** a goal — the two packages serve different surfaces.

- **Key existence (object):** `haskey` / `hasanykey` / `hasallkeys` → jsonb `?` / `?|` / `?&`, dialect-independent, GIN-indexable. Distinct from `isnotnull`: a key present with a JSON `null` value is `haskey: true` but `isnotnull: false`.
- **Case-insensitive text (string):** `icontains` / `istartswith` / `iendswith` / `ieq` / `ineq`. legacy lowercases both sides (`lower()`, literal — no `LIKE` metachar pitfalls); jsonpath uses `like_regex … flag "i"`.
- **Array emptiness (scalar arrays):** `isempty` / `isnotempty` via `jsonb_array_length`, dialect-independent; a missing / non-array value is neither (both false). Inside `elemmatch` they route through the SQL fallback.
- **Indexing guide:** new README section mapping operators to GIN / expression indexes.

**No new error codes** — key-arg guards reuse `INVALID_SCALAR_VALUE` / `INVALID_ARRAY_VALUE`.

## Changeset

**minor** (additive operators).

## Testing

- 161 unit tests; lint + typecheck + build clean.
- **68 real-PostgreSQL E2E** assertions pass on PG 11.16 (legacy) and PG 16 (legacy + jsonpath), including `haskey` vs `isnotnull`, case-insensitive matching, and `isempty`/`isnotempty` against seeded empty/non-empty/missing arrays.

## Notes

- The real-PG E2E caught a genuine bug during development: `jsonb_array_length` errors on a scalar because PostgreSQL doesn't guarantee `AND` short-circuits — fixed with a `CASE` expression so non-array values return false.
- The literal `?` / `?|` / `?&` collide with query layers that use `?` as a bind placeholder (e.g. Knex `whereRaw`); README documents using `buildNamedJsonbQuery` or a `$N` driver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)