### PR TITLE
feat(web,workbench): PWA 4a — installable manifest + generated icons

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -8,6 +8,13 @@ Package showcase, interactive playgrounds, and developer data tools for the
 Next.js App Router · TypeScript strict · Tailwind CSS v4 · shadcn/ui
 (components live in `@rfjs/web-ui`) · registry data in `@rfjs/web-core`.
 
+## PWA
+
+Installable on modern Chromium/Safari via `app/manifest.ts` + app icons
+generated at build with `next/og` `ImageResponse` (`app/icon-{192,512}.png`,
+at dotted paths so they bypass the next-intl middleware). No service worker /
+offline caching yet — that's a later phase (4b, Serwist).
+
 ## Develop
 
 ```bash

--- a/apps/web/src/app/[locale]/layout.tsx
+++ b/apps/web/src/app/[locale]/layout.tsx
@@ -26,6 +26,7 @@ export const metadata: Metadata = {
   title: "rfjs — RoyFW's TypeScript utility toolkit",
   description:
     "Utilities, playgrounds, and developer data tools for JSON, objects, filters, and query workflows.",
+  icons: { apple: "/icon-192.png" },
 };
 
 export function generateStaticParams() {

--- a/apps/web/src/app/_pwa/icon.tsx
+++ b/apps/web/src/app/_pwa/icon.tsx
@@ -1,0 +1,28 @@
+import { ImageResponse } from "next/og";
+
+// Brand-colored wordmark icon, generated at build (no static asset, no design tool).
+// Dark bedrock background + light signal ink — matches the apps' dark default.
+export function renderWordmarkIcon(size: number) {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          background: "#11151c",
+          color: "#e2e8f1",
+          fontFamily: "monospace",
+          fontWeight: 700,
+          fontSize: Math.round(size * 0.34),
+          letterSpacing: "-0.02em",
+        }}
+      >
+        rfjs
+      </div>
+    ),
+    { width: size, height: size },
+  );
+}

--- a/apps/web/src/app/icon-192.png/route.tsx
+++ b/apps/web/src/app/icon-192.png/route.tsx
@@ -1,0 +1,7 @@
+import { renderWordmarkIcon } from "../_pwa/icon";
+
+export const dynamic = "force-static";
+
+export function GET() {
+  return renderWordmarkIcon(192);
+}

--- a/apps/web/src/app/icon-512.png/route.tsx
+++ b/apps/web/src/app/icon-512.png/route.tsx
@@ -1,0 +1,7 @@
+import { renderWordmarkIcon } from "../_pwa/icon";
+
+export const dynamic = "force-static";
+
+export function GET() {
+  return renderWordmarkIcon(512);
+}

--- a/apps/web/src/app/manifest.ts
+++ b/apps/web/src/app/manifest.ts
@@ -1,0 +1,20 @@
+import type { MetadataRoute } from "next";
+
+export const dynamic = "force-static";
+
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: "rfjs — TypeScript utility toolkit",
+    short_name: "rfjs",
+    description:
+      "Utilities and developer data tools for JSON, objects, filters, and query workflows.",
+    start_url: "/",
+    display: "standalone",
+    background_color: "#11151c",
+    theme_color: "#11151c",
+    icons: [
+      { src: "/icon-192.png", sizes: "192x192", type: "image/png" },
+      { src: "/icon-512.png", sizes: "512x512", type: "image/png" },
+    ],
+  };
+}

--- a/apps/workbench/README.md
+++ b/apps/workbench/README.md
@@ -6,6 +6,12 @@ app hosts the stateful, dataset-first experiences.
 
 Spec: `docs/superpowers/specs/2026-06-13-workbench-and-web-convergence-design.md`
 
+## PWA
+
+Installable on modern Chromium/Safari via `app/manifest.ts` + build-time
+generated icons (`app/icon-{192,512}.png` via `next/og`). No service worker /
+offline yet — deferred to a later phase (4b, Serwist).
+
 ## Develop
 
 ```bash

--- a/apps/workbench/src/app/[locale]/layout.tsx
+++ b/apps/workbench/src/app/[locale]/layout.tsx
@@ -25,6 +25,7 @@ const jetbrainsMono = JetBrains_Mono({
 export const metadata: Metadata = {
   title: "rfjs workbench",
   description: "Dataset-driven workbench composing the @rfjs packages.",
+  icons: { apple: "/icon-192.png" },
 };
 
 export function generateStaticParams() {

--- a/apps/workbench/src/app/_pwa/icon.tsx
+++ b/apps/workbench/src/app/_pwa/icon.tsx
@@ -1,0 +1,28 @@
+import { ImageResponse } from "next/og";
+
+// Brand-colored wordmark icon, generated at build (no static asset, no design tool).
+// Dark bedrock background + light signal ink — matches the apps' dark default.
+export function renderWordmarkIcon(size: number) {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          background: "#11151c",
+          color: "#e2e8f1",
+          fontFamily: "monospace",
+          fontWeight: 700,
+          fontSize: Math.round(size * 0.34),
+          letterSpacing: "-0.02em",
+        }}
+      >
+        rfjs
+      </div>
+    ),
+    { width: size, height: size },
+  );
+}

--- a/apps/workbench/src/app/icon-192.png/route.tsx
+++ b/apps/workbench/src/app/icon-192.png/route.tsx
@@ -1,0 +1,7 @@
+import { renderWordmarkIcon } from "../_pwa/icon";
+
+export const dynamic = "force-static";
+
+export function GET() {
+  return renderWordmarkIcon(192);
+}

--- a/apps/workbench/src/app/icon-512.png/route.tsx
+++ b/apps/workbench/src/app/icon-512.png/route.tsx
@@ -1,0 +1,7 @@
+import { renderWordmarkIcon } from "../_pwa/icon";
+
+export const dynamic = "force-static";
+
+export function GET() {
+  return renderWordmarkIcon(512);
+}

--- a/apps/workbench/src/app/manifest.ts
+++ b/apps/workbench/src/app/manifest.ts
@@ -1,0 +1,19 @@
+import type { MetadataRoute } from "next";
+
+export const dynamic = "force-static";
+
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: "rfjs workbench",
+    short_name: "workbench",
+    description: "Dataset-driven workbench composing the @rfjs packages.",
+    start_url: "/",
+    display: "standalone",
+    background_color: "#11151c",
+    theme_color: "#11151c",
+    icons: [
+      { src: "/icon-192.png", sizes: "192x192", type: "image/png" },
+      { src: "/icon-512.png", sizes: "512x512", type: "image/png" },
+    ],
+  };
+}

--- a/docs/superpowers/plans/2026-06-14-pwa-installable.md
+++ b/docs/superpowers/plans/2026-06-14-pwa-installable.md
@@ -1,0 +1,296 @@
+# PWA 4a — 可安裝（manifest + 生成 icon，雙站）Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** apps/web 與 apps/workbench 各加 Next 16 原生 `app/manifest.ts` + 用 `ImageResponse` 從「rfjs」wordmark 生成的 192/512 icon，讓兩站在現代 Chromium/Safari 可安裝（不需 service worker）。
+
+**Architecture:** 每站自帶一份 `manifest.ts`（app root，非 `[locale]` 下，serve 為 `/manifest.webmanifest`）+ 兩個 icon route handler 放在**含點路徑**（`app/icon-192.png/route.tsx`、`app/icon-512.png/route.tsx`）以天然避開 next-intl middleware matcher（它排除含 `.` 的路徑）。icon 內容由各站一個本地 render helper 產生（深底 `#11151c` + 淺墨 `#e2e8f1` wordmark）。無 service worker、無離線快取（那是 4b）。不抽跨套件共用 factory（YAGNI；兩站各一份）。
+
+**Tech Stack:** Next 16 App Router / `next/og` ImageResponse / next-intl 4
+
+**Spec:** `docs/superpowers/specs/2026-06-13-workbench-and-web-convergence-design.md` §8（4a）
+
+**範圍：** 僅「可安裝」（manifest + 192/512 icon + iOS apple-touch-icon link）。**不含** service worker / 離線（4b）、maskable icon（follow-up）、manifest 多語系（manifest 用預設 en，非 localized）。
+
+**慣例：** commit subject 小寫開頭（commitlint `subject-case`）。Co-Authored-By 依執行者模型。pre-commit 跑 `turbo run lint-staged test --affected`；瞬時 pnpm "Unexpected end of JSON input" → 重試一次。**worktree 提醒：** 本 plan 在 worktree 執行，若 `@rfjs/*` 解析失敗先 `pnpm build:packages`。
+
+---
+
+### Task 1: apps/web manifest + 生成 icon（建立並驗證 pattern）
+
+**Files:**
+- Create: `apps/web/src/app/manifest.ts`
+- Create: `apps/web/src/app/_pwa/icon.tsx`（本地 render helper，非 route）
+- Create: `apps/web/src/app/icon-192.png/route.tsx`
+- Create: `apps/web/src/app/icon-512.png/route.tsx`
+- Modify: `apps/web/src/app/[locale]/layout.tsx`（metadata 加 apple-touch-icon）
+
+- [ ] **Step 1: icon render helper** `apps/web/src/app/_pwa/icon.tsx`
+
+```tsx
+import { ImageResponse } from "next/og";
+
+// Brand-colored wordmark icon, generated at build (no static asset, no design tool).
+// Dark bedrock background + light signal ink — matches the apps' dark default.
+export function renderWordmarkIcon(size: number) {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          background: "#11151c",
+          color: "#e2e8f1",
+          fontFamily: "monospace",
+          fontWeight: 700,
+          fontSize: Math.round(size * 0.34),
+          letterSpacing: "-0.02em",
+        }}
+      >
+        rfjs
+      </div>
+    ),
+    { width: size, height: size },
+  );
+}
+```
+
+（`_pwa` 前綴底線使其為 Next 的 private folder，不會被當成 route。）
+
+- [ ] **Step 2: 兩個 icon route**
+
+`apps/web/src/app/icon-192.png/route.tsx`
+```tsx
+import { renderWordmarkIcon } from "../_pwa/icon";
+
+export const dynamic = "force-static";
+
+export function GET() {
+  return renderWordmarkIcon(192);
+}
+```
+
+`apps/web/src/app/icon-512.png/route.tsx`
+```tsx
+import { renderWordmarkIcon } from "../_pwa/icon";
+
+export const dynamic = "force-static";
+
+export function GET() {
+  return renderWordmarkIcon(512);
+}
+```
+
+- [ ] **Step 3: `apps/web/src/app/manifest.ts`**
+
+```ts
+import type { MetadataRoute } from "next";
+
+export const dynamic = "force-static";
+
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: "rfjs — TypeScript utility toolkit",
+    short_name: "rfjs",
+    description:
+      "Utilities and developer data tools for JSON, objects, filters, and query workflows.",
+    start_url: "/",
+    display: "standalone",
+    background_color: "#11151c",
+    theme_color: "#11151c",
+    icons: [
+      { src: "/icon-192.png", sizes: "192x192", type: "image/png" },
+      { src: "/icon-512.png", sizes: "512x512", type: "image/png" },
+    ],
+  };
+}
+```
+
+- [ ] **Step 4: layout 加 apple-touch-icon** — `apps/web/src/app/[locale]/layout.tsx` 的 `metadata` 物件加 `icons`：
+
+```tsx
+export const metadata: Metadata = {
+  title: "rfjs — RoyFW's TypeScript utility toolkit",
+  description:
+    "Utilities, playgrounds, and developer data tools for JSON, objects, filters, and query workflows.",
+  icons: { apple: "/icon-192.png" },
+};
+```
+
+（其餘 layout 不動。）
+
+- [ ] **Step 5: build + 驗證 served URL 與 middleware 不攔截**
+
+```bash
+pnpm -F web build
+pnpm -F web start --port 3022 &   # 等 ~3s
+sleep 4
+curl -s -o /dev/null -w "manifest: %{http_code} %{content_type}\n" http://localhost:3022/manifest.webmanifest
+curl -s -o /dev/null -w "icon192: %{http_code} %{content_type}\n" http://localhost:3022/icon-192.png
+curl -s -o /dev/null -w "icon512: %{http_code} %{content_type}\n" http://localhost:3022/icon-512.png
+curl -s http://localhost:3022/manifest.webmanifest | head -c 400; echo
+# 收掉 server
+kill %1 2>/dev/null
+```
+Expected:
+- manifest: `200 application/manifest+json`（或 `application/json`），JSON 含 name/icons
+- icon192/icon512: `200 image/png`
+- **若 icon route 回 200 但被本地化重導（content_type 變 text/html 或 30x）**，代表 middleware 攔到了。退而修 `apps/web/src/middleware.ts` matcher，把 icon 路徑加入排除：
+  ```ts
+  matcher: "/((?!api|_next|_vercel|icon-|manifest|.*\\..*).*)",
+  ```
+  （含點路徑本應已被 `.*\\..*` 排除；此為保險。重 build 再驗一次。）在報告中註明是否需要此修正。
+
+- [ ] **Step 6: lint/types**
+
+```bash
+pnpm -F web check-types && pnpm -F web lint
+```
+Expected: 綠。
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web/src/app/manifest.ts apps/web/src/app/_pwa apps/web/src/app/icon-192.png apps/web/src/app/icon-512.png "apps/web/src/app/[locale]/layout.tsx"
+# 若改了 middleware：git add apps/web/src/middleware.ts
+git commit -m "$(cat <<'EOF'
+feat(web): add PWA manifest and generated app icons (installable)
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+（瞬時 pnpm hook 錯 → 重試一次。）
+
+## 報告
+Status；served URL 驗證結果（manifest/icon 的 code + content_type）；是否需要 middleware 修正；files；commit SHA；self-review；concerns。
+
+---
+
+### Task 2: apps/workbench manifest + 生成 icon（鏡像 web 已驗證的 pattern）
+
+**Files:**
+- Create: `apps/workbench/src/app/manifest.ts`
+- Create: `apps/workbench/src/app/_pwa/icon.tsx`
+- Create: `apps/workbench/src/app/icon-192.png/route.tsx`
+- Create: `apps/workbench/src/app/icon-512.png/route.tsx`
+- Modify: `apps/workbench/src/app/[locale]/layout.tsx`
+
+- [ ] **Step 1: icon render helper** `apps/workbench/src/app/_pwa/icon.tsx`
+
+與 web 的 `_pwa/icon.tsx` **內容相同**（深底 wordmark "rfjs"）。逐字複製 Task 1 Step 1 的 `renderWordmarkIcon`。
+
+- [ ] **Step 2: 兩個 icon route**（與 web 相同）
+
+`apps/workbench/src/app/icon-192.png/route.tsx` 與 `icon-512.png/route.tsx` —— 內容與 Task 1 Step 2 完全相同（`import { renderWordmarkIcon } from "../_pwa/icon"`、`force-static`、`GET` 回對應尺寸）。
+
+- [ ] **Step 3: `apps/workbench/src/app/manifest.ts`**
+
+```ts
+import type { MetadataRoute } from "next";
+
+export const dynamic = "force-static";
+
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: "rfjs workbench",
+    short_name: "workbench",
+    description: "Dataset-driven workbench composing the @rfjs packages.",
+    start_url: "/",
+    display: "standalone",
+    background_color: "#11151c",
+    theme_color: "#11151c",
+    icons: [
+      { src: "/icon-192.png", sizes: "192x192", type: "image/png" },
+      { src: "/icon-512.png", sizes: "512x512", type: "image/png" },
+    ],
+  };
+}
+```
+
+- [ ] **Step 4: layout 加 apple-touch-icon** — `apps/workbench/src/app/[locale]/layout.tsx` 的 `metadata` 加 `icons: { apple: "/icon-192.png" }`（其餘不動）。
+
+- [ ] **Step 5: 若 Task 1 需要 middleware 修正，workbench 比照修** `apps/workbench/src/middleware.ts`（同樣的 matcher）。否則跳過。
+
+- [ ] **Step 6: build + 驗證**
+
+```bash
+pnpm -F workbench build
+pnpm -F workbench start --port 3023 &
+sleep 4
+curl -s -o /dev/null -w "manifest: %{http_code} %{content_type}\n" http://localhost:3023/manifest.webmanifest
+curl -s -o /dev/null -w "icon192: %{http_code} %{content_type}\n" http://localhost:3023/icon-192.png
+curl -s http://localhost:3023/manifest.webmanifest | head -c 300; echo
+kill %1 2>/dev/null
+pnpm -F workbench check-types && pnpm -F workbench lint
+```
+Expected: manifest 200 + JSON（name "rfjs workbench"）；icon 200 image/png；types/lint 綠。
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/workbench/src/app/manifest.ts apps/workbench/src/app/_pwa apps/workbench/src/app/icon-192.png apps/workbench/src/app/icon-512.png "apps/workbench/src/app/[locale]/layout.tsx"
+git commit -m "$(cat <<'EOF'
+feat(workbench): add PWA manifest and generated app icons (installable)
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+## 報告
+Status；workbench manifest/icon 驗證；middleware 是否需改；files；commit SHA；self-review；concerns。
+
+---
+
+### Task 3: 雙站驗證（含真實瀏覽器 installability）+ README
+
+**Files:**
+- Modify: `apps/web/README.md`、`apps/workbench/README.md`
+
+- [ ] **Step 1: 全 sweep**
+
+```bash
+pnpm -F web check-types && pnpm -F web lint && pnpm -F web test && pnpm -F web build
+pnpm -F workbench check-types && pnpm -F workbench lint && pnpm -F workbench test && pnpm -F workbench build
+```
+Expected: 全綠（PWA 變更不影響既有測試）。
+
+- [ ] **Step 2: 真實瀏覽器 installability 驗證**（環境有 Playwright chromium）
+
+啟 `pnpm -F web start --port 3022 &`（sleep 4）。用 chromium（executablePath `/home/royfw/.cache/ms-playwright/chromium-1223/chrome-linux64/chrome`、playwright 於 `/home/royfw/.npm/_npx/9833c18b2d85bc59/node_modules/playwright/index.js`）對 `http://localhost:3022/en`：
+- 確認頁面 `<link rel="manifest">` 存在且 href 指向 `/manifest.webmanifest`
+- fetch `/manifest.webmanifest` → 解析 JSON，斷言 `name`、`display==="standalone"`、`icons` 有 192 與 512、`start_url`
+- fetch `/icon-192.png` 與 `/icon-512.png` → 確認 200 且 `content-type: image/png`、body 非空
+- 收掉 server。workbench 同樣方式對 port 3023 驗一輪（name 為 "rfjs workbench"）。
+若無法跑瀏覽器，至少以 curl 完成上述 fetch 斷言，並註明 manual install-prompt 確認 pending。
+
+- [ ] **Step 3: README**（兩站）— 各加一行說明已是可安裝 PWA（manifest + 生成 icon），離線 SW 為後續（4b）。僅加相關行。
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/README.md apps/workbench/README.md
+git commit -m "$(cat <<'EOF'
+docs(web,workbench): note installable PWA (manifest + icons); offline SW deferred
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+## 報告
+Status；雙站 sweep + 瀏覽器/curl 驗證結果（manifest 欄位、icon content-type）；files；commit SHA；concerns。
+
+---
+
+## Self-Review 紀錄
+
+- **Spec §8 4a 覆蓋**：兩站 manifest（Task1/2）✓、生成 icon 192/512（Task1/2）✓、dark `#11151c` 底色 ✓、可安裝不需 SW ✓、各自一份不抽 factory ✓、apple-touch-icon（iOS）✓。4b（SW/離線）明確不在範圍 ✓。
+- **Placeholder 掃描**：每步有完整程式碼；middleware 修正附確切 matcher，非「視情況處理」。
+- **型別/名稱一致**：`renderWordmarkIcon(size)`（Task1 定義、icon routes 與 workbench 共用同簽名）；manifest icon `src` `/icon-192.png`/`/icon-512.png` 與 route 路徑一致；`force-static` 一致。
+- **依賴順序**：Task 1 先（建立並實測 pattern + 決定 middleware 是否要改）→ Task 2 鏡像（沿用 Task 1 的 middleware 決定）→ Task 3 雙站驗證。
+- **關鍵風險已設防**：next-intl matcher × 含點 icon 路徑（Task 1 Step 5 實測 + 確切退路 matcher）。`next/og` ImageResponse 為 Next 16 內建（無新依賴）；`_pwa` 底線資料夾不被當 route。

--- a/docs/superpowers/specs/2026-06-13-workbench-and-web-convergence-design.md
+++ b/docs/superpowers/specs/2026-06-13-workbench-and-web-convergence-design.md
@@ -89,13 +89,20 @@ interface Session {
 - **v3**：better-auth 多 provider（email、Google、Microsoft Entra ID）。session shape 不變、元件零改動。Auth0 與直連 provider 二選一（聚合器），不混用。
 - **授權歸屬**：角色永遠存自己的層（v2 = JWT claim，v3 = 自有 DB），IdP 只管身份；帳號歸戶錨點 email。
 
-## 8. PWA（雙站）
+## 8. PWA（雙站，兩步法 — 2026-06-14 修訂）
 
-- 工具：`@serwist/next` + Next 內建 `app/manifest.ts`。dev mode 停用 SW。
-- **apps/web**：static assets precache + 造訪頁 runtime cache；快速工具為純 client 函式 → **離線直接可用**。
-- **apps/workbench**：離線優先 — app shell 全 precache；應用純函式 + dataset 在 IndexedDB + 公開區不經 auth middleware → 斷網全功能。
-- 注意：兩個 locale 的 shell 都要 precache；`/admin`（v2 起）離線以 client-side RoleGuard fallback。
-- PWA 設定模式兩站共用，可抽 factory。
+PWA 拆兩步交付，先低風險的「可安裝」、再延後「離線」：
+
+**4a — 可安裝（本輪 Phase 4）**
+- 兩站各加 Next 16 原生 `app/manifest.ts`：`name`/`short_name`（web=`rfjs`、workbench=`workbench`）/`description`/`display: standalone`/`start_url: /`/`theme_color` + `background_color` = dark 預設底色 `#11151c`（避免安裝後 splash 閃白）/`icons`（192 + 512）。
+- icon 用 Next `ImageResponse` 從「rfjs」wordmark + 品牌色程式生成（深底 `#11151c` + 淺墨 `#e2e8f1`），無靜態資產、無設計工具。
+- 不抽共用 factory：兩站各一份 `manifest.ts` + icon route（設定面小、名稱本就不同，YAGNI）。品牌 hex 集中常數引用，避免 theme_color 與 icon 底色不同步。
+- 現代 Chromium/Edge 已放寬安裝門檻：manifest + 192/512 icons + standalone + start_url 即可安裝（iOS Safari 靠 manifest + apple-touch-icon 加到主畫面）。**不需要 service worker 即可安裝。**
+
+**4b — 離線 service worker（延後）**
+- Serwist 選型未定：`@serwist/turbopack`（pin 9.5.11，Turbopack 原生，但套件較新、env 需 workaround）vs `@serwist/next` + build `--webpack`（成熟，但放棄 Turbopack build、形成工具分裂）。等 turbopack 套件更成熟、或 Phase 5 workbench dataset 真正需要離線時再定。
+- 屆時策略：apps/web 快速工具為純 client 函式 → 離線直接可用；apps/workbench 離線優先（dataset 在 IndexedDB）。兩 locale 的 shell 都要 precache；`/admin` 離線以 client-side RoleGuard fallback。
+- subdomain 部署（§12）已讓兩站各有乾淨的 SW scope，4b 落地無 scope 衝突。
 
 ## 9. Registry 擴充（@rfjs/web-core）
 
@@ -139,8 +146,8 @@ interface Session {
 
 1. **Phase 1 — workbench 骨架**（✅ 已完成，#140/#141）：app scaffold（Next 16 + turbo 接線）、admin shell（sidebar / topbar / ⌘K）、i18n + 主題、四路由區空殼（dashboard / datasets / apps / admin 預留）、registry `surface` 擴充。
 2. **Phase 2 — web 收斂**（✅ 已完成，#143）：§3 的 1/2/4/5/6（sidebar、index 連結、redirect、套件頁補實）。
-3. **Phase 3 — web 快速工具**（下一個）：共用工具版型（§10）+ 第一批 type-converter、object-flatten；第二批 data-filter-tester、兩個 query generator 接續。
-4. **Phase 4 — PWA**：兩站接 Serwist。
+3. **Phase 3 — web 快速工具**：共用工具版型（§10）+ 第一批 type-converter、object-flatten（✅ batch 1 完成，#148）；第二批 data-filter-tester、兩個 query generator 待做。
+4. **Phase 4 — PWA**（§8 兩步法）：**4a 可安裝**（manifest + 生成 icon，兩站，本輪）；**4b 離線 SW**（Serwist，延後至套件成熟或 Phase 5 需要）。
 5. **Phase 5 — workbench datasets + data-filter-builder**：招牌動線（dataset → 篩選 → query 輸出）。
 6. **Phase 6 — demo auth（v2）**：登入頁 + @rfjs/jwt session + `/admin` 區 + jwt sign/verify 升級 + **jwt-decoder 工具**（§10，需 route handler）。
 7. **Phase 7+（不排程）**：better-auth 多 provider、pg-toolkit 沙箱 demo、index 分組。


### PR DESCRIPTION
## Summary

Phase 4a: makes both `apps/web` and `apps/workbench` **installable PWAs** — native `app/manifest.ts` + app icons generated at build with `next/og` `ImageResponse`. No service worker / offline caching (that's 4b, deferred — see below).

### What changed (each app)
- **`app/manifest.ts`** → served at `/manifest.webmanifest`: name/short_name/description, `display: standalone`, `start_url: /`, dark `#11151c` theme + background (matches the apps' dark default, no install-splash flash), icons 192 + 512.
- **Generated icons** — `app/icon-192.png/route.tsx` + `app/icon-512.png/route.tsx` render the "rfjs" wordmark via `ImageResponse` (dark bg + light ink). They live at **dotted route paths** so they bypass the next-intl middleware matcher (`/((?!…|.*\.​.*).*)`) natively — **no middleware change needed**.
- **apple-touch-icon** — `icons: { apple: "/icon-192.png" }` added to each layout's metadata (iOS add-to-home).
- web and workbench icon helper + routes are byte-identical; only the manifest name/short_name/description differ.

Modern Chromium/Edge install with manifest + 192/512 icons + standalone alone (the old "must have a SW" criterion was relaxed); iOS Safari add-to-home reads the manifest + apple-touch-icon.

## Test plan
- [x] `pnpm install --frozen-lockfile` clean; both apps `check-types`/`lint`/`test`/`build` green (web 18, workbench 2)
- [x] Build prerenders `/manifest.webmanifest` + `/icon-{192,512}.png` as static in both apps
- [x] Real headless Chromium on both sites: `<link rel="manifest">` present, manifest fetched 200 `application/manifest+json` with correct name/display/start_url/icons, both icons 200 `image/png`, apple-touch-icon link present

## Out of scope / follow-ups
- **4b offline service worker (Serwist)** — deferred; `@serwist/turbopack` 9.5.11 vs `@serwist/next`+`--webpack` decision left until the package matures or Phase 5 datasets need offline (spec §8).
- Satori (the ImageResponse renderer) has no system fonts, so `fontFamily: "monospace"` falls back to its default sans — icons are valid/installable but the wordmark isn't true monospace. Optional follow-up: load a mono font buffer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)