### PR TITLE
fix(web): stop overlapping seam badge (ToolShell + homepage hero)

### DIFF
--- a/apps/web/src/components/home/hero-specimen.tsx
+++ b/apps/web/src/components/home/hero-specimen.tsx
@@ -1,5 +1,3 @@
-import { Seam } from "@rfjs/web-ui/components/seam";
-
 const INPUT = `{
   "user": {
     "name": "Ada",
@@ -71,20 +69,6 @@ export function HeroSpecimen() {
           code={INPUT}
           status="4 nested keys"
         />
-        <div className="flex shrink-0 items-center justify-center py-1 lg:px-1 lg:py-0">
-          <Seam
-            state="current"
-            operation="flatten()"
-            orientation="horizontal"
-            className="lg:hidden"
-          />
-          <Seam
-            state="current"
-            operation="flatten()"
-            orientation="vertical"
-            className="hidden lg:flex"
-          />
-        </div>
         <SpecimenPane
           tone="yield"
           direction="after"

--- a/apps/web/src/components/tools/tool-shell.tsx
+++ b/apps/web/src/components/tools/tool-shell.tsx
@@ -1,6 +1,8 @@
-import { Seam } from "@rfjs/web-ui/components/seam";
 import type { ReactNode } from "react";
 
+// Operation label sits as a centered chip ABOVE the panes (Seam badge
+// vocabulary: "▸ op" mono), not floating between them — a between-panes badge
+// is wider than the gutter and overlaps the panels' inner edges/content.
 export function ToolShell({
   operation,
   input,
@@ -11,13 +13,16 @@ export function ToolShell({
   output: ReactNode;
 }) {
   return (
-    <div className="flex flex-col items-stretch gap-3 lg:flex-row">
-      <div className="min-w-0 flex-1">{input}</div>
-      <div className="flex shrink-0 items-center justify-center py-1 lg:px-1 lg:py-0">
-        <Seam state="current" operation={operation} orientation="horizontal" className="lg:hidden" />
-        <Seam state="current" operation={operation} orientation="vertical" className="hidden lg:flex" />
+    <div className="flex flex-col gap-3">
+      <div className="flex justify-center">
+        <span className="rounded-sm border border-border bg-slab px-1.5 py-0.5 font-mono text-[10px] leading-none text-signal/65">
+          ▸ {operation}
+        </span>
       </div>
-      <div className="min-w-0 flex-1">{output}</div>
+      <div className="flex flex-col items-stretch gap-3 lg:flex-row">
+        <div className="min-w-0 flex-1">{input}</div>
+        <div className="min-w-0 flex-1">{output}</div>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

The "▸ op" Seam badge floated vertically-centered in the thin (1px) gutter **between** two side-by-side panes; being wider than the gutter it overflowed onto the panels' inner borders/content. This happened in two places — fixed both:

- **`ToolShell`** (quick-tool pages, e.g. type-converter / object-flatten): operation label moved to a **centered chip above the panes** (same `▸ op` mono badge vocabulary). Panes sit side-by-side (desktop) / stacked (mobile) with no between-panes badge.
- **`hero-specimen`** (homepage before→after showcase): removed the between-panes Seam entirely — the figcaption below already reads "input → flatten() → output — a static specimen of @rfjs/object-utils", so the data-flow narrative is preserved.

The shared `@rfjs/web-ui` `Seam` component is untouched (its other usages — the full-width "explore" divider, the tool-card hover strip, the sidebar active indicator — don't have the between-panes overlap and are unaffected).

## Test plan
- [x] `pnpm -F web check-types && lint && build` — clean
- [x] Real headless Chromium, desktop (1280px) + mobile (390px): ToolShell chip centered above with clean panes; homepage hero panes clean side-by-side / stacked; no overlap, no RWD weirdness

## Notes
Independent of PR #152 (PWA installable) — different files, no conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)