### PR TITLE
chore(web): remove orphaned playground i18n keys

### DIFF
--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -18,8 +18,6 @@
     "showcaseBody": "Every tool is a live demo of an @rfjs/* package.",
     "toolsTitle": "Data Tools",
     "toolsBody": "Flatten, convert, decode — all in your browser.",
-    "playgroundTitle": "Query & Filter Playground",
-    "playgroundBody": "Build filters, compile them to SQL or Mongo.",
     "templatesTitle": "Templates",
     "templatesBody": "Scaffold TypeScript projects with start-ts-by."
   },
@@ -28,8 +26,6 @@
     "packagesDescription": "The @rfjs/* utility toolkit.",
     "toolsTitle": "Tools",
     "toolsDescription": "Developer data tools, each powered by an @rfjs/* package.",
-    "playgroundTitle": "Playground",
-    "playgroundDescription": "Interactive builders for @rfjs/* workflows.",
     "templatesTitle": "Templates",
     "templatesDescription": "start-ts-by project templates.",
     "templatesBody": "Template gallery (sourced from templates/registry.json) arrives in a later phase."
@@ -38,7 +34,6 @@
   "Status": { "ready": "Ready", "preview": "Preview", "planned": "Planned" },
   "Detail": {
     "toolComingSoon": "This tool ships in a later phase.",
-    "playgroundComingSoon": "This playground ships in a later phase.",
     "packageComingSoon": "Package detail and playground arrive in a later phase.",
     "status": "Status: {status}",
     "workbenchBadge": "Workbench ↗",

--- a/apps/web/src/messages/zh-TW.json
+++ b/apps/web/src/messages/zh-TW.json
@@ -18,8 +18,6 @@
     "showcaseBody": "每個工具都是某個 @rfjs/* 套件的即時示範。",
     "toolsTitle": "資料工具",
     "toolsBody": "壓平、轉型、解碼 —— 全在瀏覽器完成。",
-    "playgroundTitle": "查詢與篩選 Playground",
-    "playgroundBody": "組合篩選條件,編譯成 SQL 或 Mongo 查詢。",
     "templatesTitle": "範本",
     "templatesBody": "用 start-ts-by 建立 TypeScript 專案。"
   },
@@ -28,8 +26,6 @@
     "packagesDescription": "@rfjs/* 工具組。",
     "toolsTitle": "工具",
     "toolsDescription": "開發者資料工具,每個都由某個 @rfjs/* 套件驅動。",
-    "playgroundTitle": "Playground",
-    "playgroundDescription": "@rfjs/* 工作流的互動式建構器。",
     "templatesTitle": "範本",
     "templatesDescription": "start-ts-by 專案範本。",
     "templatesBody": "範本藝廊(資料源自 templates/registry.json)會在後續階段推出。"
@@ -38,7 +34,6 @@
   "Status": { "ready": "可用", "preview": "預覽", "planned": "規劃中" },
   "Detail": {
     "toolComingSoon": "此工具會在後續階段推出。",
-    "playgroundComingSoon": "此 playground 會在後續階段推出。",
     "packageComingSoon": "套件詳情與 playground 會在後續階段推出。",
     "status": "狀態:{status}",
     "workbenchBadge": "Workbench ↗",


### PR DESCRIPTION
## Summary

Removes 5 i18n keys per locale that became unreferenced after the Phase 2 web convergence — the `/playground` route now just `redirect()`s to `/tools`, so its copy is dead:

- `Features.playgroundTitle`, `Features.playgroundBody`
- `Pages.playgroundTitle`, `Pages.playgroundDescription`
- `Detail.playgroundComingSoon`

## Why safe
Verified **zero references** across `apps/web`, `@rfjs/web-core`, `@rfjs/web-ui` (exact leaf names + a broad `playground` text sweep). The coming-soon playground *tools* (`data-filter-builder`, `object-transformer`) remain in the registry and render `Detail.toolComingSoon` — not `playgroundComingSoon` — so they're untouched. `Tools.*` and `Home.tagline`/`layout` prose that merely mention "playground" are left as-is.

## Test plan
- [x] Both locales valid JSON, **90 keys each, KEYS-MATCH** ✓
- [x] No `playground(Title|Body|Description|ComingSoon)` keys remain
- [x] `turbo build --filter=web...` → 7/7, all 12 tool routes SSG ×2 locales
- [x] pre-commit hook (`lint-staged test --affected`) passed

Independent of #155 (toolchain) — different files, both merge cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)