### PR TITLE
chore(web-ui): unify quote style and relative intra-package imports

### DIFF
--- a/packages/web-ui/src/components/button.tsx
+++ b/packages/web-ui/src/components/button.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { cva, type VariantProps } from 'class-variance-authority';
 import { Slot } from 'radix-ui';
 
-import { cn } from '@rfjs/web-ui/lib/utils';
+import { cn } from '../lib/utils';
 
 const buttonVariants = cva(
   "inline-flex shrink-0 items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",

--- a/packages/web-ui/src/components/copy-button.spec.tsx
+++ b/packages/web-ui/src/components/copy-button.spec.tsx
@@ -1,22 +1,26 @@
-import { render, screen, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { CopyButton } from "./copy-button";
+import { CopyButton } from './copy-button';
 
-describe("CopyButton", () => {
+describe('CopyButton', () => {
   beforeEach(() => {
-    Object.assign(navigator, { clipboard: { writeText: vi.fn().mockResolvedValue(undefined) } });
+    Object.assign(navigator, {
+      clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
   });
 
-  it("writes the given text to the clipboard on click", async () => {
+  it('writes the given text to the clipboard on click', async () => {
     const { container } = render(<CopyButton text="hello" label="Copy SQL" />);
-    container.querySelector("button")!.click();
-    await waitFor(() => expect(navigator.clipboard.writeText).toHaveBeenCalledWith("hello"));
+    container.querySelector('button')!.click();
+    await waitFor(() =>
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith('hello'),
+    );
   });
 
-  it("shows a copied state after clicking", async () => {
+  it('shows a copied state after clicking', async () => {
     const { container } = render(<CopyButton text="hello" label="Copy SQL" />);
-    container.querySelector("button")!.click();
+    container.querySelector('button')!.click();
     await waitFor(() => expect(screen.getByText(/copied/i)).toBeDefined());
   });
 });

--- a/packages/web-ui/src/components/copy-button.tsx
+++ b/packages/web-ui/src/components/copy-button.tsx
@@ -1,9 +1,9 @@
-"use client";
+'use client';
 
-import { Check, Copy } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { Check, Copy } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
 
-import { Button } from "./button";
+import { Button } from './button';
 
 export interface CopyButtonProps {
   text: string;
@@ -11,13 +11,16 @@ export interface CopyButtonProps {
   className?: string;
 }
 
-export function CopyButton({ text, label = "Copy", className }: CopyButtonProps) {
+export function CopyButton({ text, label = 'Copy', className }: CopyButtonProps) {
   const [copied, setCopied] = useState(false);
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  useEffect(() => () => {
-    if (timer.current) clearTimeout(timer.current);
-  }, []);
+  useEffect(
+    () => () => {
+      if (timer.current) clearTimeout(timer.current);
+    },
+    [],
+  );
 
   async function onCopy() {
     try {
@@ -31,9 +34,15 @@ export function CopyButton({ text, label = "Copy", className }: CopyButtonProps)
   }
 
   return (
-    <Button variant="outline" size="sm" className={className} onClick={onCopy} aria-live="polite">
+    <Button
+      variant="outline"
+      size="sm"
+      className={className}
+      onClick={onCopy}
+      aria-live="polite"
+    >
       {copied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
-      {copied ? "Copied" : label}
+      {copied ? 'Copied' : label}
     </Button>
   );
 }

--- a/packages/web-ui/src/components/dropdown-menu.tsx
+++ b/packages/web-ui/src/components/dropdown-menu.tsx
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import { DropdownMenu as DropdownMenuPrimitive } from 'radix-ui';
 
-import { cn } from '@rfjs/web-ui/lib/utils';
+import { cn } from '../lib/utils';
 
 function DropdownMenu(props: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
   return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {...props} />;

--- a/packages/web-ui/src/components/panel.spec.tsx
+++ b/packages/web-ui/src/components/panel.spec.tsx
@@ -1,33 +1,33 @@
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
 
-import { Panel } from "./panel";
+import { Panel } from './panel';
 
-describe("Panel", () => {
-  it("renders the title and children", () => {
+describe('Panel', () => {
+  it('renders the title and children', () => {
     render(<Panel title="Datasets">3 samples</Panel>);
-    expect(screen.getByRole("heading", { name: "Datasets" })).toBeDefined();
-    expect(screen.getByText("3 samples")).toBeDefined();
+    expect(screen.getByRole('heading', { name: 'Datasets' })).toBeDefined();
+    expect(screen.getByText('3 samples')).toBeDefined();
   });
 
-  it("omits the heading when no title is given", () => {
+  it('omits the heading when no title is given', () => {
     render(<Panel>body only</Panel>);
-    expect(screen.queryByRole("heading")).toBeNull();
+    expect(screen.queryByRole('heading')).toBeNull();
   });
 
-  it("renders an action in the header", () => {
+  it('renders an action in the header', () => {
     render(
       <Panel title="Output" action={<button>copy</button>}>
         body
       </Panel>,
     );
-    expect(screen.getByRole("button", { name: "copy" })).toBeDefined();
-    expect(screen.getByRole("heading", { name: "Output" })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'copy' })).toBeDefined();
+    expect(screen.getByRole('heading', { name: 'Output' })).toBeDefined();
   });
 
-  it("renders the action even with no title, and still no heading", () => {
+  it('renders the action even with no title, and still no heading', () => {
     render(<Panel action={<button>copy</button>}>body</Panel>);
-    expect(screen.getByRole("button", { name: "copy" })).toBeDefined();
-    expect(screen.queryByRole("heading")).toBeNull();
+    expect(screen.getByRole('button', { name: 'copy' })).toBeDefined();
+    expect(screen.queryByRole('heading')).toBeNull();
   });
 });

--- a/packages/web-ui/src/components/panel.tsx
+++ b/packages/web-ui/src/components/panel.tsx
@@ -1,6 +1,6 @@
-import type { ReactNode } from "react";
+import type { ReactNode } from 'react';
 
-import { cn } from "../lib/utils";
+import { cn } from '../lib/utils';
 
 export interface PanelProps {
   title?: string;
@@ -12,7 +12,7 @@ export interface PanelProps {
 export function Panel({ title, action, children, className }: PanelProps) {
   const hasHeader = Boolean(title) || Boolean(action);
   return (
-    <section className={cn("rounded-lg border bg-card text-card-foreground", className)}>
+    <section className={cn('rounded-lg border bg-card text-card-foreground', className)}>
       {hasHeader ? (
         <div className="flex items-center justify-between gap-2 border-b px-4 py-3">
           {title ? (

--- a/packages/web-ui/src/components/seam.spec.tsx
+++ b/packages/web-ui/src/components/seam.spec.tsx
@@ -1,25 +1,25 @@
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
 
-import { Seam } from "./seam";
+import { Seam } from './seam';
 
-describe("Seam", () => {
-  it("renders the operation label in a chip", () => {
+describe('Seam', () => {
+  it('renders the operation label in a chip', () => {
     render(<Seam state="current" operation="flatten()" />);
     expect(screen.getByText(/flatten\(\)/)).toBeDefined();
   });
 
-  it("exposes state via data-state for style + tests (not color alone)", () => {
+  it('exposes state via data-state for style + tests (not color alone)', () => {
     const { container } = render(<Seam state="stale" operation="flatten()" />);
     expect(container.querySelector('[data-state="stale"]')).not.toBeNull();
   });
 
-  it("shows an ERR chip when state is error", () => {
+  it('shows an ERR chip when state is error', () => {
     render(<Seam state="error" operation="flatten()" />);
-    expect(screen.getByText("ERR")).toBeDefined();
+    expect(screen.getByText('ERR')).toBeDefined();
   });
 
-  it("marks the decorative rule aria-hidden", () => {
+  it('marks the decorative rule aria-hidden', () => {
     const { container } = render(<Seam state="current" operation="flatten()" />);
     expect(container.querySelector('[aria-hidden="true"]')).not.toBeNull();
   });

--- a/packages/web-ui/src/components/seam.tsx
+++ b/packages/web-ui/src/components/seam.tsx
@@ -1,49 +1,54 @@
-import { cn } from "../lib/utils";
+import { cn } from '../lib/utils';
 
-export type SeamState = "current" | "stale" | "running" | "error";
+export type SeamState = 'current' | 'stale' | 'running' | 'error';
 
 export interface SeamProps {
   state: SeamState;
   operation: string;
-  orientation?: "vertical" | "horizontal";
+  orientation?: 'vertical' | 'horizontal';
   className?: string;
 }
 
 const lineByState: Record<SeamState, string> = {
-  current: "border-solid opacity-100",
-  stale: "border-dashed opacity-70",
-  running: "border-solid opacity-100 motion-safe:animate-pulse",
-  error: "border-dotted opacity-80",
+  current: 'border-solid opacity-100',
+  stale: 'border-dashed opacity-70',
+  running: 'border-solid opacity-100 motion-safe:animate-pulse',
+  error: 'border-dotted opacity-80',
 };
 
-export function Seam({ state, operation, orientation = "vertical", className }: SeamProps) {
-  const isError = state === "error";
+export function Seam({
+  state,
+  operation,
+  orientation = 'vertical',
+  className,
+}: SeamProps) {
+  const isError = state === 'error';
   return (
     <div
       data-state={state}
       className={cn(
-        "relative flex items-center justify-center",
-        orientation === "vertical" ? "h-full w-px flex-col" : "h-px w-full flex-row",
+        'relative flex items-center justify-center',
+        orientation === 'vertical' ? 'h-full w-px flex-col' : 'h-px w-full flex-row',
         className,
       )}
     >
       <span
         aria-hidden="true"
         className={cn(
-          "absolute inset-0 border-0 bg-gradient-to-b from-intake to-yield",
-          orientation === "vertical" ? "w-px border-l" : "h-px border-t bg-gradient-to-r",
+          'absolute inset-0 border-0 bg-gradient-to-b from-intake to-yield',
+          orientation === 'vertical' ? 'w-px border-l' : 'h-px border-t bg-gradient-to-r',
           lineByState[state],
         )}
       />
       <span
         className={cn(
-          "relative z-10 rounded-sm border px-1.5 py-0.5 font-mono text-[10px] leading-none",
+          'relative z-10 rounded-sm border px-1.5 py-0.5 font-mono text-[10px] leading-none',
           isError
-            ? "border-dashed border-fault bg-bedrock text-fault"
-            : "border-border bg-slab text-signal/65",
+            ? 'border-dashed border-fault bg-bedrock text-fault'
+            : 'border-border bg-slab text-signal/65',
         )}
       >
-        {isError ? "ERR" : `▸ ${operation}`}
+        {isError ? 'ERR' : `▸ ${operation}`}
       </span>
     </div>
   );

--- a/packages/web-ui/src/components/theme-toggle.tsx
+++ b/packages/web-ui/src/components/theme-toggle.tsx
@@ -1,23 +1,25 @@
-"use client";
+'use client';
 
-import { Moon, Sun } from "lucide-react";
-import { useTheme } from "next-themes";
-import { useEffect, useState } from "react";
+import { Moon, Sun } from 'lucide-react';
+import { useTheme } from 'next-themes';
+import { useEffect, useState } from 'react';
 
-import { Button } from "./button";
+import { Button } from './button';
 
 export function ThemeToggle() {
   const { resolvedTheme, setTheme } = useTheme();
   const [mounted, setMounted] = useState(false);
   useEffect(() => setMounted(true), []);
 
-  const isDark = resolvedTheme === "dark";
+  const isDark = resolvedTheme === 'dark';
   return (
     <Button
       variant="ghost"
       size="icon"
-      aria-label={mounted ? `Switch to ${isDark ? "light" : "dark"} theme` : "Toggle theme"}
-      onClick={() => setTheme(isDark ? "light" : "dark")}
+      aria-label={
+        mounted ? `Switch to ${isDark ? 'light' : 'dark'} theme` : 'Toggle theme'
+      }
+      onClick={() => setTheme(isDark ? 'light' : 'dark')}
     >
       {mounted && isDark ? <Sun className="size-4" /> : <Moon className="size-4" />}
     </Button>


### PR DESCRIPTION
## Summary

web-ui's `.prettierrc` already sets `singleQuote: true`, but several components predated it and kept double quotes (copy-button, panel, seam, theme-toggle + their specs). This brings the whole package into compliance with its own prettier config, plus two import-style fixes:

- `prettier --write packages/web-ui/src/**/*.{ts,tsx}` → double→single quotes + minor JSX reflow
- `button.tsx` / `dropdown-menu.tsx`: self-referential `@rfjs/web-ui/lib/utils` → relative `../lib/utils` (the convention the rest of the package already uses, e.g. `seam.tsx`, `panel.tsx`)

Formatting-only — no logic changes.

## Test plan
- [x] `check-types` (tsc --noEmit) clean
- [x] `lint` (eslint --max-warnings 0) clean
- [x] `vitest:run` → 10/10 pass
- [x] pre-commit hook (`lint-staged test --affected`) passed (web-ui + web + workbench)
- [x] No remaining double-quote imports or `@rfjs/web-ui/lib` self-imports in the package

Independent of #155 / #156 — different files, merges cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)