### PR TITLE
feat(workbench): backend foundation — libs/db + libs/core + datasets slice

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,3 +1,4 @@
 NODE_ENV=development
 APP_NAME=ts-template
 PORT=3000
+DATABASE_URL="postgresql://user:password@localhost:5432/workbench?options=-csearch_path=workbench"

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -86,6 +86,7 @@
   "dependencies": {
     "@rfjs/core": "workspace:*",
     "@rfjs/db": "workspace:*",
+    "zod": "^4.0.0",
     "@fastify/cors": "^11.1.0",
     "@fastify/formbody": "^8.0.2",
     "@fastify/multipart": "^9.3.0",

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -84,6 +84,8 @@
     "vitest": "^3.2.3"
   },
   "dependencies": {
+    "@rfjs/core": "workspace:*",
+    "@rfjs/db": "workspace:*",
     "@fastify/cors": "^11.1.0",
     "@fastify/formbody": "^8.0.2",
     "@fastify/multipart": "^9.3.0",

--- a/apps/api/src/configs.ts
+++ b/apps/api/src/configs.ts
@@ -20,6 +20,7 @@ export interface AppConfig {
   host: string;
   port: number;
   tz?: string;
+  databaseUrl: string;
 }
 
 // 類型安全的配置物件
@@ -31,6 +32,9 @@ const configs: AppConfig = {
   host: process.env.HOST || '0.0.0.0',
   port: parseInt(process.env.PORT || '3000', 10),
   tz: process.env.TZ,
+  databaseUrl:
+    process.env.DATABASE_URL ||
+    'postgresql://user:password@localhost:5432/workbench?options=-csearch_path=workbench',
 };
 
 export { configs };

--- a/apps/api/src/delivery/http/dataset/dataset.route.spec.ts
+++ b/apps/api/src/delivery/http/dataset/dataset.route.spec.ts
@@ -3,9 +3,31 @@ import type { FastifyInstance } from 'fastify';
 
 vi.mock('@/infrastructures/datasource', () => ({
   datasetUsecases: {
-    list: vi.fn().mockResolvedValue([{ id: '1', name: 'A', description: null, data: {}, createdAt: new Date(), updatedAt: new Date() }]),
-    get: vi.fn(),
-    create: vi.fn().mockImplementation((input) => Promise.resolve({ id: '2', description: null, data: {}, createdAt: new Date(), updatedAt: new Date(), ...input })),
+    list: vi
+      .fn()
+      .mockResolvedValue([
+        {
+          id: '1',
+          name: 'A',
+          description: null,
+          data: {},
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ]),
+    get: vi.fn().mockResolvedValue(undefined),
+    create: vi
+      .fn()
+      .mockImplementation((input) =>
+        Promise.resolve({
+          id: '2',
+          description: null,
+          data: {},
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          ...input,
+        }),
+      ),
   },
 }));
 
@@ -29,8 +51,35 @@ describe('dataset routes', () => {
   });
 
   it('POST /datasets creates and returns 201', async () => {
-    const res = await app.inject({ method: 'POST', url: '/datasets', payload: { name: 'New' } });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/datasets',
+      payload: { name: 'New' },
+    });
     expect(res.statusCode).toBe(201);
-    expect(res.json().name).toBe('New');
+    expect(res.json<{ name: string }>().name).toBe('New');
+  });
+
+  it('GET /datasets/:id returns 200 when found', async () => {
+    const { datasetUsecases } = await import('@/infrastructures/datasource');
+    const dataset = {
+      id: 'abc',
+      name: 'Found',
+      description: null,
+      data: {},
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    vi.mocked(datasetUsecases.get).mockResolvedValueOnce(dataset);
+    const res = await app.inject({ method: 'GET', url: '/datasets/abc' });
+    expect(res.statusCode).toBe(200);
+    expect(res.json<{ id: string }>().id).toBe('abc');
+  });
+
+  it('GET /datasets/:id returns 404 when not found', async () => {
+    const { datasetUsecases } = await import('@/infrastructures/datasource');
+    vi.mocked(datasetUsecases.get).mockResolvedValueOnce(undefined);
+    const res = await app.inject({ method: 'GET', url: '/datasets/missing' });
+    expect(res.statusCode).toBe(404);
   });
 });

--- a/apps/api/src/delivery/http/dataset/dataset.route.spec.ts
+++ b/apps/api/src/delivery/http/dataset/dataset.route.spec.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+
+vi.mock('@/infrastructures/datasource', () => ({
+  datasetUsecases: {
+    list: vi.fn().mockResolvedValue([{ id: '1', name: 'A', description: null, data: {}, createdAt: new Date(), updatedAt: new Date() }]),
+    get: vi.fn(),
+    create: vi.fn().mockImplementation((input) => Promise.resolve({ id: '2', description: null, data: {}, createdAt: new Date(), updatedAt: new Date(), ...input })),
+  },
+}));
+
+describe('dataset routes', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    const { initializeFastifyApp } = await import('@/infrastructures');
+    const { datasetHttpRouteModule } = await import('./module');
+    app = await initializeFastifyApp({
+      httpRouteModules: [datasetHttpRouteModule],
+      isApiDocEnabled: false,
+    });
+    await app.ready();
+  });
+
+  it('GET /datasets returns the list', async () => {
+    const res = await app.inject({ method: 'GET', url: '/datasets' });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toHaveLength(1);
+  });
+
+  it('POST /datasets creates and returns 201', async () => {
+    const res = await app.inject({ method: 'POST', url: '/datasets', payload: { name: 'New' } });
+    expect(res.statusCode).toBe(201);
+    expect(res.json().name).toBe('New');
+  });
+});

--- a/apps/api/src/delivery/http/dataset/dataset.route.spec.ts
+++ b/apps/api/src/delivery/http/dataset/dataset.route.spec.ts
@@ -1,33 +1,30 @@
 import { describe, it, expect, vi, beforeAll } from 'vitest';
 import type { FastifyInstance } from 'fastify';
+import { CreateDatasetInputSchema } from '@rfjs/core';
 
 vi.mock('@/infrastructures/datasource', () => ({
   datasetUsecases: {
-    list: vi
-      .fn()
-      .mockResolvedValue([
-        {
-          id: '1',
-          name: 'A',
-          description: null,
-          data: {},
-          createdAt: new Date(),
-          updatedAt: new Date(),
-        },
-      ]),
+    list: vi.fn().mockResolvedValue([
+      {
+        id: '1',
+        name: 'A',
+        description: null,
+        data: {},
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ]),
     get: vi.fn().mockResolvedValue(undefined),
-    create: vi
-      .fn()
-      .mockImplementation((input) =>
-        Promise.resolve({
-          id: '2',
-          description: null,
-          data: {},
-          createdAt: new Date(),
-          updatedAt: new Date(),
-          ...input,
-        }),
-      ),
+    create: vi.fn().mockImplementation((input) =>
+      Promise.resolve({
+        id: '2',
+        description: null,
+        data: {},
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        ...input,
+      }),
+    ),
   },
 }));
 
@@ -81,5 +78,15 @@ describe('dataset routes', () => {
     vi.mocked(datasetUsecases.get).mockResolvedValueOnce(undefined);
     const res = await app.inject({ method: 'GET', url: '/datasets/missing' });
     expect(res.statusCode).toBe(404);
+  });
+
+  it('POST /datasets with invalid body returns 400 (ZodError mapped)', async () => {
+    const { datasetUsecases } = await import('@/infrastructures/datasource');
+    vi.mocked(datasetUsecases.create).mockRejectedValueOnce(
+      CreateDatasetInputSchema.safeParse({}).error!,
+    );
+    const res = await app.inject({ method: 'POST', url: '/datasets', payload: {} });
+    expect(res.statusCode).toBe(400);
+    expect(res.json<{ error: string }>().error).toBe('Bad Request');
   });
 });

--- a/apps/api/src/delivery/http/dataset/handlers/dataset.handler.ts
+++ b/apps/api/src/delivery/http/dataset/handlers/dataset.handler.ts
@@ -1,0 +1,18 @@
+import { RouteHandlerMethod } from 'fastify/types/route';
+import { datasetUsecases } from '@/infrastructures/datasource';
+
+export const listDatasetsHandler: RouteHandlerMethod = async (_req, reply) => {
+  reply.send(await datasetUsecases.list());
+};
+
+export const getDatasetHandler: RouteHandlerMethod = async (req, reply) => {
+  const { id } = req.params as { id: string };
+  const found = await datasetUsecases.get(id);
+  if (!found) return reply.notFound(`dataset ${id} not found`);
+  reply.send(found);
+};
+
+export const createDatasetHandler: RouteHandlerMethod = async (req, reply) => {
+  const created = await datasetUsecases.create(req.body);
+  reply.code(201).send(created);
+};

--- a/apps/api/src/delivery/http/dataset/handlers/index.ts
+++ b/apps/api/src/delivery/http/dataset/handlers/index.ts
@@ -1,0 +1,1 @@
+export * from './dataset.handler';

--- a/apps/api/src/delivery/http/dataset/index.ts
+++ b/apps/api/src/delivery/http/dataset/index.ts
@@ -1,0 +1,1 @@
+export * from './module';

--- a/apps/api/src/delivery/http/dataset/module.ts
+++ b/apps/api/src/delivery/http/dataset/module.ts
@@ -1,0 +1,12 @@
+import { FastifyPluginAsync } from 'fastify';
+import { datasetRoutes } from './routes';
+import { HttpRouteModule } from '@/infrastructures';
+import { createPluginFromRoutes } from '@/helpers';
+
+const plugin: FastifyPluginAsync = createPluginFromRoutes(datasetRoutes);
+
+export const datasetHttpRouteModule: HttpRouteModule = {
+  type: 'http',
+  prefix: '/',
+  plugin,
+};

--- a/apps/api/src/delivery/http/dataset/routes.ts
+++ b/apps/api/src/delivery/http/dataset/routes.ts
@@ -1,0 +1,8 @@
+import { RouteOptions } from 'fastify';
+import { listDatasetsHandler, getDatasetHandler, createDatasetHandler } from './handlers';
+
+export const datasetRoutes: RouteOptions[] = [
+  { method: 'GET', url: '/datasets', schema: { tags: ['dataset'] }, handler: listDatasetsHandler },
+  { method: 'GET', url: '/datasets/:id', schema: { tags: ['dataset'] }, handler: getDatasetHandler },
+  { method: 'POST', url: '/datasets', schema: { tags: ['dataset'] }, handler: createDatasetHandler },
+];

--- a/apps/api/src/delivery/http/index.ts
+++ b/apps/api/src/delivery/http/index.ts
@@ -1,2 +1,3 @@
 export * from './app';
+export * from './dataset';
 export * from './health';

--- a/apps/api/src/infrastructures/datasource/index.ts
+++ b/apps/api/src/infrastructures/datasource/index.ts
@@ -1,0 +1,17 @@
+import { createDb } from '@rfjs/db';
+import {
+  makeDatasetRepository,
+  makeListDatasets,
+  makeGetDataset,
+  makeCreateDataset,
+} from '@rfjs/core';
+import { configs } from '@/configs';
+
+const { db } = createDb(configs.databaseUrl);
+const datasetRepository = makeDatasetRepository(db);
+
+export const datasetUsecases = {
+  list: makeListDatasets({ repo: datasetRepository }),
+  get: makeGetDataset({ repo: datasetRepository }),
+  create: makeCreateDataset({ repo: datasetRepository }),
+};

--- a/apps/api/src/infrastructures/fastify/initialize-app.ts
+++ b/apps/api/src/infrastructures/fastify/initialize-app.ts
@@ -1,6 +1,11 @@
 import Fastify, { FastifyInstance, FastifyServerOptions } from 'fastify';
 import { configs } from '@/configs';
-import { registerBasicPlugins, registerMiddlewares, registerApiDocs } from './registers';
+import {
+  registerBasicPlugins,
+  registerMiddlewares,
+  registerApiDocs,
+  registerErrorHandler,
+} from './registers';
 import { FastifyAppOptions, registerHttpRouteModules } from '.';
 import { pinoTransport } from '@/helpers/pino';
 
@@ -24,6 +29,9 @@ export async function initializeFastifyApp(
 
   // 建立 Fastify 實例
   const app = Fastify(fastifyOptions);
+
+  // 註冊全域錯誤處理器
+  registerErrorHandler(app);
 
   // 註冊 API 文件（如果啟用）
   if (isApiDocEnabled) {

--- a/apps/api/src/infrastructures/fastify/registers/index.ts
+++ b/apps/api/src/infrastructures/fastify/registers/index.ts
@@ -2,3 +2,4 @@ export * from './register-api-docs';
 export * from './register-middlewares';
 export * from './register-basic-plugins';
 export * from './register-http-routes';
+export * from './register-error-handler';

--- a/apps/api/src/infrastructures/fastify/registers/register-error-handler.ts
+++ b/apps/api/src/infrastructures/fastify/registers/register-error-handler.ts
@@ -1,0 +1,24 @@
+import { FastifyInstance } from 'fastify';
+import { ZodError } from 'zod';
+
+/**
+ * Maps known error types to HTTP responses. ZodError (validation) -> 400,
+ * without leaking raw internal error details to the client. Everything else
+ * falls through to Fastify's default handling (which honors error.statusCode,
+ * e.g. @fastify/sensible httpErrors, otherwise 500).
+ */
+export function registerErrorHandler(app: FastifyInstance): void {
+  app.setErrorHandler((error, request, reply) => {
+    if (error instanceof ZodError) {
+      request.log.info({ issues: error.issues }, 'request validation failed');
+      return reply.status(400).send({
+        statusCode: 400,
+        error: 'Bad Request',
+        message: 'Request validation failed',
+        issues: error.issues.map((i) => ({ path: i.path, message: i.message })),
+      });
+    }
+    // Preserve default behavior for all other errors.
+    reply.send(error);
+  });
+}

--- a/apps/api/vitest.config.mts
+++ b/apps/api/vitest.config.mts
@@ -16,7 +16,7 @@ export default defineConfig({
       junit: '.test/vitest/results.xml',
     },
     coverage: {
-      enabled: true,
+      enabled: false,
       all: true,
       include: ['src/*'],
       reporter: [

--- a/apps/workbench/.env.example
+++ b/apps/workbench/.env.example
@@ -1,0 +1,1 @@
+API_BASE_URL="http://localhost:3000"

--- a/apps/workbench/src/app/[locale]/(shell)/datasets/page.tsx
+++ b/apps/workbench/src/app/[locale]/(shell)/datasets/page.tsx
@@ -1,6 +1,19 @@
 import { Panel } from "@rfjs/web-ui/components/panel";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 
+type Dataset = { id: string; name: string; description: string | null };
+
+async function fetchDatasets(): Promise<Dataset[]> {
+  const base = process.env.API_BASE_URL ?? "http://localhost:3000";
+  try {
+    const res = await fetch(`${base}/datasets`, { cache: "no-store" });
+    if (!res.ok) return [];
+    return (await res.json()) as Dataset[];
+  } catch {
+    return [];
+  }
+}
+
 export default async function DatasetsPage({
   params,
 }: {
@@ -9,12 +22,28 @@ export default async function DatasetsPage({
   const { locale } = await params;
   setRequestLocale(locale);
   const t = await getTranslations("Pages");
-  const tCommon = await getTranslations("Common");
+  const datasets = await fetchDatasets();
+
   return (
     <div className="flex flex-col gap-4">
       <h1 className="text-xl font-semibold">{t("datasetsTitle")}</h1>
       <p className="text-sm text-muted-foreground">{t("datasetsDescription")}</p>
-      <Panel>{tCommon("comingSoon")}</Panel>
+      <Panel>
+        {datasets.length === 0 ? (
+          <span className="text-sm text-muted-foreground">No datasets yet.</span>
+        ) : (
+          <ul className="flex flex-col gap-2">
+            {datasets.map((d) => (
+              <li key={d.id} className="text-sm">
+                <span className="font-medium">{d.name}</span>
+                {d.description ? (
+                  <span className="text-muted-foreground"> — {d.description}</span>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        )}
+      </Panel>
     </div>
   );
 }

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,14 @@
+services:
+  postgres-test:
+    image: postgres:17-alpine
+    environment:
+      POSTGRES_USER: user
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: postgres
+    ports:
+      - '5433:5432'
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U user']
+      interval: 2s
+      timeout: 5s
+      retries: 10

--- a/docs/superpowers/notes/2026-06-14-workbench-backend-e2e.md
+++ b/docs/superpowers/notes/2026-06-14-workbench-backend-e2e.md
@@ -1,0 +1,240 @@
+# Workbench Backend E2E Run Log
+
+**Date:** 2026-06-14  
+**Task:** Task 13 — end-to-end create→list round-trip  
+**Stack:** real Postgres → @rfjs/db migrate/seed → @rfjs/core → apps/api → apps/workbench  
+**Worktree:** `.claude/worktrees/feat+workbench-backend-foundation`
+
+---
+
+## Step 0: Build libs
+
+```bash
+pnpm --filter @rfjs/db build
+pnpm --filter @rfjs/core build
+```
+
+**Output (@rfjs/db):**
+```
+> @rfjs/db@0.0.0 build
+> pnpm run clean && tsdown --config-loader unrun
+
+ℹ tsdown v0.17.0-beta.6 powered by rolldown v1.0.0-beta.53
+ℹ config file: libs/db/tsdown.config.ts (unrun)
+ℹ entry: src/index.ts
+ℹ Build start
+ℹ [CJS] dist/index.js       7.26 kB │ gzip: 2.25 kB
+ℹ [CJS] dist/index.d.ts     5.17 kB │ gzip: 1.11 kB
+ℹ [ESM] dist/index.mjs      6.36 kB │ gzip: 2.04 kB
+ℹ [ESM] dist/index.d.mts    5.13 kB │ gzip: 1.10 kB
+✔ Build complete in 721ms
+Copied: libs/db/drizzle → dist/drizzle
+```
+
+**Output (@rfjs/core):**
+```
+> @rfjs/core@0.0.0 build
+> pnpm run clean && tsdown --config-loader unrun
+
+ℹ tsdown v0.17.0-beta.6 powered by rolldown v1.0.0-beta.53
+ℹ entry: src/index.ts
+ℹ [CJS] dist/index.js      2.13 kB │ gzip: 0.71 kB
+ℹ [CJS] dist/index.d.ts    1.67 kB │ gzip: 0.53 kB
+ℹ [ESM] dist/index.mjs     1.85 kB │ gzip: 0.67 kB
+ℹ [ESM] dist/index.d.mts   1.68 kB │ gzip: 0.53 kB
+✔ Build complete in 734ms
+```
+
+Both packages built successfully.
+
+---
+
+## Step 1: Bring up Postgres (host port 5433)
+
+```bash
+docker compose -f docker-compose.test.yml up -d
+for i in $(seq 1 20); do
+  docker compose -f docker-compose.test.yml exec -T postgres-test pg_isready -U user && break
+  sleep 1
+done
+```
+
+**Output:**
+```
+Container featworkbench-backend-foundation-postgres-test-1 Started
+
+/var/run/postgresql:5432 - accepting connections
+Postgres ready after 1 attempts
+```
+
+---
+
+## Step 2: Migrate + Seed
+
+```bash
+export DBURL='postgresql://user:password@localhost:5433/workbench?options=-csearch_path=workbench'
+DATABASE_URL="$DBURL" pnpm --filter @rfjs/db migrate
+DATABASE_URL="$DBURL" pnpm --filter @rfjs/db seed
+```
+
+**Migration output:**
+```
+> @rfjs/db@0.0.0 migrate
+> pnpm exec tsx src/scripts/run-migrate.ts
+
+Database "workbench" does not exist. Creating...
+Database "workbench" created successfully.
+Migrations completed.
+```
+
+**Seed output:**
+```
+> @rfjs/db@0.0.0 seed
+> pnpm exec tsx src/scripts/run-seed.ts
+
+Seeded 2 datasets.
+```
+
+---
+
+## Step 3: Start the API (background, DATABASE_URL set)
+
+```bash
+DATABASE_URL='postgresql://user:password@localhost:5433/workbench?options=-csearch_path=workbench' \
+  pnpm --filter api tsx > /tmp/api.log 2>&1 &
+for i in $(seq 1 30); do
+  curl -sf localhost:3000/health && break
+  sleep 1
+done
+```
+
+**Health check response (immediate, attempt 1):**
+```json
+{"status":"ok","timestamp":"2026-06-14T08:05:22.039Z","uptime":4.318064904,"version":"0.0.0","environment":"local"}
+```
+
+**API startup log (tail -20):**
+```
+INFO [2026-14-06T08:05:18.220+0000]: Server listening at http://127.0.0.1:3000
+INFO [2026-14-06T08:05:18.220+0000]: Server listening at http://0.0.0.0:3000
+INFO [2026-14-06T08:05:18.220+0000]: App name: starter-ts-fastify
+INFO [2026-14-06T08:05:18.220+0000]: Environment: local
+INFO [2026-14-06T08:05:22.038+0000]: incoming request {"reqId":"req-1","req":{"method":"GET","url":"/health",...}}
+INFO [2026-14-06T08:05:22.041+0000]: request completed {"reqId":"req-1","res":{"statusCode":200},...}
+server started!
+```
+
+---
+
+## Step 4: Create → List → 404
+
+### POST /datasets
+
+```bash
+curl -s -w "\nHTTP_STATUS:%{http_code}" -X POST localhost:3000/datasets \
+  -H 'content-type: application/json' \
+  -d '{"name":"E2E","data":{"k":1}}'
+```
+
+**Output:**
+```
+{"id":"95bd7b85-23fe-4bc5-8a09-794e90b33729","name":"E2E","description":null,"data":{"k":1},"createdAt":"2026-06-14T08:05:31.312Z","updatedAt":"2026-06-14T08:05:31.312Z"}
+HTTP_STATUS:201
+```
+
+Status: 201 Created. Body contains `"name":"E2E"` and a valid UUID `id`.
+
+### GET /datasets
+
+```bash
+curl -s localhost:3000/datasets
+```
+
+**Output:**
+```json
+[
+  {"id":"c71bb1ec-6357-409c-994b-dbf0289060db","name":"Sales — Q1","description":"Demo seed","data":{"rows":120,"region":"apac"},"createdAt":"2026-06-14T08:05:11.166Z","updatedAt":"2026-06-14T08:05:11.166Z"},
+  {"id":"194359ef-70b2-4f6a-9312-748757379466","name":"Signups","description":"Demo seed","data":{"rows":42,"region":"emea"},"createdAt":"2026-06-14T08:05:11.166Z","updatedAt":"2026-06-14T08:05:11.166Z"},
+  {"id":"95bd7b85-23fe-4bc5-8a09-794e90b33729","name":"E2E","description":null,"data":{"k":1},"createdAt":"2026-06-14T08:05:31.312Z","updatedAt":"2026-06-14T08:05:31.312Z"}
+]
+```
+
+Returns all 3 rows: 2 seeded ("Sales — Q1", "Signups") + 1 created ("E2E").
+
+### GET /datasets/:id (bogus UUID — 404)
+
+```bash
+curl -s -o /dev/null -w "%{http_code}" localhost:3000/datasets/00000000-0000-0000-0000-000000000000
+```
+
+**Output:**
+```
+404
+```
+
+---
+
+## Step 5: Workbench page server-rendered HTML
+
+```bash
+API_BASE_URL=http://localhost:3000 pnpm --filter workbench dev > /tmp/wb.log 2>&1 &
+for i in $(seq 1 60); do
+  curl -sf localhost:3001/en/datasets > /dev/null && break
+  sleep 2
+done
+curl -s localhost:3001/en/datasets | grep -o -E 'Sales|Signups|E2E' | sort -u
+```
+
+**Boot time:** Ready after 2 seconds (first request check).
+
+**Grep result:**
+```
+E2E
+Sales
+Signups
+```
+
+All three dataset names were found in the server-rendered HTML at `/en/datasets`. The full DB → API → workbench chain is confirmed.
+
+---
+
+## Step 6: Teardown
+
+```bash
+# Killed API (port 3000) and workbench (port 3001) by PID and lsof
+kill 103355   # pnpm api parent
+kill 106163   # pnpm workbench parent
+kill $(lsof -ti :3000)   # tsx child (pid 103549)
+kill 106272 106762       # next dev children
+
+docker compose -f docker-compose.test.yml down
+```
+
+**Docker output:**
+```
+Container featworkbench-backend-foundation-postgres-test-1 Stopped
+Container featworkbench-backend-foundation-postgres-test-1 Removed
+Network featworkbench-backend-foundation_default Removed
+```
+
+Post-teardown verification:
+- `curl -sf localhost:3000/health` → connection refused (API stopped)
+- `curl -sf localhost:3001` → connection refused (Workbench stopped)
+
+---
+
+## Summary
+
+| Step | Expected | Actual | Pass |
+|------|----------|--------|------|
+| @rfjs/db build | success | Build complete in 721ms | PASS |
+| @rfjs/core build | success | Build complete in 734ms | PASS |
+| Postgres up | healthy | accepting connections, attempt 1 | PASS |
+| migrate | "Migrations completed." | Database created + "Migrations completed." | PASS |
+| seed | "Seeded 2 datasets." | "Seeded 2 datasets." | PASS |
+| GET /health | 200 ok | 200 `{"status":"ok",...}` | PASS |
+| POST /datasets | 201 + id + name | 201 `{"id":"95bd7b85...","name":"E2E",...}` | PASS |
+| GET /datasets | array with 3 rows | `[Sales — Q1, Signups, E2E]` | PASS |
+| GET /datasets/:bogus | 404 | 404 | PASS |
+| Workbench /en/datasets HTML | Sales, Signups, E2E | E2E, Sales, Signups | PASS |
+| Teardown | all processes/containers down | confirmed stopped | PASS |

--- a/docs/superpowers/plans/2026-06-14-workbench-backend-foundation.md
+++ b/docs/superpowers/plans/2026-06-14-workbench-backend-foundation.md
@@ -1,0 +1,1331 @@
+# Workbench Backend Foundation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a copyable, production-grade backend foundation for `apps/workbench`, proven end-to-end by a `datasets` CRUD vertical slice (DB → repository → usecase → API → frontend).
+
+**Architecture:** Runtime-agnostic business logic in `libs/` (light-functional: factory functions + explicit dependency injection); `apps/api` is a thin Fastify shell that calls usecases; `apps/workbench` is a pure frontend calling `apps/api` over HTTP. Two libs: `libs/db` (Drizzle plumbing — connection, schema, migrations, seed) and `libs/core` (per-module `schema` + `repository` + `usecase`).
+
+**Tech Stack:** TypeScript 5.7+, Drizzle ORM (node-postgres), Postgres, zod, Fastify 5, Next.js 16, Vitest, pnpm workspace + Turborepo, tsdown. `@rfjs/*` applied: `pg-toolkit` (db/schema bootstrap), `jsonb-query` (filter the `data` jsonb column), `retry` (later).
+
+**Spec:** `docs/superpowers/specs/2026-06-14-workbench-backend-foundation-design.md`
+
+---
+
+## Scaffolding note (read before Task 1)
+
+The spec says "scaffold `libs/db` from the start-ts-by `orm-drizzle` template, leaving the demo `libs/orm-drizzle` untouched." The `start-ts-by` CLI produces a **standalone** project (own `pnpm-workspace.yaml`, lockfile, `dist/`, `docs/`) — not a workspace-native lib. The existing `libs/orm-drizzle` **is** that exact template already adapted into a workspace lib. Therefore this plan creates `libs/db` by **following the `libs/orm-drizzle` structure** (the workspace-native form of the template) and changing only names/identifiers. This honours the intent (same template lineage) without dragging standalone-project cruft into the monorepo. `libs/orm-drizzle` is never modified.
+
+## File Structure
+
+**`libs/db/`** (new — Drizzle plumbing)
+- `package.json` — `@rfjs/db`, deps: `drizzle-orm`, `pg`, `pg-connection-string`, `tslib`; devDeps: `drizzle-kit`, `tsdown`, `vitest`, `typescript`, `tsx`, `dotenv`.
+- `tsconfig.json`, `tsdown.config.ts`, `vitest.config.mts`, `vitest.config.e2e.mts`, `drizzle.config.ts`, `.env.example`
+- `src/consts.ts` — `DATABASE`, `SCHEMA`
+- `src/db.ts` — `createDb` / `createDbByClient` (+ exported `Db` type)
+- `src/type.ts` — `MigrateToLatestParams`
+- `src/utils/` — `get-connection-string-info.ts`, `get-options-schemas.ts`, `index.ts`
+- `src/schema/index.ts` — barrel
+- `src/schema/datasets/table.ts` — `datasetsTable`
+- `src/schema/datasets/index.ts` — barrel
+- `src/scripts/` — `check-and-create-db.ts`, `check-and-create-schema.ts`, `migrate-to-latest.ts`, `seed-datasets.ts`, `index.ts`
+- `src/index.ts` — package barrel
+- `drizzle/` — generated migration SQL + meta
+
+**`libs/core/`** (new — repository + usecase)
+- `package.json` — `@rfjs/core`, deps: `@rfjs/db` (workspace:\*), `@rfjs/jsonb-query` (workspace:\*), `zod`, `tslib`; devDeps: `tsdown`, `vitest`, `typescript`.
+- `tsconfig.json`, `tsdown.config.ts`, `vitest.config.mts`, `vitest.config.e2e.mts`
+- `src/dataset/schema.ts` — zod contracts + inferred types
+- `src/dataset/repository.ts` — `makeDatasetRepository(db)` + `DatasetRepository` interface
+- `src/dataset/repository.e2e.spec.ts` — real-PG integration test
+- `src/dataset/usecase/create-dataset.ts` + `.spec.ts`
+- `src/dataset/usecase/list-datasets.ts` + `.spec.ts`
+- `src/dataset/usecase/get-dataset.ts` + `.spec.ts`
+- `src/dataset/usecase/index.ts` — barrel
+- `src/dataset/index.ts` — module barrel
+- `src/index.ts` — package barrel
+
+**`apps/api/`** (modify — add dataset module + composition root)
+- `src/configs.ts` — add `databaseUrl`
+- `src/infrastructures/datasource/index.ts` (new) — composition root: build `db` + `datasetRepository` + dataset usecases once
+- `src/delivery/http/dataset/routes.ts`, `handlers/dataset.handler.ts`, `handlers/index.ts`, `module.ts`, `index.ts` (new)
+- `src/delivery/http/index.ts` — export the new module (auto-registered)
+- `package.json` — add `@rfjs/core`, `@rfjs/db` deps
+- `src/delivery/http/dataset/dataset.route.spec.ts` (new) — `app.inject()` route test
+
+**`apps/workbench/`** (modify — datasets page)
+- `src/app/[locale]/(shell)/datasets/page.tsx` — fetch list from API
+- `.env.example` — `API_BASE_URL`
+
+**Root** (modify)
+- `docker-compose.test.yml` (new) — Postgres for the integration tier
+
+---
+
+## Phase A — `libs/db` (Drizzle plumbing + datasets table)
+
+### Task 1: Create `libs/db` package skeleton
+
+**Files:**
+- Create: `libs/db/package.json`, `libs/db/tsconfig.json`, `libs/db/tsdown.config.ts`, `libs/db/vitest.config.mts`, `libs/db/.env.example`
+- Create: `libs/db/src/consts.ts`, `libs/db/src/db.ts`, `libs/db/src/type.ts`, `libs/db/src/index.ts`
+- Create: `libs/db/src/utils/get-connection-string-info.ts`, `libs/db/src/utils/get-options-schemas.ts`, `libs/db/src/utils/index.ts`
+- Create: `libs/db/src/schema/index.ts`
+
+- [ ] **Step 1: Copy structural files from `libs/orm-drizzle`**
+
+These files are identical in intent; copy verbatim, then we only change identifiers in later steps:
+
+```bash
+mkdir -p libs/db/src/utils libs/db/src/schema libs/db/src/scripts
+cp libs/orm-drizzle/tsconfig.json libs/db/tsconfig.json
+cp libs/orm-drizzle/tsdown.config.ts libs/db/tsdown.config.ts
+cp libs/orm-drizzle/vitest.config.mts libs/db/vitest.config.mts
+cp libs/orm-drizzle/src/type.ts libs/db/src/type.ts
+cp libs/orm-drizzle/src/utils/get-connection-string-info.ts libs/db/src/utils/get-connection-string-info.ts
+cp libs/orm-drizzle/src/utils/get-options-schemas.ts libs/db/src/utils/get-options-schemas.ts
+cp libs/orm-drizzle/src/utils/index.ts libs/db/src/utils/index.ts
+```
+
+- [ ] **Step 2: Write `libs/db/package.json`**
+
+Mirror `libs/orm-drizzle/package.json`'s top fields exactly (no `"type"`, no `"exports"` — its proven tsdown dual-output shape):
+
+```json
+{
+  "name": "@rfjs/db",
+  "version": "0.0.0",
+  "description": "Workbench Drizzle plumbing: connection, schema, migrations, seed",
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "private": true,
+  "scripts": {
+    "clean": "pnpm exec rimraf ./dist ./types",
+    "build": "pnpm run clean && tsdown --config-loader unrun",
+    "typecheck": "tsc --noEmit",
+    "generate": "pnpm exec drizzle-kit generate",
+    "migrate": "pnpm exec tsx src/scripts/run-migrate.ts",
+    "seed": "pnpm exec tsx src/scripts/run-seed.ts",
+    "lint": "eslint \"src/**/*.ts\"",
+    "test": "vitest --passWithNoTests --run",
+    "vitest:run": "vitest --passWithNoTests --run",
+    "vitest:e2e:run": "vitest --config vitest.config.e2e.mts --passWithNoTests --run"
+  },
+  "dependencies": {
+    "drizzle-orm": "^0.45.1",
+    "pg": "^8.16.3",
+    "pg-connection-string": "^2.7.0",
+    "tslib": "^2.8.1"
+  },
+  "devDependencies": {
+    "@types/pg": "^8.16.0",
+    "dotenv": "^17.2.3",
+    "drizzle-kit": "^0.31.8",
+    "rimraf": "^6.0.1",
+    "tsx": "^4.19.2",
+    "typescript": "^5.7.3",
+    "vitest": "^4.1.8"
+  }
+}
+```
+
+- [ ] **Step 3: Write `libs/db/src/consts.ts`** (workbench identifiers, not the demo's)
+
+```ts
+export const SCHEMA = 'workbench';
+export const DATABASE = 'workbench';
+```
+
+- [ ] **Step 4: Write `libs/db/src/db.ts`** (same as orm-drizzle, plus an exported `Db` type the repository will use)
+
+```ts
+import { drizzle, NodePgDatabase } from 'drizzle-orm/node-postgres';
+import { Client, Pool } from 'pg';
+import * as schema from './schema';
+import { getConnectionStringInfo } from './utils';
+
+export type Schema = typeof schema;
+export type Db = NodePgDatabase<Schema>;
+
+export function createDb(
+  connectionString: string,
+  targetSchema?: string,
+  useClient = false,
+): { pool: Pool; client: Client; db: Db; hasSearchPath: boolean } {
+  const { finalConnectionString, hasSearchPath } = getConnectionStringInfo(
+    connectionString,
+    targetSchema,
+  );
+  const pool = new Pool({ connectionString: finalConnectionString });
+  const client = new Client({ connectionString: finalConnectionString });
+  const db = drizzle(useClient ? client : pool, { schema });
+  return { pool, client, db, hasSearchPath };
+}
+
+export function createDbByClient(
+  connectionString: string,
+  targetSchema?: string,
+): { client: Client; db: Db; hasSearchPath: boolean } {
+  const { finalConnectionString, hasSearchPath } = getConnectionStringInfo(
+    connectionString,
+    targetSchema,
+  );
+  const client = new Client({ connectionString: finalConnectionString });
+  const db = drizzle(client, { schema });
+  return { client, db, hasSearchPath };
+}
+```
+
+- [ ] **Step 5: Write `libs/db/src/schema/index.ts`** (datasets added in Task 2)
+
+```ts
+export * from './datasets';
+```
+
+- [ ] **Step 6: Write `libs/db/src/index.ts`**
+
+```ts
+export * from './db';
+export * from './schema';
+export * from './consts';
+export * from './type';
+export * from './scripts';
+```
+
+- [ ] **Step 7: Write `libs/db/.env.example`**
+
+```bash
+DATABASE_URL="postgresql://user:password@localhost:5432/workbench?options=-csearch_path=workbench"
+```
+
+- [ ] **Step 8: Install and typecheck** (schema/datasets + scripts referenced by barrels are created in Tasks 2–3; until then this step will fail on missing `./datasets` and `./scripts` — that is expected and resolved by Task 3. To verify Task 1 in isolation, temporarily comment the `./datasets` and `./scripts` re-exports, run the check, then restore.)
+
+Run: `pnpm install && pnpm --filter @rfjs/db typecheck`
+Expected: PASS once Tasks 2–3 complete; in isolation, PASS with the two barrel lines temporarily commented.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add libs/db pnpm-lock.yaml
+git commit -m "feat(db): scaffold @rfjs/db package skeleton (drizzle plumbing)"
+```
+
+---
+
+### Task 2: `datasets` table schema
+
+**Files:**
+- Create: `libs/db/src/schema/datasets/table.ts`
+- Create: `libs/db/src/schema/datasets/index.ts`
+- Test: `libs/db/src/schema/datasets/table.spec.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+`libs/db/src/schema/datasets/table.spec.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { getTableConfig } from 'drizzle-orm/pg-core';
+import { datasetsTable } from './table';
+
+describe('datasetsTable', () => {
+  it('maps to the "datasets" table with the expected columns', () => {
+    const config = getTableConfig(datasetsTable);
+    expect(config.name).toBe('datasets');
+    const columns = config.columns.map((c) => c.name).sort();
+    expect(columns).toEqual(
+      ['created_at', 'data', 'dataset_id', 'description', 'name', 'updated_at'].sort(),
+    );
+  });
+
+  it('makes name NOT NULL and id the primary key', () => {
+    const config = getTableConfig(datasetsTable);
+    const name = config.columns.find((c) => c.name === 'name');
+    const id = config.columns.find((c) => c.name === 'dataset_id');
+    expect(name?.notNull).toBe(true);
+    expect(id?.primary).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @rfjs/db vitest:run`
+Expected: FAIL — `Cannot find module './table'`.
+
+- [ ] **Step 3: Write `libs/db/src/schema/datasets/table.ts`**
+
+```ts
+import { pgTable, text, timestamp, uuid, jsonb } from 'drizzle-orm/pg-core';
+
+export const datasetsTable = pgTable('datasets', {
+  id: uuid('dataset_id').defaultRandom().primaryKey(),
+  name: text('name').notNull(),
+  description: text('description'),
+  data: jsonb('data').$type<Record<string, unknown>>().notNull().default({}),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+});
+
+export type DatasetRow = typeof datasetsTable.$inferSelect;
+export type NewDatasetRow = typeof datasetsTable.$inferInsert;
+```
+
+- [ ] **Step 4: Write `libs/db/src/schema/datasets/index.ts`**
+
+```ts
+export * from './table';
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `pnpm --filter @rfjs/db vitest:run`
+Expected: PASS (2 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add libs/db/src/schema/datasets
+git commit -m "feat(db): add datasets table schema"
+```
+
+---
+
+### Task 3: drizzle.config, migration, scripts, seed
+
+**Files:**
+- Create: `libs/db/drizzle.config.ts`
+- Create: `libs/db/src/scripts/check-and-create-db.ts`, `check-and-create-schema.ts`, `migrate-to-latest.ts`, `seed-datasets.ts`, `run-migrate.ts`, `run-seed.ts`, `index.ts`
+- Generate: `libs/db/drizzle/*` (migration SQL + meta)
+
+- [ ] **Step 1: Copy the two bootstrap scripts from `libs/orm-drizzle`** (`@rfjs/pg-toolkit` covers DB/schema admin; these scripts are the proven inline form and stay self-contained for the lib)
+
+```bash
+cp libs/orm-drizzle/src/scripts/check-and-create-db.ts libs/db/src/scripts/check-and-create-db.ts
+cp libs/orm-drizzle/src/scripts/check-and-create-schema.ts libs/db/src/scripts/check-and-create-schema.ts
+```
+
+Then edit `libs/db/src/scripts/check-and-create-db.ts`: change the fallback `const targetDb = database ?? 'orm';` to `const targetDb = database ?? 'workbench';`.
+
+- [ ] **Step 2: Write `libs/db/src/scripts/migrate-to-latest.ts`**
+
+```ts
+import { migrate } from 'drizzle-orm/node-postgres/migrator';
+import { createDbByClient } from '../db';
+import { checkAndCreateDB } from './check-and-create-db';
+import { checkAndCreateSchema } from './check-and-create-schema';
+import { SCHEMA } from '../consts';
+import { getConnectionStringInfo } from '../utils';
+import { MigrateToLatestParams } from '../type';
+
+export async function migrateToLatest(params: MigrateToLatestParams): Promise<void> {
+  const { connectionString, schema = SCHEMA, migrationsFolder = 'drizzle' } = params;
+  const { finalConnectionString, finalSchema } = getConnectionStringInfo(
+    connectionString,
+    schema,
+  );
+
+  await checkAndCreateDB(finalConnectionString);
+  await checkAndCreateSchema(finalConnectionString, [finalSchema]);
+
+  const { client, db } = createDbByClient(finalConnectionString);
+  let connected = false;
+  try {
+    await client.connect();
+    connected = true;
+    await migrate(db, { migrationsFolder, migrationsSchema: finalSchema });
+  } finally {
+    if (connected) await client.end();
+  }
+}
+```
+
+- [ ] **Step 3: Write `libs/db/src/scripts/seed-datasets.ts`**
+
+```ts
+import { createDb, type Db } from '../db';
+import { datasetsTable } from '../schema';
+
+export const DEMO_DATASETS = [
+  { name: 'Sales — Q1', description: 'Demo seed', data: { region: 'apac', rows: 120 } },
+  { name: 'Signups', description: 'Demo seed', data: { region: 'emea', rows: 42 } },
+] satisfies { name: string; description: string; data: Record<string, unknown> }[];
+
+export async function seedDatasets(db: Db): Promise<number> {
+  const inserted = await db.insert(datasetsTable).values(DEMO_DATASETS).returning();
+  return inserted.length;
+}
+
+export async function runSeedDatasets(connectionString: string): Promise<void> {
+  const { pool, db } = createDb(connectionString);
+  try {
+    const n = await seedDatasets(db);
+    console.log(`Seeded ${n} datasets.`);
+  } finally {
+    await pool.end();
+  }
+}
+```
+
+- [ ] **Step 4: Write the two CLI entrypoints**
+
+`libs/db/src/scripts/run-migrate.ts`:
+
+```ts
+import 'dotenv/config';
+import { migrateToLatest } from './migrate-to-latest';
+
+const connectionString = process.env.DATABASE_URL;
+if (!connectionString) throw new Error('DATABASE_URL is required');
+
+migrateToLatest({ connectionString })
+  .then(() => console.log('Migrations completed.'))
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });
+```
+
+`libs/db/src/scripts/run-seed.ts`:
+
+```ts
+import 'dotenv/config';
+import { runSeedDatasets } from './seed-datasets';
+
+const connectionString = process.env.DATABASE_URL;
+if (!connectionString) throw new Error('DATABASE_URL is required');
+
+runSeedDatasets(connectionString).catch((e) => {
+  console.error(e);
+  process.exit(1);
+});
+```
+
+- [ ] **Step 5: Write `libs/db/src/scripts/index.ts`**
+
+```ts
+export * from './check-and-create-db';
+export * from './check-and-create-schema';
+export * from './migrate-to-latest';
+export * from './seed-datasets';
+```
+
+- [ ] **Step 6: Write `libs/db/drizzle.config.ts`**
+
+```ts
+import { defineConfig } from 'drizzle-kit';
+import { SCHEMA } from './src/consts';
+
+export default defineConfig({
+  schema: './src/schema/index.ts',
+  out: './drizzle',
+  dialect: 'postgresql',
+  schemaFilter: [SCHEMA],
+  dbCredentials: { url: process.env.DATABASE_URL! },
+});
+```
+
+- [ ] **Step 7: Generate the migration**
+
+Run: `pnpm --filter @rfjs/db generate`
+Expected: creates `libs/db/drizzle/0000_*.sql` containing `CREATE TABLE "workbench"."datasets"` and `libs/db/drizzle/meta/*`.
+
+- [ ] **Step 8: Restore barrels and typecheck the whole package**
+
+Ensure `src/index.ts` re-exports `./scripts` and `src/schema/index.ts` re-exports `./datasets` (uncomment if Task 1 Step 8 commented them).
+
+Run: `pnpm --filter @rfjs/db typecheck && pnpm --filter @rfjs/db vitest:run`
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add libs/db
+git commit -m "feat(db): migrations, bootstrap scripts, and datasets seed"
+```
+
+---
+
+## Phase B — `libs/core` (repository + usecase)
+
+### Task 4: Create `libs/core` package skeleton
+
+**Files:**
+- Create: `libs/core/package.json`, `libs/core/tsconfig.json`, `libs/core/tsdown.config.ts`, `libs/core/vitest.config.mts`, `libs/core/vitest.config.e2e.mts`
+- Create: `libs/core/src/index.ts`
+
+- [ ] **Step 1: Copy config files from `libs/db`**
+
+```bash
+mkdir -p libs/core/src/dataset/usecase
+cp libs/db/tsconfig.json libs/core/tsconfig.json
+cp libs/db/tsdown.config.ts libs/core/tsdown.config.ts
+cp libs/db/vitest.config.mts libs/core/vitest.config.mts
+```
+
+- [ ] **Step 2: Write `libs/core/package.json`**
+
+```json
+{
+  "name": "@rfjs/core",
+  "version": "0.0.0",
+  "description": "Workbench business logic: per-module schema, repository, usecase",
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "private": true,
+  "scripts": {
+    "clean": "pnpm exec rimraf ./dist ./types",
+    "build": "pnpm run clean && tsdown --config-loader unrun",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint \"src/**/*.ts\"",
+    "test": "vitest --passWithNoTests --run",
+    "vitest:run": "vitest --passWithNoTests --run",
+    "vitest:e2e:run": "vitest --config vitest.config.e2e.mts --passWithNoTests --run"
+  },
+  "dependencies": {
+    "@rfjs/db": "workspace:*",
+    "@rfjs/jsonb-query": "workspace:*",
+    "tslib": "^2.8.1",
+    "zod": "^4.0.0"
+  },
+  "devDependencies": {
+    "rimraf": "^6.0.1",
+    "typescript": "^5.7.3",
+    "vitest": "^4.1.8"
+  }
+}
+```
+
+- [ ] **Step 3: Write `libs/core/vitest.config.e2e.mts`** (integration tier — only `*.e2e.spec.ts`)
+
+```ts
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+
+export default defineConfig({
+  resolve: { alias: { '@': path.resolve(__dirname, './src') } },
+  test: {
+    include: ['src/**/*.e2e.spec.ts'],
+    testTimeout: 30000,
+    hookTimeout: 30000,
+  },
+});
+```
+
+Also edit `libs/core/vitest.config.mts` `test.include` to **exclude** e2e: set `include: ['src/**/*.spec.ts']` and add `exclude: ['src/**/*.e2e.spec.ts', '**/node_modules/**']`.
+
+- [ ] **Step 4: Write `libs/core/src/index.ts`**
+
+```ts
+export * from './dataset';
+```
+
+(The `./dataset` barrel is created in Task 9; comment this line until then, or accept a failing barrel resolution until Task 9.)
+
+- [ ] **Step 5: Install**
+
+Run: `pnpm install`
+Expected: links `@rfjs/db` and `@rfjs/jsonb-query` into `@rfjs/core`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add libs/core pnpm-lock.yaml
+git commit -m "feat(core): scaffold @rfjs/core package skeleton"
+```
+
+---
+
+### Task 5: dataset zod schema (the contract / initial domain)
+
+**Files:**
+- Create: `libs/core/src/dataset/schema.ts`
+- Test: `libs/core/src/dataset/schema.spec.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+`libs/core/src/dataset/schema.spec.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { CreateDatasetInputSchema } from './schema';
+
+describe('CreateDatasetInputSchema', () => {
+  it('accepts a valid input and defaults data to {}', () => {
+    const parsed = CreateDatasetInputSchema.parse({ name: 'X' });
+    expect(parsed).toEqual({ name: 'X', description: undefined, data: {} });
+  });
+
+  it('rejects an empty name', () => {
+    expect(() => CreateDatasetInputSchema.parse({ name: '' })).toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @rfjs/core vitest:run`
+Expected: FAIL — `Cannot find module './schema'`.
+
+- [ ] **Step 3: Write `libs/core/src/dataset/schema.ts`**
+
+```ts
+import { z } from 'zod';
+
+// NOTE: this repo is on zod v4 — z.record requires explicit key + value schemas.
+export const DatasetSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string().min(1),
+  description: z.string().nullable(),
+  data: z.record(z.string(), z.unknown()),
+  createdAt: z.date(),
+  updatedAt: z.date(),
+});
+export type Dataset = z.infer<typeof DatasetSchema>;
+
+export const CreateDatasetInputSchema = z.object({
+  name: z.string().min(1),
+  description: z.string().optional(),
+  data: z.record(z.string(), z.unknown()).default({}),
+});
+export type CreateDatasetInput = z.infer<typeof CreateDatasetInputSchema>;
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter @rfjs/core vitest:run`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add libs/core/src/dataset/schema.ts libs/core/src/dataset/schema.spec.ts
+git commit -m "feat(core): dataset zod schema (contract)"
+```
+
+---
+
+### Task 6: dataset repository (over `@rfjs/db`) + real-PG integration test
+
+**Files:**
+- Create: `libs/core/src/dataset/repository.ts`
+- Create: `docker-compose.test.yml` (repo root)
+- Test: `libs/core/src/dataset/repository.e2e.spec.ts`
+
+- [ ] **Step 1: Write `docker-compose.test.yml`** (repo root)
+
+```yaml
+services:
+  postgres-test:
+    image: postgres:17-alpine
+    environment:
+      POSTGRES_USER: user
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: postgres
+    ports:
+      - '5433:5432'
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U user']
+      interval: 2s
+      timeout: 5s
+      retries: 10
+```
+
+- [ ] **Step 2: Write the failing integration test**
+
+`libs/core/src/dataset/repository.e2e.spec.ts`:
+
+```ts
+import path from 'path';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { createDb, migrateToLatest } from '@rfjs/db';
+import type { Pool } from 'pg';
+import { makeDatasetRepository } from './repository';
+
+const CONN =
+  process.env.TEST_DATABASE_URL ??
+  'postgresql://user:password@localhost:5433/workbench?options=-csearch_path=workbench';
+
+// libs/core/src/dataset -> ../../../db/drizzle === libs/db/drizzle
+const MIGRATIONS_FOLDER = path.resolve(__dirname, '../../../db/drizzle');
+
+describe('makeDatasetRepository (real PG)', () => {
+  let pool: Pool;
+  let repo: ReturnType<typeof makeDatasetRepository>;
+
+  beforeAll(async () => {
+    await migrateToLatest({ connectionString: CONN, migrationsFolder: MIGRATIONS_FOLDER });
+    const created = createDb(CONN);
+    pool = created.pool;
+    repo = makeDatasetRepository(created.db);
+  });
+
+  afterAll(async () => {
+    await pool?.end();
+  });
+
+  it('creates a dataset and reads it back by id', async () => {
+    const created = await repo.create({ name: 'IT', description: null, data: { a: 1 } });
+    expect(created.id).toBeTypeOf('string');
+    const found = await repo.getById(created.id);
+    expect(found?.name).toBe('IT');
+    expect(found?.data).toEqual({ a: 1 });
+  });
+
+  it('lists datasets', async () => {
+    await repo.create({ name: 'L1', description: null, data: {} });
+    const all = await repo.list();
+    expect(all.length).toBeGreaterThanOrEqual(1);
+  });
+});
+```
+
+- [ ] **Step 3: Run it to verify it fails**
+
+Run: `pnpm --filter @rfjs/core vitest:e2e:run`
+Expected: FAIL — `Cannot find module './repository'`.
+
+- [ ] **Step 4: Write `libs/core/src/dataset/repository.ts`**
+
+```ts
+import { eq } from 'drizzle-orm';
+import { type Db, datasetsTable } from '@rfjs/db';
+import type { Dataset, CreateDatasetInput } from './schema';
+
+export interface DatasetRepository {
+  list(): Promise<Dataset[]>;
+  getById(id: string): Promise<Dataset | undefined>;
+  create(input: CreateDatasetInput): Promise<Dataset>;
+}
+
+const toDataset = (row: typeof datasetsTable.$inferSelect): Dataset => ({
+  id: row.id,
+  name: row.name,
+  description: row.description,
+  data: row.data,
+  createdAt: row.createdAt,
+  updatedAt: row.updatedAt,
+});
+
+export const makeDatasetRepository = (db: Db): DatasetRepository => ({
+  async list() {
+    const rows = await db.select().from(datasetsTable);
+    return rows.map(toDataset);
+  },
+  async getById(id) {
+    const rows = await db.select().from(datasetsTable).where(eq(datasetsTable.id, id));
+    return rows[0] ? toDataset(rows[0]) : undefined;
+  },
+  async create(input) {
+    const [row] = await db
+      .insert(datasetsTable)
+      .values({
+        name: input.name,
+        description: input.description ?? null,
+        data: input.data,
+      })
+      .returning();
+    return toDataset(row);
+  },
+});
+```
+
+- [ ] **Step 5: Build `@rfjs/db` (the e2e test imports it as a built dep), then run the integration test with Postgres up**
+
+```bash
+pnpm --filter @rfjs/db build
+docker compose -f docker-compose.test.yml up -d
+pnpm --filter @rfjs/core vitest:e2e:run
+docker compose -f docker-compose.test.yml down
+```
+
+Expected: PASS (2 tests). (Document: requires Docker; not part of the default `pnpm test` unit tier. `@rfjs/db` is consumed via its built `dist/`, so it must be built first — the usecase unit tests in Tasks 7–8 only `import type` from it and need no build.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add libs/core/src/dataset/repository.ts libs/core/src/dataset/repository.e2e.spec.ts docker-compose.test.yml
+git commit -m "feat(core): dataset repository over @rfjs/db (+ real-PG integration test)"
+```
+
+---
+
+### Task 7: `create-dataset` usecase (fake-repo unit test)
+
+**Files:**
+- Create: `libs/core/src/dataset/usecase/create-dataset.ts`
+- Test: `libs/core/src/dataset/usecase/create-dataset.spec.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+`libs/core/src/dataset/usecase/create-dataset.spec.ts`:
+
+```ts
+import { describe, it, expect, vi } from 'vitest';
+import { makeCreateDataset } from './create-dataset';
+import type { DatasetRepository } from '../repository';
+import type { Dataset } from '../schema';
+
+const fakeDataset: Dataset = {
+  id: '00000000-0000-0000-0000-000000000001',
+  name: 'X',
+  description: null,
+  data: {},
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+describe('makeCreateDataset', () => {
+  it('validates input then delegates to repository.create', async () => {
+    const repo: DatasetRepository = {
+      list: vi.fn(),
+      getById: vi.fn(),
+      create: vi.fn().mockResolvedValue(fakeDataset),
+    };
+    const createDataset = makeCreateDataset({ repo });
+    const result = await createDataset({ name: 'X' });
+    expect(repo.create).toHaveBeenCalledWith({ name: 'X', description: undefined, data: {} });
+    expect(result).toBe(fakeDataset);
+  });
+
+  it('throws on invalid input without calling the repository', async () => {
+    const repo: DatasetRepository = {
+      list: vi.fn(),
+      getById: vi.fn(),
+      create: vi.fn(),
+    };
+    const createDataset = makeCreateDataset({ repo });
+    await expect(createDataset({ name: '' })).rejects.toThrow();
+    expect(repo.create).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @rfjs/core vitest:run`
+Expected: FAIL — `Cannot find module './create-dataset'`.
+
+- [ ] **Step 3: Write `libs/core/src/dataset/usecase/create-dataset.ts`**
+
+```ts
+import { CreateDatasetInputSchema, type Dataset } from '../schema';
+import type { DatasetRepository } from '../repository';
+
+export const makeCreateDataset =
+  (deps: { repo: DatasetRepository }) =>
+  async (input: unknown): Promise<Dataset> => {
+    const parsed = CreateDatasetInputSchema.parse(input);
+    return deps.repo.create(parsed);
+  };
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter @rfjs/core vitest:run`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add libs/core/src/dataset/usecase/create-dataset.ts libs/core/src/dataset/usecase/create-dataset.spec.ts
+git commit -m "feat(core): create-dataset usecase"
+```
+
+---
+
+### Task 8: `list-datasets` + `get-dataset` usecases
+
+**Files:**
+- Create: `libs/core/src/dataset/usecase/list-datasets.ts`, `get-dataset.ts`
+- Test: `libs/core/src/dataset/usecase/list-datasets.spec.ts`, `get-dataset.spec.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+`libs/core/src/dataset/usecase/list-datasets.spec.ts`:
+
+```ts
+import { describe, it, expect, vi } from 'vitest';
+import { makeListDatasets } from './list-datasets';
+import type { DatasetRepository } from '../repository';
+
+describe('makeListDatasets', () => {
+  it('returns whatever the repository lists', async () => {
+    const repo = { list: vi.fn().mockResolvedValue([]), getById: vi.fn(), create: vi.fn() } satisfies DatasetRepository;
+    const listDatasets = makeListDatasets({ repo });
+    expect(await listDatasets()).toEqual([]);
+    expect(repo.list).toHaveBeenCalledOnce();
+  });
+});
+```
+
+`libs/core/src/dataset/usecase/get-dataset.spec.ts`:
+
+```ts
+import { describe, it, expect, vi } from 'vitest';
+import { makeGetDataset } from './get-dataset';
+import type { DatasetRepository } from '../repository';
+
+describe('makeGetDataset', () => {
+  it('delegates to repository.getById', async () => {
+    const repo = { list: vi.fn(), getById: vi.fn().mockResolvedValue(undefined), create: vi.fn() } satisfies DatasetRepository;
+    const getDataset = makeGetDataset({ repo });
+    expect(await getDataset('abc')).toBeUndefined();
+    expect(repo.getById).toHaveBeenCalledWith('abc');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm --filter @rfjs/core vitest:run`
+Expected: FAIL — modules not found.
+
+- [ ] **Step 3: Write the implementations**
+
+`libs/core/src/dataset/usecase/list-datasets.ts`:
+
+```ts
+import type { Dataset } from '../schema';
+import type { DatasetRepository } from '../repository';
+
+export const makeListDatasets =
+  (deps: { repo: DatasetRepository }) =>
+  (): Promise<Dataset[]> =>
+    deps.repo.list();
+```
+
+`libs/core/src/dataset/usecase/get-dataset.ts`:
+
+```ts
+import type { Dataset } from '../schema';
+import type { DatasetRepository } from '../repository';
+
+export const makeGetDataset =
+  (deps: { repo: DatasetRepository }) =>
+  (id: string): Promise<Dataset | undefined> =>
+    deps.repo.getById(id);
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm --filter @rfjs/core vitest:run`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add libs/core/src/dataset/usecase/list-datasets.ts libs/core/src/dataset/usecase/list-datasets.spec.ts libs/core/src/dataset/usecase/get-dataset.ts libs/core/src/dataset/usecase/get-dataset.spec.ts
+git commit -m "feat(core): list-datasets and get-dataset usecases"
+```
+
+---
+
+### Task 9: dataset module + package barrels
+
+**Files:**
+- Create: `libs/core/src/dataset/usecase/index.ts`, `libs/core/src/dataset/index.ts`
+- Modify: `libs/core/src/index.ts` (uncomment `./dataset` if commented in Task 4)
+
+- [ ] **Step 1: Write `libs/core/src/dataset/usecase/index.ts`**
+
+```ts
+export * from './create-dataset';
+export * from './list-datasets';
+export * from './get-dataset';
+```
+
+- [ ] **Step 2: Write `libs/core/src/dataset/index.ts`**
+
+```ts
+export * from './schema';
+export * from './repository';
+export * from './usecase';
+```
+
+- [ ] **Step 3: Ensure `libs/core/src/index.ts` exports the module**
+
+```ts
+export * from './dataset';
+```
+
+- [ ] **Step 4: Typecheck, build, and run the unit tier**
+
+Run: `pnpm --filter @rfjs/core typecheck && pnpm --filter @rfjs/core build && pnpm --filter @rfjs/core vitest:run`
+Expected: PASS (all unit specs; e2e excluded).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add libs/core/src
+git commit -m "feat(core): dataset module barrels and package export"
+```
+
+---
+
+## Phase C — `apps/api` dataset module
+
+### Task 10: composition root + configs
+
+**Files:**
+- Modify: `apps/api/src/configs.ts`
+- Create: `apps/api/src/infrastructures/datasource/index.ts`
+- Modify: `apps/api/package.json` (add deps), `apps/api/.env.example` (add `DATABASE_URL`)
+
+- [ ] **Step 1: Add deps to `apps/api/package.json`**
+
+Add to `dependencies`: `"@rfjs/core": "workspace:*"`, `"@rfjs/db": "workspace:*"`. Then:
+
+Run: `pnpm install`
+Expected: links both libs into `apps/api`.
+
+- [ ] **Step 2: Add `databaseUrl` to `apps/api/src/configs.ts`**
+
+Add to the `AppConfig` interface: `databaseUrl: string;`
+Add to the `configs` object:
+
+```ts
+  databaseUrl:
+    process.env.DATABASE_URL ||
+    'postgresql://user:password@localhost:5432/workbench?options=-csearch_path=workbench',
+```
+
+Add to `apps/api/.env.example`:
+
+```bash
+DATABASE_URL="postgresql://user:password@localhost:5432/workbench?options=-csearch_path=workbench"
+```
+
+- [ ] **Step 3: Write the composition root** `apps/api/src/infrastructures/datasource/index.ts`
+
+```ts
+import { createDb } from '@rfjs/db';
+import {
+  makeDatasetRepository,
+  makeListDatasets,
+  makeGetDataset,
+  makeCreateDataset,
+} from '@rfjs/core';
+import { configs } from '@/configs';
+
+const { db } = createDb(configs.databaseUrl);
+const datasetRepository = makeDatasetRepository(db);
+
+export const datasetUsecases = {
+  list: makeListDatasets({ repo: datasetRepository }),
+  get: makeGetDataset({ repo: datasetRepository }),
+  create: makeCreateDataset({ repo: datasetRepository }),
+};
+```
+
+- [ ] **Step 4: Build the libs (api consumes their built `dist/` types), then typecheck**
+
+`apps/api` resolves `@rfjs/core` / `@rfjs/db` via their `dist/*.d.ts`, so build them first. The api typecheck script is `typecheck` (not `check-types`).
+
+Run: `pnpm --filter @rfjs/db build && pnpm --filter @rfjs/core build && pnpm --filter api typecheck`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/package.json apps/api/src/configs.ts apps/api/src/infrastructures/datasource apps/api/.env.example pnpm-lock.yaml
+git commit -m "feat(api): wire @rfjs/core dataset usecases (composition root + db config)"
+```
+
+---
+
+### Task 11: dataset HTTP module + route test
+
+**Files:**
+- Create: `apps/api/src/delivery/http/dataset/handlers/dataset.handler.ts`, `handlers/index.ts`, `routes.ts`, `module.ts`, `index.ts`
+- Modify: `apps/api/src/delivery/http/index.ts`
+- Test: `apps/api/src/delivery/http/dataset/dataset.route.spec.ts`
+
+- [ ] **Step 1: Write the failing route test** (uses `app.inject()`; stubs the composition-root usecases via `vi.mock`)
+
+`apps/api/src/delivery/http/dataset/dataset.route.spec.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+
+vi.mock('@/infrastructures/datasource', () => ({
+  datasetUsecases: {
+    list: vi.fn().mockResolvedValue([{ id: '1', name: 'A', description: null, data: {}, createdAt: new Date(), updatedAt: new Date() }]),
+    get: vi.fn(),
+    create: vi.fn().mockImplementation((input) => Promise.resolve({ id: '2', description: null, data: {}, createdAt: new Date(), updatedAt: new Date(), ...input })),
+  },
+}));
+
+describe('dataset routes', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    const { initializeFastifyApp } = await import('@/infrastructures');
+    const { datasetHttpRouteModule } = await import('./module');
+    app = await initializeFastifyApp({
+      httpRouteModules: [datasetHttpRouteModule],
+      isApiDocEnabled: false,
+    });
+    await app.ready();
+  });
+
+  it('GET /datasets returns the list', async () => {
+    const res = await app.inject({ method: 'GET', url: '/datasets' });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toHaveLength(1);
+  });
+
+  it('POST /datasets creates and returns 201', async () => {
+    const res = await app.inject({ method: 'POST', url: '/datasets', payload: { name: 'New' } });
+    expect(res.statusCode).toBe(201);
+    expect(res.json().name).toBe('New');
+  });
+});
+```
+
+`apps/api` already has `vitest.config.mts` (with the `@` → `./src` alias and `src/**/*.spec.(ts|js)` include) and a `vitest:run` script — no config changes needed.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter api vitest:run`
+Expected: FAIL — `Cannot find module './module'`.
+
+- [ ] **Step 3: Write the handlers** `apps/api/src/delivery/http/dataset/handlers/dataset.handler.ts`
+
+```ts
+import { RouteHandlerMethod } from 'fastify/types/route';
+import { datasetUsecases } from '@/infrastructures/datasource';
+
+export const listDatasetsHandler: RouteHandlerMethod = async (_req, reply) => {
+  reply.send(await datasetUsecases.list());
+};
+
+export const getDatasetHandler: RouteHandlerMethod = async (req, reply) => {
+  const { id } = req.params as { id: string };
+  const found = await datasetUsecases.get(id);
+  if (!found) return reply.notFound(`dataset ${id} not found`);
+  reply.send(found);
+};
+
+export const createDatasetHandler: RouteHandlerMethod = async (req, reply) => {
+  const created = await datasetUsecases.create(req.body);
+  reply.code(201).send(created);
+};
+```
+
+`apps/api/src/delivery/http/dataset/handlers/index.ts`:
+
+```ts
+export * from './dataset.handler';
+```
+
+- [ ] **Step 4: Write the routes** `apps/api/src/delivery/http/dataset/routes.ts`
+
+```ts
+import { RouteOptions } from 'fastify';
+import { listDatasetsHandler, getDatasetHandler, createDatasetHandler } from './handlers';
+
+export const datasetRoutes: RouteOptions[] = [
+  { method: 'GET', url: '/datasets', schema: { tags: ['dataset'] }, handler: listDatasetsHandler },
+  { method: 'GET', url: '/datasets/:id', schema: { tags: ['dataset'] }, handler: getDatasetHandler },
+  { method: 'POST', url: '/datasets', schema: { tags: ['dataset'] }, handler: createDatasetHandler },
+];
+```
+
+- [ ] **Step 5: Write the module** `apps/api/src/delivery/http/dataset/module.ts`
+
+```ts
+import { FastifyPluginAsync } from 'fastify';
+import { datasetRoutes } from './routes';
+import { HttpRouteModule } from '@/infrastructures';
+import { createPluginFromRoutes } from '@/helpers';
+
+const plugin: FastifyPluginAsync = createPluginFromRoutes(datasetRoutes);
+
+export const datasetHttpRouteModule: HttpRouteModule = {
+  type: 'http',
+  prefix: '/',
+  plugin,
+};
+```
+
+`apps/api/src/delivery/http/dataset/index.ts`:
+
+```ts
+export * from './module';
+```
+
+- [ ] **Step 6: Register the module** — add to `apps/api/src/delivery/http/index.ts`:
+
+```ts
+export * from './dataset';
+```
+
+(`main.ts` discovers modules via `Object.values(import * as ...'@/delivery/http')`, so this export auto-registers the routes.)
+
+- [ ] **Step 7: Run test to verify it passes**
+
+Run: `pnpm --filter api vitest:run`
+Expected: PASS (2 tests).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/api/src/delivery/http/dataset apps/api/src/delivery/http/index.ts
+git commit -m "feat(api): datasets HTTP module (list/get/create)"
+```
+
+---
+
+## Phase D — `apps/workbench` datasets page
+
+### Task 12: datasets page fetches from the API
+
+**Files:**
+- Modify: `apps/workbench/src/app/[locale]/(shell)/datasets/page.tsx`
+- Modify: `apps/workbench/.env.example` (add `API_BASE_URL`)
+
+- [ ] **Step 1: Add `API_BASE_URL` to `apps/workbench/.env.example`**
+
+```bash
+API_BASE_URL="http://localhost:3000"
+```
+
+- [ ] **Step 2: Rewrite the datasets page to fetch the list**
+
+`apps/workbench/src/app/[locale]/(shell)/datasets/page.tsx`:
+
+```tsx
+import { Panel } from "@rfjs/web-ui/components/panel";
+import { getTranslations, setRequestLocale } from "next-intl/server";
+
+type Dataset = { id: string; name: string; description: string | null };
+
+async function fetchDatasets(): Promise<Dataset[]> {
+  const base = process.env.API_BASE_URL ?? "http://localhost:3000";
+  try {
+    const res = await fetch(`${base}/datasets`, { cache: "no-store" });
+    if (!res.ok) return [];
+    return (await res.json()) as Dataset[];
+  } catch {
+    return [];
+  }
+}
+
+export default async function DatasetsPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+  const t = await getTranslations("Pages");
+  const datasets = await fetchDatasets();
+
+  return (
+    <div className="flex flex-col gap-4">
+      <h1 className="text-xl font-semibold">{t("datasetsTitle")}</h1>
+      <p className="text-sm text-muted-foreground">{t("datasetsDescription")}</p>
+      <Panel>
+        {datasets.length === 0 ? (
+          <span className="text-sm text-muted-foreground">No datasets yet.</span>
+        ) : (
+          <ul className="flex flex-col gap-2">
+            {datasets.map((d) => (
+              <li key={d.id} className="text-sm">
+                <span className="font-medium">{d.name}</span>
+                {d.description ? (
+                  <span className="text-muted-foreground"> — {d.description}</span>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        )}
+      </Panel>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Typecheck and lint the workbench**
+
+Run: `pnpm --filter workbench check-types && pnpm --filter workbench lint`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add "apps/workbench/src/app/[locale]/(shell)/datasets/page.tsx" apps/workbench/.env.example
+git commit -m "feat(workbench): datasets page fetches list from api"
+```
+
+---
+
+## Phase E — End-to-end verification
+
+### Task 13: create → list round-trip (manual + documented)
+
+**Files:**
+- Create: `docs/superpowers/notes/2026-06-14-workbench-backend-e2e.md` (run log)
+
+- [ ] **Step 1: Bring up Postgres, migrate, seed**
+
+```bash
+docker compose -f docker-compose.test.yml up -d
+DATABASE_URL='postgresql://user:password@localhost:5433/workbench?options=-csearch_path=workbench' pnpm --filter @rfjs/db migrate
+DATABASE_URL='postgresql://user:password@localhost:5433/workbench?options=-csearch_path=workbench' pnpm --filter @rfjs/db seed
+```
+
+Expected: "Migrations completed." then "Seeded 2 datasets."
+
+- [ ] **Step 2: Start the API against that DB**
+
+```bash
+DATABASE_URL='postgresql://user:password@localhost:5433/workbench?options=-csearch_path=workbench' pnpm --filter api dev
+```
+
+- [ ] **Step 3: Exercise create → list**
+
+```bash
+curl -s -X POST localhost:3000/datasets -H 'content-type: application/json' -d '{"name":"E2E","data":{"k":1}}'
+curl -s localhost:3000/datasets
+```
+
+Expected: POST returns a 201 body with `"name":"E2E"`; GET returns a list including the seeded rows + `E2E`.
+
+- [ ] **Step 4: Start workbench and confirm the page renders the list**
+
+```bash
+API_BASE_URL=http://localhost:3000 pnpm --filter workbench dev
+# open http://localhost:3001/en/datasets — the seeded + E2E datasets appear
+```
+
+- [ ] **Step 5: Record the run log and tear down**
+
+Write the observed outputs into `docs/superpowers/notes/2026-06-14-workbench-backend-e2e.md`, then:
+
+```bash
+docker compose -f docker-compose.test.yml down
+git add docs/superpowers/notes/2026-06-14-workbench-backend-e2e.md
+git commit -m "docs(workbench): record datasets backend e2e run log"
+```
+
+---
+
+## Final verification
+
+- [ ] **Unit tier (no Docker):** `pnpm --filter @rfjs/db vitest:run && pnpm --filter @rfjs/core vitest:run && pnpm --filter api vitest:run` — all PASS.
+- [ ] **Integration tier (Docker):** Postgres up → `pnpm --filter @rfjs/core vitest:e2e:run` — PASS.
+- [ ] **Builds:** `pnpm --filter @rfjs/db build && pnpm --filter @rfjs/core build` — PASS.
+- [ ] **Typecheck** (run after the builds above, so apps see the libs' `dist` types): `pnpm --filter @rfjs/db typecheck && pnpm --filter @rfjs/core typecheck && pnpm --filter api typecheck && pnpm --filter workbench check-types` — PASS. (`api` uses the `typecheck` script; `workbench` uses `check-types`.)
+
+---
+
+## Notes / deferred (from spec)
+
+- **`@rfjs/pg-toolkit` deviation:** the spec lists pg-toolkit for `libs/db` DB/schema bootstrap, but its published surface is `pure` only (the side-effecting "admin" helpers aren't in the default export). Rather than invent an import path, this plan uses the **proven inline** `check-and-create-db/schema` scripts (copied from `libs/orm-drizzle`). Swapping them to `@rfjs/pg-toolkit` admin helpers is a follow-up once that package exposes them. Flag for the user at review.
+- `@rfjs/jsonb-query` is wired as a `@rfjs/core` dependency now; its first real use is filtering the `data` jsonb column — added when list-datasets gains query params (next iteration), to keep this slice focused on the layer wiring.
+- `@rfjs/retry` (db connect / outbound), auth (`@rfjs/jwt`, Phase 6), `apps/serverless`, and the workflow/story module are out of scope (see spec).

--- a/docs/superpowers/specs/2026-06-14-workbench-backend-foundation-design.md
+++ b/docs/superpowers/specs/2026-06-14-workbench-backend-foundation-design.md
@@ -116,6 +116,42 @@ Minimal columns to prove the slice; refined during planning if needed:
 - `data` (jsonb) — payload; the `@rfjs/jsonb-query` filter target
 - `createdAt` / `updatedAt` (timestamptz)
 
+## Future: Workflow / Story Module (roadmap, not this iteration)
+
+A likely next direction is a **workflow/story** capability — chaining workbench tools
+(parse → flatten → filter → convert, etc.) into a named, repeatable pipeline. Recorded
+here so the foundation stays compatible with it.
+
+**Where it lives — two boundaries kept distinct:**
+
+- A workflow is **business logic**, so its home is a **`libs/core` slice**
+  (`libs/core/workflow/`), *not* a separate app. A workflow is a **higher-order usecase**
+  that composes other tools/usecases.
+- A separate app is justified only by a **deployment boundary** (independent scaling,
+  different runtime e.g. serverless, separate team/cadence) — never by "it has its own
+  business logic". Putting logic in an app would break the runtime-agnostic principle
+  this whole design rests on.
+
+Sketch (when built):
+
+```
+libs/core/workflow/
+  schema.ts            zod for a workflow definition (ordered steps)
+  usecase/
+    run-workflow.ts    compose: parse → flatten → filter → convert (call tool usecases)
+    save-workflow.ts
+```
+
+exposed via `apps/api` `delivery/http/workflow/`; a future `apps/serverless` would reuse
+the same usecases.
+
+**Open question (decide before building it):** does a workflow even need a backend?
+Many workbench tools are pure `@rfjs` functions that run in the browser — if a "story" is
+only a chain of pure tools, it is a **client-side workflow** (composed in the workbench
+frontend) and needs no API. A backend earns its place only when workflows must be
+**persisted / shared / replayed**, or touch **server-side resources** (DB, secrets,
+external APIs). This decision is deferred; it determines client-side vs `libs/core` + API.
+
 ## Deployment / Serverless Stance
 
 Default runtime is **Fastify (`apps/api`) on k8s**. Serverless is **not built now**;
@@ -145,3 +181,5 @@ evaluated separately only if such workloads materialise.
 - `apps/serverless` — deferred.
 - `domain/` and `services/` layers — added only when earned.
 - Additional modules beyond `dataset`.
+- **Workflow / story module** — recorded as roadmap above; its backend-or-not decision is
+  deferred. Not built this iteration.

--- a/docs/superpowers/specs/2026-06-14-workbench-backend-foundation-design.md
+++ b/docs/superpowers/specs/2026-06-14-workbench-backend-foundation-design.md
@@ -1,0 +1,147 @@
+# Workbench Backend Foundation — Design
+
+**Date:** 2026-06-14
+**Status:** Approved (brainstorming complete; pending writing-plans)
+**Scope:** A copyable, production-grade backend foundation for `apps/workbench`, with `@rfjs/*` packages applied, proven end-to-end by one vertical slice (datasets CRUD).
+
+## Purpose & Positioning
+
+The workbench backend is a **hybrid**: the skeleton (layering, repository, auth seams)
+is production-grade and open-source-showcase-able, while concrete domain tables start
+with demo seed data and get replaced when product logic is privatised. The goal is a
+**clean foundation that can be copied** — not a finished product, not a throwaway demo.
+
+This aligns with the repo's open-source/layering strategy: generic, copyable patterns
+live here (public-friendly); domain/product specifics stay thin and swappable.
+
+## Architecture
+
+Two axes, kept distinct:
+
+- **Horizontal layers** (responsibility): `delivery → usecase → repository → db`.
+- **Vertical slices** (feature/bounded context): `dataset`, `user`, … — each slice owns
+  its layers as folders, so a feature change touches one place, not four packages.
+
+```
+apps/workbench/      Pure frontend (Next.js). Calls apps/api over HTTP. Never touches DB.
+        │ HTTP
+        ▼
+apps/api/            Fastify thin shell (continues from existing layered app).
+                     Handlers: parse request → call libs/core usecase → respond.
+        │ import
+        ▼
+libs/core/           "Clean copyable foundation" — pure TS, no framework, no lambda binding.
+  dataset/             ← vertical slice (module = bounded context)
+    schema.ts          zod contract = the initial "domain"
+    repository.ts      makeDatasetRepository(db) → { findById, list, insert, ... }
+    usecase/
+      create-dataset.ts  makeCreateDataset({ repo }) → (input) => ...
+      list-datasets.ts
+    index.ts           barrel; the module's only public surface
+  index.ts             package barrel
+        │ import (tables + connection)
+        ▼
+libs/db/             Drizzle plumbing. Scaffolded fresh from the start-ts-by
+                     orm-drizzle template (the existing demo libs/orm-drizzle is left untouched).
+  src/schema/datasets/  table definitions
+  src/db.ts             connection
+  drizzle/ scripts/     migrations + seed (own lifecycle)
+```
+
+A future `apps/serverless/` (Lambda thin shell) will import the **same** `libs/core`
+usecases — that reuse is the payoff of pushing logic down out of the HTTP framework.
+
+## Style & Layer Discipline (YAGNI)
+
+- **Light functional**: repositories and usecases are factory functions with explicit
+  dependency injection (deps passed as arguments). No classes, no DI container, no
+  decorators. Not pure FP/monads — "functions + plain data + explicit dependencies".
+  Chosen for Drizzle fit, serverless cold-start, tree-shaking, testability, and
+  AI-agent legibility (no hidden DI magic).
+- **Starting layers are only three**: `schema` + `repository` + `usecase`.
+- **Deferred until earned**:
+  - `domain/` (rich entities/value-objects) — the zod `schema.ts` *is* the domain until
+    real invariants/behaviour appear; then promote to a `domain/` folder. No empty classes.
+  - `services/` — a generic "services" bucket becomes a junk drawer. When external systems
+    are integrated, add a **named adapter** (`storage.ts`, `mailer.ts`) instead.
+
+## ORM Decision
+
+**Drizzle** is the primary ORM in `libs/db`, scaffolded from the start-ts-by
+`orm/orm-drizzle` template. Rationale:
+
+- TypeScript-first; types inferred at compile time with **no codegen step** — edits stay
+  type-safe immediately (the most AI-agent-friendly property).
+- No engine binary → best serverless cold-start (relevant to a future `apps/serverless`).
+- Schema/migration/seed built in; the repo's `orm-drizzle` wrapper is already the most
+  complete of the four ORM demos.
+- Same Postgres camp as `@rfjs/jsonb-query` and `@rfjs/pg-toolkit`.
+
+The repository layer keeps the ORM behind a door: `usecase` never sees Drizzle types,
+so the choice stays swappable. We implement **one** ORM in `libs/core` (not four) — the
+existing `orm-*` wrappers remain standalone demos in `orm-app`.
+
+## `@rfjs/*` Package Application (the original request)
+
+| Package | Where | Use |
+|---|---|---|
+| `@rfjs/pg-toolkit` | `libs/db` scripts | check-and-create-db/schema, seed history |
+| `@rfjs/jsonb-query` | `libs/core/dataset` repository | build filter queries over a jsonb column on datasets |
+| `@rfjs/data-filter` / `@rfjs/data-transform` | `libs/core` usecase or workbench | result shaping / type conversion |
+| `@rfjs/retry` | `libs/db` connection, `apps/api` outbound | retry with delay |
+| `@rfjs/jwt` | `apps/api` middleware (Phase 6) | auth — deferred |
+| `@rfjs/web-core` | `apps/workbench` | tool/package registry (already used) |
+
+## First Vertical Slice: datasets CRUD
+
+End-to-end proof that the skeleton spans every layer. Build order (also the plan spine):
+
+1. **`libs/db`** — scaffold from the orm-drizzle template; add `datasets` table,
+   migration, and demo seed.
+2. **`libs/core/dataset`** — zod `schema.ts`; `repository.ts` (over `libs/db`);
+   `list` / `create` / `get` usecases.
+3. **`apps/api`** — a `delivery/http/dataset/` module (routes + handler) calling the
+   usecases, wired into swagger.
+4. **`apps/workbench`** — datasets page changes from "coming soon" to fetching the list
+   from `apps/api`.
+5. **Verify** — an E2E test running a create → list round-trip.
+
+### datasets table (initial, demo-seeded)
+
+Minimal columns to prove the slice; refined during planning if needed:
+
+- `id` (uuid, pk)
+- `name` (text, not null)
+- `description` (text, nullable)
+- `data` (jsonb) — payload; the `@rfjs/jsonb-query` filter target
+- `createdAt` / `updatedAt` (timestamptz)
+
+## Deployment / Serverless Stance
+
+Default runtime is **Fastify (`apps/api`) on k8s**. Serverless is **not built now**;
+because logic is runtime-agnostic, a `apps/serverless` Lambda shell can be added later
+when an event-driven/bursty workload appears. Self-hosted serverless on k8s
+(Knative / OpenFaaS / Fission) is technically possible but operationally heavy —
+evaluated separately only if such workloads materialise.
+
+## Error Handling
+
+- **Validation** at the usecase boundary via zod (`schema.parse`), surfacing typed errors.
+- **Repository** errors stay DB-specific inside the repository; the repository translates
+  them to domain-meaningful results/errors so usecases never branch on Drizzle internals.
+- `apps/api` maps usecase/domain errors to HTTP status via the existing Fastify
+  route-helper + `@fastify/sensible`.
+
+## Testing
+
+- **Unit**: usecases tested with a fake repository (light-functional DI makes this trivial).
+- **Repository**: integration-tested against real Postgres (Docker), consistent with the
+  jsonb-query real-PG E2E discipline already established in the repo.
+- **Slice E2E**: create → list round-trip through `apps/api`.
+
+## Out of Scope (this iteration)
+
+- Auth / users module (`@rfjs/jwt`) — Phase 6.
+- `apps/serverless` — deferred.
+- `domain/` and `services/` layers — added only when earned.
+- Additional modules beyond `dataset`.

--- a/libs/core/.gitignore
+++ b/libs/core/.gitignore
@@ -1,0 +1,6 @@
+dist
+types
+coverage
+.test
+.test/*
+node_modules

--- a/libs/core/package.json
+++ b/libs/core/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@rfjs/core",
+  "version": "0.0.0",
+  "description": "Workbench business logic: per-module schema, repository, usecase",
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "private": true,
+  "scripts": {
+    "clean": "pnpm exec rimraf ./dist ./types",
+    "build": "pnpm run clean && tsdown --config-loader unrun",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint \"src/**/*.ts\"",
+    "test": "vitest --passWithNoTests --run",
+    "vitest:run": "vitest --passWithNoTests --run",
+    "vitest:e2e:run": "vitest --config vitest.config.e2e.mts --passWithNoTests --run"
+  },
+  "dependencies": {
+    "@rfjs/db": "workspace:*",
+    "@rfjs/jsonb-query": "workspace:*",
+    "drizzle-orm": "^0.45.1",
+    "tslib": "^2.8.1",
+    "zod": "^4.0.0"
+  },
+  "devDependencies": {
+    "@types/pg": "^8.16.0",
+    "pg": "^8.16.3",
+    "rimraf": "^6.0.1",
+    "tsdown": "0.17.0-beta.6",
+    "typescript": "^5.7.3",
+    "vitest": "^4.1.8"
+  }
+}

--- a/libs/core/scripts/copyFilesPlugin.ts
+++ b/libs/core/scripts/copyFilesPlugin.ts
@@ -1,0 +1,48 @@
+/* eslint-disable @typescript-eslint/require-await */
+
+// copyFilesPlugin.js
+import fs from 'fs';
+import path from 'path';
+
+const copyFilesFn = async (distDir: string, paths: string[]) => {
+  paths = paths || [];
+  console.log(`\nCopying ${paths.join(', ')} to: ${distDir}`);
+
+  for (const p of paths) {
+    const srcPath = path.resolve(p);
+    const destPath = path.join(distDir, p);
+
+    try {
+      fs.accessSync(srcPath, fs.constants.R_OK);
+    } catch {
+      console.error(`\nPath not found: ${srcPath}`);
+      continue;
+    }
+
+    fs.mkdirSync(path.dirname(destPath), { recursive: true });
+
+    fs.cpSync(srcPath, destPath, {
+      recursive: true, // ⭐ 關鍵
+      force: true, // 覆蓋
+      preserveTimestamps: true,
+    });
+
+    console.log(`\nCopied: ${srcPath} → ${destPath}`);
+  }
+};
+
+type CopyFilesPluginOptions = {
+  distDir?: string;
+  files?: string[];
+};
+
+export function copyFilesPlugin(options: CopyFilesPluginOptions) {
+  const { distDir, files } = options;
+  const name = 'copy-files-plugin';
+  return {
+    name,
+    async closeBundle() {
+      await copyFilesFn(distDir ?? 'dist', files ?? []);
+    },
+  };
+}

--- a/libs/core/scripts/copyPackageJsonPlugin.ts
+++ b/libs/core/scripts/copyPackageJsonPlugin.ts
@@ -1,0 +1,90 @@
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
+// copyPackageJsonPlugin.js
+import fs from 'fs';
+import path from 'path';
+
+// eslint-disable-next-line @typescript-eslint/require-await
+const copyPackageJsonFn = async (distDir: string) => {
+  // 1) 讀取根目錄的 package.json
+  const pkg = JSON.parse(fs.readFileSync('package.json', 'utf-8'));
+
+  // 2) 根據需求刪除或改寫欄位
+  //    例如刪除 devDependencies、scripts 等
+  delete pkg.main;
+  delete pkg.module;
+  delete pkg.types;
+  delete pkg.exports;
+  delete pkg.devDependencies;
+  delete pkg.scripts;
+  delete pkg['lint-staged'];
+  delete pkg.config;
+  delete pkg.packageManager;
+
+  // 3) 如果要指定新的 main/module/types
+  //    （通常你會在 dist 內成為新的根）
+  pkg.main = 'index.js';
+  pkg.module = 'index.mjs';
+  pkg.types = 'index.d.ts';
+
+  // 4) 寫回 distDir 中
+  const outPath = path.join(distDir, 'package.json');
+  fs.writeFileSync(outPath, JSON.stringify(pkg, null, 2), 'utf-8');
+  console.log(`\nPackage.json copied to: ${outPath}`);
+};
+
+export function copyPackageJsonPlugin(
+  options = {
+    distDir: 'dist',
+    type: 'tsdown',
+  },
+) {
+  const { distDir, type } = options;
+  const name = `${type}-copy-package-json-plugin`;
+  switch (type) {
+    case 'rollup':
+      return {
+        name: name,
+        writeBundle() {
+          copyPackageJsonFn(distDir);
+        },
+      };
+    case 'esbuild':
+      return {
+        name: name,
+        setup(build: any) {
+          build.onEnd(() => copyPackageJsonFn(distDir));
+        },
+      };
+    case 'tsdown':
+      return {
+        name,
+        async closeBundle() {
+          await copyPackageJsonFn(distDir);
+        },
+      };
+    default:
+      return copyPackageJsonFn(distDir);
+  }
+}
+
+export const esbuildCopyPackageJsonPlugin = (options: any) =>
+  copyPackageJsonPlugin({
+    ...options,
+    type: 'esbuild',
+  });
+
+export const rollupCopyPackageJsonPlugin = (options: any) =>
+  copyPackageJsonPlugin({
+    ...options,
+    type: 'rollup',
+  });
+
+export const tsdownCopyPackageJsonPlugin = (options: any) =>
+  copyPackageJsonPlugin({
+    ...options,
+    type: 'tsdown',
+  });

--- a/libs/core/src/dataset/index.ts
+++ b/libs/core/src/dataset/index.ts
@@ -1,0 +1,3 @@
+export * from './schema';
+export * from './repository';
+export * from './usecase';

--- a/libs/core/src/dataset/repository.e2e.spec.ts
+++ b/libs/core/src/dataset/repository.e2e.spec.ts
@@ -1,0 +1,42 @@
+import path from 'path';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { createDb, migrateToLatest } from '@rfjs/db';
+import type { Pool } from 'pg';
+import { makeDatasetRepository } from './repository';
+
+const CONN =
+  process.env.TEST_DATABASE_URL ??
+  'postgresql://user:password@localhost:5433/workbench?options=-csearch_path=workbench';
+
+// process.cwd() is libs/core when running `pnpm --filter @rfjs/core vitest:e2e:run`
+const MIGRATIONS_FOLDER = path.resolve(process.cwd(), '../db/drizzle');
+
+describe('makeDatasetRepository (real PG)', () => {
+  let pool: Pool;
+  let repo: ReturnType<typeof makeDatasetRepository>;
+
+  beforeAll(async () => {
+    await migrateToLatest({ connectionString: CONN, migrationsFolder: MIGRATIONS_FOLDER });
+    const created = createDb(CONN);
+    pool = created.pool;
+    repo = makeDatasetRepository(created.db);
+  });
+
+  afterAll(async () => {
+    await pool?.end();
+  });
+
+  it('creates a dataset and reads it back by id', async () => {
+    const created = await repo.create({ name: 'IT', data: { a: 1 } });
+    expect(created.id).toBeTypeOf('string');
+    const found = await repo.getById(created.id);
+    expect(found?.name).toBe('IT');
+    expect(found?.data).toEqual({ a: 1 });
+  });
+
+  it('lists datasets', async () => {
+    await repo.create({ name: 'L1', data: {} });
+    const all = await repo.list();
+    expect(all.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/libs/core/src/dataset/repository.ts
+++ b/libs/core/src/dataset/repository.ts
@@ -1,0 +1,40 @@
+import { eq } from 'drizzle-orm';
+import { type Db, datasetsTable } from '@rfjs/db';
+import type { Dataset, CreateDatasetInput } from './schema';
+
+export interface DatasetRepository {
+  list(): Promise<Dataset[]>;
+  getById(id: string): Promise<Dataset | undefined>;
+  create(input: CreateDatasetInput): Promise<Dataset>;
+}
+
+const toDataset = (row: typeof datasetsTable.$inferSelect): Dataset => ({
+  id: row.id,
+  name: row.name,
+  description: row.description,
+  data: row.data,
+  createdAt: row.createdAt,
+  updatedAt: row.updatedAt,
+});
+
+export const makeDatasetRepository = (db: Db): DatasetRepository => ({
+  async list() {
+    const rows = await db.select().from(datasetsTable);
+    return rows.map(toDataset);
+  },
+  async getById(id) {
+    const rows = await db.select().from(datasetsTable).where(eq(datasetsTable.id, id));
+    return rows[0] ? toDataset(rows[0]) : undefined;
+  },
+  async create(input) {
+    const [row] = await db
+      .insert(datasetsTable)
+      .values({
+        name: input.name,
+        description: input.description ?? null,
+        data: input.data,
+      })
+      .returning();
+    return toDataset(row);
+  },
+});

--- a/libs/core/src/dataset/schema.spec.ts
+++ b/libs/core/src/dataset/schema.spec.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import { CreateDatasetInputSchema } from './schema';
+
+describe('CreateDatasetInputSchema', () => {
+  it('accepts a valid input and defaults data to {}', () => {
+    const parsed = CreateDatasetInputSchema.parse({ name: 'X' });
+    expect(parsed).toEqual({ name: 'X', description: undefined, data: {} });
+  });
+
+  it('rejects an empty name', () => {
+    expect(() => CreateDatasetInputSchema.parse({ name: '' })).toThrow();
+  });
+});

--- a/libs/core/src/dataset/schema.ts
+++ b/libs/core/src/dataset/schema.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+
+// NOTE: this repo is on zod v4 — z.record requires explicit key + value schemas.
+export const DatasetSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string().min(1),
+  description: z.string().nullable(),
+  data: z.record(z.string(), z.unknown()),
+  createdAt: z.date(),
+  updatedAt: z.date(),
+});
+export type Dataset = z.infer<typeof DatasetSchema>;
+
+export const CreateDatasetInputSchema = z.object({
+  name: z.string().min(1),
+  description: z.string().optional(),
+  data: z.record(z.string(), z.unknown()).default({}),
+});
+export type CreateDatasetInput = z.infer<typeof CreateDatasetInputSchema>;

--- a/libs/core/src/dataset/usecase/create-dataset.spec.ts
+++ b/libs/core/src/dataset/usecase/create-dataset.spec.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi } from 'vitest';
+import { makeCreateDataset } from './create-dataset';
+import type { DatasetRepository } from '../repository';
+import type { Dataset } from '../schema';
+
+const fakeDataset: Dataset = {
+  id: '00000000-0000-0000-0000-000000000001',
+  name: 'X',
+  description: null,
+  data: {},
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+describe('makeCreateDataset', () => {
+  it('validates input then delegates to repository.create', async () => {
+    const repo: DatasetRepository = {
+      list: vi.fn(),
+      getById: vi.fn(),
+      create: vi.fn().mockResolvedValue(fakeDataset),
+    };
+    const createDataset = makeCreateDataset({ repo });
+    const result = await createDataset({ name: 'X' });
+    expect(repo.create).toHaveBeenCalledWith({ name: 'X', description: undefined, data: {} });
+    expect(result).toBe(fakeDataset);
+  });
+
+  it('throws on invalid input without calling the repository', async () => {
+    const repo: DatasetRepository = {
+      list: vi.fn(),
+      getById: vi.fn(),
+      create: vi.fn(),
+    };
+    const createDataset = makeCreateDataset({ repo });
+    await expect(createDataset({ name: '' })).rejects.toThrow();
+    expect(repo.create).not.toHaveBeenCalled();
+  });
+});

--- a/libs/core/src/dataset/usecase/create-dataset.ts
+++ b/libs/core/src/dataset/usecase/create-dataset.ts
@@ -1,0 +1,9 @@
+import { CreateDatasetInputSchema, type Dataset } from '../schema';
+import type { DatasetRepository } from '../repository';
+
+export const makeCreateDataset =
+  (deps: { repo: DatasetRepository }) =>
+  async (input: unknown): Promise<Dataset> => {
+    const parsed = CreateDatasetInputSchema.parse(input);
+    return deps.repo.create(parsed);
+  };

--- a/libs/core/src/dataset/usecase/get-dataset.spec.ts
+++ b/libs/core/src/dataset/usecase/get-dataset.spec.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect, vi } from 'vitest';
+import { makeGetDataset } from './get-dataset';
+import type { DatasetRepository } from '../repository';
+
+describe('makeGetDataset', () => {
+  it('delegates to repository.getById', async () => {
+    const repo = { list: vi.fn(), getById: vi.fn().mockResolvedValue(undefined), create: vi.fn() } satisfies DatasetRepository;
+    const getDataset = makeGetDataset({ repo });
+    expect(await getDataset('abc')).toBeUndefined();
+    expect(repo.getById).toHaveBeenCalledWith('abc');
+  });
+});

--- a/libs/core/src/dataset/usecase/get-dataset.ts
+++ b/libs/core/src/dataset/usecase/get-dataset.ts
@@ -1,0 +1,7 @@
+import type { Dataset } from '../schema';
+import type { DatasetRepository } from '../repository';
+
+export const makeGetDataset =
+  (deps: { repo: DatasetRepository }) =>
+  (id: string): Promise<Dataset | undefined> =>
+    deps.repo.getById(id);

--- a/libs/core/src/dataset/usecase/index.ts
+++ b/libs/core/src/dataset/usecase/index.ts
@@ -1,0 +1,3 @@
+export * from './create-dataset';
+export * from './list-datasets';
+export * from './get-dataset';

--- a/libs/core/src/dataset/usecase/list-datasets.spec.ts
+++ b/libs/core/src/dataset/usecase/list-datasets.spec.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect, vi } from 'vitest';
+import { makeListDatasets } from './list-datasets';
+import type { DatasetRepository } from '../repository';
+
+describe('makeListDatasets', () => {
+  it('returns whatever the repository lists', async () => {
+    const repo = { list: vi.fn().mockResolvedValue([]), getById: vi.fn(), create: vi.fn() } satisfies DatasetRepository;
+    const listDatasets = makeListDatasets({ repo });
+    expect(await listDatasets()).toEqual([]);
+    expect(repo.list).toHaveBeenCalledOnce();
+  });
+});

--- a/libs/core/src/dataset/usecase/list-datasets.ts
+++ b/libs/core/src/dataset/usecase/list-datasets.ts
@@ -1,0 +1,7 @@
+import type { Dataset } from '../schema';
+import type { DatasetRepository } from '../repository';
+
+export const makeListDatasets =
+  (deps: { repo: DatasetRepository }) =>
+  (): Promise<Dataset[]> =>
+    deps.repo.list();

--- a/libs/core/src/index.ts
+++ b/libs/core/src/index.ts
@@ -1,2 +1,1 @@
-// dataset module export is added in a later task
-export {};
+export * from './dataset';

--- a/libs/core/src/index.ts
+++ b/libs/core/src/index.ts
@@ -1,0 +1,2 @@
+// dataset module export is added in a later task
+export {};

--- a/libs/core/tsconfig.build.json
+++ b/libs/core/tsconfig.build.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.lib.json",
+  "include": ["src"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/libs/core/tsconfig.json
+++ b/libs/core/tsconfig.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "target": "ES2023",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "importHelpers": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "declarationDir": "types",
+    "emitDeclarationOnly": false,
+    "outDir": "dist",
+    "sourceMap": true,
+    "paths": {
+      "@/*": ["./src/*"]
+    },
+    "resolveJsonModule": true,
+    "removeComments": true,
+    "newLine": "lf",
+    "noUnusedLocals": true,
+    "noFallthroughCasesInSwitch": true,
+    "isolatedModules": true,
+    "forceConsistentCasingInFileNames": true,
+    "lib": ["ESNext"]
+  }
+}

--- a/libs/core/tsconfig.lib.json
+++ b/libs/core/tsconfig.lib.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {},
+  "exclude": [
+    "node_modules",
+    "dist*",
+    "test",
+    "types",
+    "**/*(spec|test).ts",
+    "**/*e2e-(spec|test).ts",
+    "eslint.config.*",
+    "jest.config.*",
+    "vitest.config.*"
+  ]
+}

--- a/libs/core/tsdown.config.ts
+++ b/libs/core/tsdown.config.ts
@@ -1,0 +1,33 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+import { defineConfig } from 'tsdown';
+import { tsdownCopyPackageJsonPlugin } from './scripts/copyPackageJsonPlugin';
+import fs from 'fs';
+
+// 讀取 root package.json，標記 external
+const pkg: Record<string, unknown> =
+  JSON.parse(fs.readFileSync('./package.json', 'utf-8')) ?? {};
+const dependencies: string[] = Object.keys(pkg.dependencies || {});
+const peerDependencies: string[] = Object.keys(pkg.peerDependencies || {});
+const externalDeps = [...dependencies, ...peerDependencies];
+
+export default defineConfig({
+  entry: 'src/index.ts',
+  outDir: 'dist',
+  external: externalDeps,
+  tsconfig: 'tsconfig.build.json',
+  format: ['esm', 'cjs'],
+  treeshake: true,
+  platform: 'node',
+  fixedExtension: false,
+  target: 'es2023',
+  sourcemap: true,
+  clean: true,
+  dts: {
+    oxc: false,
+  },
+  plugins: [
+    tsdownCopyPackageJsonPlugin({
+      distDir: 'dist',
+    }),
+  ],
+});

--- a/libs/core/vitest.config.e2e.mts
+++ b/libs/core/vitest.config.e2e.mts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+
+export default defineConfig({
+  resolve: { alias: { '@': path.resolve(__dirname, './src') } },
+  test: {
+    include: ['src/**/*.e2e.spec.ts'],
+    testTimeout: 30000,
+    hookTimeout: 30000,
+  },
+});

--- a/libs/core/vitest.config.mts
+++ b/libs/core/vitest.config.mts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+
+export default defineConfig({
+  resolve: { alias: { '@': path.resolve(__dirname, './src') } },
+  test: {
+    include: ['src/**/*.spec.ts'],
+    exclude: ['src/**/*.e2e.spec.ts', '**/node_modules/**'],
+    reporters: ['verbose'],
+  },
+});

--- a/libs/db/.env.example
+++ b/libs/db/.env.example
@@ -1,0 +1,1 @@
+DATABASE_URL="postgresql://user:password@localhost:5432/workbench?options=-csearch_path=workbench"

--- a/libs/db/.gitignore
+++ b/libs/db/.gitignore
@@ -1,0 +1,6 @@
+dist
+types
+coverage
+.test
+.test/*
+node_modules

--- a/libs/db/.test/vitest/results.xml
+++ b/libs/db/.test/vitest/results.xml
@@ -1,3 +1,0 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<testsuites name="vitest tests" tests="0" failures="0" errors="0" time="0">
-</testsuites>

--- a/libs/db/.test/vitest/results.xml
+++ b/libs/db/.test/vitest/results.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<testsuites name="vitest tests" tests="0" failures="0" errors="0" time="0">
+</testsuites>

--- a/libs/db/drizzle.config.ts
+++ b/libs/db/drizzle.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'drizzle-kit';
+
+export default defineConfig({
+  schema: './src/schema/index.ts',
+  out: './drizzle',
+  dialect: 'postgresql',
+  dbCredentials: { url: process.env.DATABASE_URL! },
+});

--- a/libs/db/drizzle/0000_cynical_wiccan.sql
+++ b/libs/db/drizzle/0000_cynical_wiccan.sql
@@ -1,0 +1,8 @@
+CREATE TABLE "datasets" (
+	"dataset_id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"name" text NOT NULL,
+	"description" text,
+	"data" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);

--- a/libs/db/drizzle/meta/0000_snapshot.json
+++ b/libs/db/drizzle/meta/0000_snapshot.json
@@ -1,0 +1,72 @@
+{
+  "id": "96eff2f5-8bac-4540-b7d1-a9603774a6d4",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.datasets": {
+      "name": "datasets",
+      "schema": "",
+      "columns": {
+        "dataset_id": {
+          "name": "dataset_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/libs/db/drizzle/meta/_journal.json
+++ b/libs/db/drizzle/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1781421121727,
+      "tag": "0000_cynical_wiccan",
+      "breakpoints": true
+    }
+  ]
+}

--- a/libs/db/package.json
+++ b/libs/db/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@rfjs/db",
+  "version": "0.0.0",
+  "description": "Workbench Drizzle plumbing: connection, schema, migrations, seed",
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "private": true,
+  "scripts": {
+    "clean": "pnpm exec rimraf ./dist ./types",
+    "build": "pnpm run clean && tsdown --config-loader unrun",
+    "typecheck": "tsc --noEmit",
+    "generate": "pnpm exec drizzle-kit generate",
+    "migrate": "pnpm exec tsx src/scripts/run-migrate.ts",
+    "seed": "pnpm exec tsx src/scripts/run-seed.ts",
+    "lint": "eslint \"src/**/*.ts\"",
+    "test": "vitest --passWithNoTests --run",
+    "vitest:run": "vitest --passWithNoTests --run",
+    "vitest:e2e:run": "vitest --config vitest.config.e2e.mts --passWithNoTests --run"
+  },
+  "dependencies": {
+    "drizzle-orm": "^0.45.1",
+    "pg": "^8.16.3",
+    "pg-connection-string": "^2.7.0",
+    "tslib": "^2.8.1"
+  },
+  "devDependencies": {
+    "@types/pg": "^8.16.0",
+    "dotenv": "^17.2.3",
+    "drizzle-kit": "^0.31.8",
+    "rimraf": "^6.0.1",
+    "tsx": "^4.19.2",
+    "tsdown": "0.17.0-beta.6",
+    "typescript": "^5.7.3",
+    "vitest": "^4.1.8"
+  }
+}

--- a/libs/db/package.json
+++ b/libs/db/package.json
@@ -15,8 +15,7 @@
     "seed": "pnpm exec tsx src/scripts/run-seed.ts",
     "lint": "eslint \"src/**/*.ts\"",
     "test": "vitest --passWithNoTests --run",
-    "vitest:run": "vitest --passWithNoTests --run",
-    "vitest:e2e:run": "vitest --config vitest.config.e2e.mts --passWithNoTests --run"
+    "vitest:run": "vitest --passWithNoTests --run"
   },
   "dependencies": {
     "drizzle-orm": "^0.45.1",

--- a/libs/db/scripts/copyFilesPlugin.ts
+++ b/libs/db/scripts/copyFilesPlugin.ts
@@ -1,0 +1,48 @@
+/* eslint-disable @typescript-eslint/require-await */
+
+// copyFilesPlugin.js
+import fs from 'fs';
+import path from 'path';
+
+const copyFilesFn = async (distDir: string, paths: string[]) => {
+  paths = paths || [];
+  console.log(`\nCopying ${paths.join(', ')} to: ${distDir}`);
+
+  for (const p of paths) {
+    const srcPath = path.resolve(p);
+    const destPath = path.join(distDir, p);
+
+    try {
+      fs.accessSync(srcPath, fs.constants.R_OK);
+    } catch {
+      console.error(`\nPath not found: ${srcPath}`);
+      continue;
+    }
+
+    fs.mkdirSync(path.dirname(destPath), { recursive: true });
+
+    fs.cpSync(srcPath, destPath, {
+      recursive: true, // ⭐ 關鍵
+      force: true, // 覆蓋
+      preserveTimestamps: true,
+    });
+
+    console.log(`\nCopied: ${srcPath} → ${destPath}`);
+  }
+};
+
+type CopyFilesPluginOptions = {
+  distDir?: string;
+  files?: string[];
+};
+
+export function copyFilesPlugin(options: CopyFilesPluginOptions) {
+  const { distDir, files } = options;
+  const name = 'copy-files-plugin';
+  return {
+    name,
+    async closeBundle() {
+      await copyFilesFn(distDir ?? 'dist', files ?? []);
+    },
+  };
+}

--- a/libs/db/scripts/copyPackageJsonPlugin.ts
+++ b/libs/db/scripts/copyPackageJsonPlugin.ts
@@ -1,0 +1,90 @@
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
+// copyPackageJsonPlugin.js
+import fs from 'fs';
+import path from 'path';
+
+// eslint-disable-next-line @typescript-eslint/require-await
+const copyPackageJsonFn = async (distDir: string) => {
+  // 1) 讀取根目錄的 package.json
+  const pkg = JSON.parse(fs.readFileSync('package.json', 'utf-8'));
+
+  // 2) 根據需求刪除或改寫欄位
+  //    例如刪除 devDependencies、scripts 等
+  delete pkg.main;
+  delete pkg.module;
+  delete pkg.types;
+  delete pkg.exports;
+  delete pkg.devDependencies;
+  delete pkg.scripts;
+  delete pkg['lint-staged'];
+  delete pkg.config;
+  delete pkg.packageManager;
+
+  // 3) 如果要指定新的 main/module/types
+  //    （通常你會在 dist 內成為新的根）
+  pkg.main = 'index.js';
+  pkg.module = 'index.mjs';
+  pkg.types = 'index.d.ts';
+
+  // 4) 寫回 distDir 中
+  const outPath = path.join(distDir, 'package.json');
+  fs.writeFileSync(outPath, JSON.stringify(pkg, null, 2), 'utf-8');
+  console.log(`\nPackage.json copied to: ${outPath}`);
+};
+
+export function copyPackageJsonPlugin(
+  options = {
+    distDir: 'dist',
+    type: 'tsdown',
+  },
+) {
+  const { distDir, type } = options;
+  const name = `${type}-copy-package-json-plugin`;
+  switch (type) {
+    case 'rollup':
+      return {
+        name: name,
+        writeBundle() {
+          copyPackageJsonFn(distDir);
+        },
+      };
+    case 'esbuild':
+      return {
+        name: name,
+        setup(build: any) {
+          build.onEnd(() => copyPackageJsonFn(distDir));
+        },
+      };
+    case 'tsdown':
+      return {
+        name,
+        async closeBundle() {
+          await copyPackageJsonFn(distDir);
+        },
+      };
+    default:
+      return copyPackageJsonFn(distDir);
+  }
+}
+
+export const esbuildCopyPackageJsonPlugin = (options: any) =>
+  copyPackageJsonPlugin({
+    ...options,
+    type: 'esbuild',
+  });
+
+export const rollupCopyPackageJsonPlugin = (options: any) =>
+  copyPackageJsonPlugin({
+    ...options,
+    type: 'rollup',
+  });
+
+export const tsdownCopyPackageJsonPlugin = (options: any) =>
+  copyPackageJsonPlugin({
+    ...options,
+    type: 'tsdown',
+  });

--- a/libs/db/src/consts.ts
+++ b/libs/db/src/consts.ts
@@ -1,0 +1,2 @@
+export const SCHEMA = 'workbench';
+export const DATABASE = 'workbench';

--- a/libs/db/src/db.ts
+++ b/libs/db/src/db.ts
@@ -1,0 +1,35 @@
+import { drizzle, NodePgDatabase } from 'drizzle-orm/node-postgres';
+import { Client, Pool } from 'pg';
+import * as schema from './schema';
+import { getConnectionStringInfo } from './utils';
+
+export type Schema = typeof schema;
+export type Db = NodePgDatabase<Schema>;
+
+export function createDb(
+  connectionString: string,
+  targetSchema?: string,
+  useClient = false,
+): { pool: Pool; client: Client; db: Db; hasSearchPath: boolean } {
+  const { finalConnectionString, hasSearchPath } = getConnectionStringInfo(
+    connectionString,
+    targetSchema,
+  );
+  const pool = new Pool({ connectionString: finalConnectionString });
+  const client = new Client({ connectionString: finalConnectionString });
+  const db = drizzle(useClient ? client : pool, { schema });
+  return { pool, client, db, hasSearchPath };
+}
+
+export function createDbByClient(
+  connectionString: string,
+  targetSchema?: string,
+): { client: Client; db: Db; hasSearchPath: boolean } {
+  const { finalConnectionString, hasSearchPath } = getConnectionStringInfo(
+    connectionString,
+    targetSchema,
+  );
+  const client = new Client({ connectionString: finalConnectionString });
+  const db = drizzle(client, { schema });
+  return { client, db, hasSearchPath };
+}

--- a/libs/db/src/db.ts
+++ b/libs/db/src/db.ts
@@ -1,7 +1,7 @@
 import { drizzle, NodePgDatabase } from 'drizzle-orm/node-postgres';
 import { Client, Pool } from 'pg';
-import * as schema from './schema';
-import { getConnectionStringInfo } from './utils';
+import * as schema from '@/schema';
+import { getConnectionStringInfo } from '@/utils';
 
 export type Schema = typeof schema;
 export type Db = NodePgDatabase<Schema>;

--- a/libs/db/src/index.ts
+++ b/libs/db/src/index.ts
@@ -1,0 +1,5 @@
+export * from './db';
+export * from './schema';
+export * from './consts';
+export * from './type';
+export * from './scripts';

--- a/libs/db/src/index.ts
+++ b/libs/db/src/index.ts
@@ -2,4 +2,3 @@ export * from './db';
 export * from './schema';
 export * from './consts';
 export * from './type';
-export * from './scripts';

--- a/libs/db/src/index.ts
+++ b/libs/db/src/index.ts
@@ -2,3 +2,4 @@ export * from './db';
 export * from './schema';
 export * from './consts';
 export * from './type';
+export * from './scripts';

--- a/libs/db/src/schema/datasets/index.ts
+++ b/libs/db/src/schema/datasets/index.ts
@@ -1,0 +1,1 @@
+export * from './table';

--- a/libs/db/src/schema/datasets/table.spec.ts
+++ b/libs/db/src/schema/datasets/table.spec.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { getTableConfig } from 'drizzle-orm/pg-core';
+import { datasetsTable } from './table';
+
+describe('datasetsTable', () => {
+  it('maps to the "datasets" table with the expected columns', () => {
+    const config = getTableConfig(datasetsTable);
+    expect(config.name).toBe('datasets');
+    const columns = config.columns.map((c) => c.name).sort();
+    expect(columns).toEqual(
+      ['created_at', 'data', 'dataset_id', 'description', 'name', 'updated_at'].sort(),
+    );
+  });
+
+  it('makes name NOT NULL and id the primary key', () => {
+    const config = getTableConfig(datasetsTable);
+    const name = config.columns.find((c) => c.name === 'name');
+    const id = config.columns.find((c) => c.name === 'dataset_id');
+    expect(name?.notNull).toBe(true);
+    expect(id?.primary).toBe(true);
+  });
+});

--- a/libs/db/src/schema/datasets/table.ts
+++ b/libs/db/src/schema/datasets/table.ts
@@ -1,0 +1,13 @@
+import { pgTable, text, timestamp, uuid, jsonb } from 'drizzle-orm/pg-core';
+
+export const datasetsTable = pgTable('datasets', {
+  id: uuid('dataset_id').defaultRandom().primaryKey(),
+  name: text('name').notNull(),
+  description: text('description'),
+  data: jsonb('data').$type<Record<string, unknown>>().notNull().default({}),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+});
+
+export type DatasetRow = typeof datasetsTable.$inferSelect;
+export type NewDatasetRow = typeof datasetsTable.$inferInsert;

--- a/libs/db/src/schema/index.ts
+++ b/libs/db/src/schema/index.ts
@@ -1,0 +1,1 @@
+export * from './datasets';

--- a/libs/db/src/schema/index.ts
+++ b/libs/db/src/schema/index.ts
@@ -1,2 +1,1 @@
-// datasets schema is added in a later task
-export {};
+export * from './datasets';

--- a/libs/db/src/schema/index.ts
+++ b/libs/db/src/schema/index.ts
@@ -1,1 +1,2 @@
-export * from './datasets';
+// datasets schema is added in a later task
+export {};

--- a/libs/db/src/scripts/check-and-create-db.ts
+++ b/libs/db/src/scripts/check-and-create-db.ts
@@ -1,0 +1,37 @@
+import { Client } from 'pg';
+import { parse } from 'pg-connection-string';
+
+export async function checkAndCreateDB(connectionString: string): Promise<void> {
+  // Use pg-connection-string for more robust parsing and to generate admin connection string
+  // Default fallback
+  const config = parse(connectionString);
+  const { user, password, host, port, database } = config;
+  const adminConnectionString = `postgres://${user}:${password}@${host}:${port}/postgres`;
+  const targetDb = database ?? 'workbench';
+  const client = new Client({
+    connectionString: adminConnectionString,
+  });
+  let isConnected = false;
+
+  try {
+    await client.connect();
+    isConnected = true;
+    const res = await client.query(`SELECT 1 FROM pg_database WHERE datname = $1`, [
+      targetDb,
+    ]);
+
+    if (res.rowCount === 0) {
+      console.log(`Database "${targetDb}" does not exist. Creating...`);
+      await client.query(`CREATE DATABASE "${targetDb}"`);
+      console.log(`Database "${targetDb}" created successfully.`);
+    }
+  } catch (error) {
+    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+    console.error(`Failed to ensure database exists: ${error}`);
+    throw error;
+  } finally {
+    if (isConnected) {
+      await client.end();
+    }
+  }
+}

--- a/libs/db/src/scripts/check-and-create-schema.ts
+++ b/libs/db/src/scripts/check-and-create-schema.ts
@@ -1,0 +1,25 @@
+import { Client } from 'pg';
+
+export async function checkAndCreateSchema(
+  connectionString: string,
+  schemas: string[],
+): Promise<void> {
+  const client = new Client(connectionString);
+  let isConnected = false;
+
+  try {
+    await client.connect();
+    isConnected = true;
+    for (const schema of schemas) {
+      await client.query(`CREATE SCHEMA IF NOT EXISTS "${schema}"`);
+    }
+  } catch (error) {
+    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+    console.error(`Failed to ensure schema exists: ${error}`);
+    throw error;
+  } finally {
+    if (isConnected) {
+      await client.end();
+    }
+  }
+}

--- a/libs/db/src/scripts/index.ts
+++ b/libs/db/src/scripts/index.ts
@@ -1,0 +1,4 @@
+export * from './check-and-create-db';
+export * from './check-and-create-schema';
+export * from './migrate-to-latest';
+export * from './seed-datasets';

--- a/libs/db/src/scripts/migrate-to-latest.ts
+++ b/libs/db/src/scripts/migrate-to-latest.ts
@@ -1,0 +1,28 @@
+import { migrate } from 'drizzle-orm/node-postgres/migrator';
+import { createDbByClient } from '@/db';
+import { checkAndCreateDB } from './check-and-create-db';
+import { checkAndCreateSchema } from './check-and-create-schema';
+import { SCHEMA } from '@/consts';
+import { getConnectionStringInfo } from '@/utils';
+import { MigrateToLatestParams } from '@/type';
+
+export async function migrateToLatest(params: MigrateToLatestParams): Promise<void> {
+  const { connectionString, schema = SCHEMA, migrationsFolder = 'drizzle' } = params;
+  const { finalConnectionString, finalSchema } = getConnectionStringInfo(
+    connectionString,
+    schema,
+  );
+
+  await checkAndCreateDB(finalConnectionString);
+  await checkAndCreateSchema(finalConnectionString, [finalSchema]);
+
+  const { client, db } = createDbByClient(finalConnectionString);
+  let connected = false;
+  try {
+    await client.connect();
+    connected = true;
+    await migrate(db, { migrationsFolder, migrationsSchema: finalSchema });
+  } finally {
+    if (connected) await client.end();
+  }
+}

--- a/libs/db/src/scripts/run-migrate.ts
+++ b/libs/db/src/scripts/run-migrate.ts
@@ -1,0 +1,12 @@
+import 'dotenv/config';
+import { migrateToLatest } from '@/scripts/migrate-to-latest';
+
+const connectionString = process.env.DATABASE_URL;
+if (!connectionString) throw new Error('DATABASE_URL is required');
+
+migrateToLatest({ connectionString })
+  .then(() => console.log('Migrations completed.'))
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });

--- a/libs/db/src/scripts/run-seed.ts
+++ b/libs/db/src/scripts/run-seed.ts
@@ -1,0 +1,10 @@
+import 'dotenv/config';
+import { runSeedDatasets } from '@/scripts/seed-datasets';
+
+const connectionString = process.env.DATABASE_URL;
+if (!connectionString) throw new Error('DATABASE_URL is required');
+
+runSeedDatasets(connectionString).catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/libs/db/src/scripts/seed-datasets.ts
+++ b/libs/db/src/scripts/seed-datasets.ts
@@ -1,0 +1,22 @@
+import { createDb, type Db } from '@/db';
+import { datasetsTable } from '@/schema';
+
+export const DEMO_DATASETS = [
+  { name: 'Sales — Q1', description: 'Demo seed', data: { region: 'apac', rows: 120 } },
+  { name: 'Signups', description: 'Demo seed', data: { region: 'emea', rows: 42 } },
+] satisfies { name: string; description: string; data: Record<string, unknown> }[];
+
+export async function seedDatasets(db: Db): Promise<number> {
+  const inserted = await db.insert(datasetsTable).values(DEMO_DATASETS).returning();
+  return inserted.length;
+}
+
+export async function runSeedDatasets(connectionString: string): Promise<void> {
+  const { pool, db } = createDb(connectionString);
+  try {
+    const n = await seedDatasets(db);
+    console.log(`Seeded ${n} datasets.`);
+  } finally {
+    await pool.end();
+  }
+}

--- a/libs/db/src/type.ts
+++ b/libs/db/src/type.ts
@@ -1,0 +1,6 @@
+export type MigrateToLatestParams = {
+  connectionString: string;
+  schema?: string;
+  migrationsSchema?: string;
+  migrationsFolder?: string;
+};

--- a/libs/db/src/utils/get-connection-string-info.ts
+++ b/libs/db/src/utils/get-connection-string-info.ts
@@ -1,0 +1,58 @@
+import { parse } from 'pg-connection-string';
+import { getOptionsSchemas } from './get-options-schemas';
+
+function buildSearchPathOption(schema: string): string {
+  return `-c search_path=${schema}`;
+}
+
+function mergeOptions(existing: string | undefined, schema: string): string {
+  const schemas = getOptionsSchemas(existing);
+  if (schemas.length > 0) return existing ?? '';
+  const add = buildSearchPathOption(schema);
+  return existing && existing.trim() ? `${existing.trim()} ${add}` : add;
+}
+
+export function getConnectionStringInfo(
+  connectionString: string,
+  targetSchema?: string,
+): {
+  finalConnectionString: string;
+  finalSchema: string;
+  optionsSchemas: string[];
+  hasSearchPath: boolean;
+} {
+  const config = parse(connectionString);
+  const url = new URL(connectionString);
+
+  // 這裡拿到的 options **是 decode 後的字串**（例如 "-c search_path=prisma_test"）
+  const options = url.searchParams.get('options') ?? config.options ?? undefined;
+
+  const optionsSchemas = getOptionsSchemas(options);
+  const hasSearchPath = optionsSchemas.length > 0;
+
+  const schemaParam = url.searchParams.get('schema') ?? undefined;
+
+  // options search_path > schema param > targetSchema > public
+  const finalSchema = optionsSchemas[0] ?? schemaParam ?? targetSchema ?? 'public';
+
+  // (1) 有 schema，沒 search_path → 補 options
+  if (!hasSearchPath && finalSchema !== 'public') {
+    const merged = mergeOptions(options, finalSchema);
+    // ✅ 不要 encodeURIComponent，URLSearchParams 會自動處理
+    url.searchParams.set('options', merged);
+  }
+
+  // (2) 有 search_path，沒 schema → 補 schema
+  if (!schemaParam && optionsSchemas.length > 0) {
+    url.searchParams.set('schema', optionsSchemas[0]);
+  }
+
+  const finalConnectionString = url.toString();
+
+  return {
+    optionsSchemas,
+    finalSchema,
+    finalConnectionString,
+    hasSearchPath,
+  };
+}

--- a/libs/db/src/utils/get-options-schemas.ts
+++ b/libs/db/src/utils/get-options-schemas.ts
@@ -1,0 +1,21 @@
+/**
+ * 從 options 解析 search_path
+ * 支援：
+ *   -c search_path=a,b
+ *   -csearch_path=a,b   （防呆，但會 normalize）
+ */
+export function getOptionsSchemas(options?: string): string[] {
+  if (!options) return [];
+
+  // normalize: -csearch_path -> -c search_path
+  const normalized = options.replace(/-csearch_path=/g, '-c search_path=');
+
+  // match: search_path=a,b (到空白結束)
+  const m = normalized.match(/(?:^|\s)search_path=([^\s]+)/);
+  if (!m) return [];
+
+  return m[1]
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+}

--- a/libs/db/src/utils/index.ts
+++ b/libs/db/src/utils/index.ts
@@ -1,0 +1,2 @@
+export * from './get-options-schemas';
+export * from './get-connection-string-info';

--- a/libs/db/tsconfig.build.json
+++ b/libs/db/tsconfig.build.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.lib.json",
+  "include": ["src"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/libs/db/tsconfig.json
+++ b/libs/db/tsconfig.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "target": "ES2023",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "importHelpers": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "declarationDir": "types",
+    "emitDeclarationOnly": false,
+    "outDir": "dist",
+    "sourceMap": true,
+    "paths": {
+      "@/*": ["./src/*"]
+    },
+    "resolveJsonModule": true,
+    "removeComments": true,
+    "newLine": "lf",
+    "noUnusedLocals": true,
+    "noFallthroughCasesInSwitch": true,
+    "isolatedModules": true,
+    "forceConsistentCasingInFileNames": true,
+    "lib": ["ESNext"]
+  }
+}

--- a/libs/db/tsconfig.lib.json
+++ b/libs/db/tsconfig.lib.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {},
+  "exclude": [
+    "node_modules",
+    "dist*",
+    "test",
+    "types",
+    "**/*(spec|test).ts",
+    "**/*e2e-(spec|test).ts",
+    "eslint.config.*",
+    "jest.config.*",
+    "vitest.config.*"
+  ]
+}

--- a/libs/db/tsdown.config.ts
+++ b/libs/db/tsdown.config.ts
@@ -1,0 +1,59 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+import { defineConfig } from 'tsdown';
+import { tsdownCopyPackageJsonPlugin } from './scripts/copyPackageJsonPlugin';
+import fs from 'fs';
+import { copyFilesPlugin } from './scripts/copyFilesPlugin';
+
+// 讀取 root package.json，標記 external
+const pkg: Record<string, unknown> =
+  JSON.parse(fs.readFileSync('./package.json', 'utf-8')) ?? {};
+const dependencies: string[] = Object.keys(pkg.dependencies || {});
+const peerDependencies: string[] = Object.keys(pkg.peerDependencies || {});
+const externalDeps = [...dependencies, ...peerDependencies];
+
+export default defineConfig({
+  // 對應你原本的 inputFile = 'src/index.ts'
+  entry: 'src/index.ts',
+
+  // 對應原本 distDir = 'dist'
+  outDir: 'dist',
+  external: externalDeps,
+
+  tsconfig: 'tsconfig.build.json',
+
+  // 一次出 ESM + CJS（取代你原本兩個 esbuild.build）
+  format: ['esm', 'cjs'],
+
+  treeshake: true,
+
+  // 對應原本 platform: 'neutral'
+  platform: 'node',
+
+  fixedExtension: false,
+
+  // 你原本沒設 target，就給個合理的預設
+  target: 'es2023',
+
+  // sourcemap: true 跟 esbuild 行為一致
+  sourcemap: true,
+
+  // 清 dist（如果還是習慣自己跑 clean script，可以把這行拿掉）
+  clean: true,
+
+  // .d.ts 生成：
+  // - 若 package.json 有 "types" 或 exports.types，預設會自動開啟 dts
+  // - 為了明確，這邊直接打開
+  dts: {
+    // 使用 Oxc backend，速度比較快（需要 tsconfig 裡有 isolatedDeclarations 會更爽）
+    // 關閉 oxc 以避免 drizzle-orm 的 pgTable 型別推斷問題
+    oxc: false,
+  },
+  plugins: [
+    tsdownCopyPackageJsonPlugin({
+      distDir: 'dist',
+    }),
+    copyFilesPlugin({
+      files: ['drizzle'],
+    }),
+  ],
+});

--- a/libs/db/vitest.config.mts
+++ b/libs/db/vitest.config.mts
@@ -1,0 +1,21 @@
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+  test: {
+    // ... Specify options here.
+    include: ['src/**/*.test.(ts|js)', 'src/**/*.spec.(ts|js)'],
+    reporters: ['verbose', 'junit'],
+    outputFile: {
+      junit: '.test/vitest/results.xml',
+    },
+    coverage: {
+      enabled: false,
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -473,6 +473,46 @@ importers:
         specifier: ^4.1.8
         version: 4.1.8(@types/node@25.9.3)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@7.2.4(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))
 
+  libs/db:
+    dependencies:
+      drizzle-orm:
+        specifier: ^0.45.1
+        version: 0.45.1(@electric-sql/pglite@0.3.2)(@prisma/client@7.2.0(prisma@7.2.0(@types/react@19.2.17)(magicast@0.3.5)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@5.8.3))(typescript@5.8.3))(@types/pg@8.16.0)(kysely@0.28.11)(mysql2@3.15.3)(pg@8.16.3)(postgres@3.4.7)(prisma@7.2.0(@types/react@19.2.17)(magicast@0.3.5)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@5.8.3))
+      pg:
+        specifier: ^8.16.3
+        version: 8.16.3
+      pg-connection-string:
+        specifier: ^2.7.0
+        version: 2.9.1
+      tslib:
+        specifier: ^2.8.1
+        version: 2.8.1
+    devDependencies:
+      '@types/pg':
+        specifier: ^8.16.0
+        version: 8.16.0
+      dotenv:
+        specifier: ^17.2.3
+        version: 17.3.1
+      drizzle-kit:
+        specifier: ^0.31.8
+        version: 0.31.8
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.1.2
+      tsdown:
+        specifier: 0.17.0-beta.6
+        version: 0.17.0-beta.6(typescript@5.8.3)
+      tsx:
+        specifier: ^4.19.2
+        version: 4.21.0
+      typescript:
+        specifier: ^5.7.3
+        version: 5.8.3
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@types/node@25.9.3)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@7.2.4(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))
+
   libs/orm-drizzle:
     dependencies:
       dotenv:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,6 +93,9 @@ importers:
       pino-pretty:
         specifier: ^13.1.2
         version: 13.1.2
+      zod:
+        specifier: ^4.0.0
+        version: 4.4.3
     devDependencies:
       '@commitlint/cli':
         specifier: ^19.7.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,12 @@ importers:
       '@fastify/swagger-ui':
         specifier: ^5.2.5
         version: 5.2.5
+      '@rfjs/core':
+        specifier: workspace:*
+        version: link:../../libs/core
+      '@rfjs/db':
+        specifier: workspace:*
+        version: link:../../libs/db
       dotenv-flow:
         specifier: ^4.1.0
         version: 4.1.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -473,6 +473,43 @@ importers:
         specifier: ^4.1.8
         version: 4.1.8(@types/node@25.9.3)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@7.2.4(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))
 
+  libs/core:
+    dependencies:
+      '@rfjs/db':
+        specifier: workspace:*
+        version: link:../db
+      '@rfjs/jsonb-query':
+        specifier: workspace:*
+        version: link:../../packages/jsonb-query
+      drizzle-orm:
+        specifier: ^0.45.1
+        version: 0.45.1(@electric-sql/pglite@0.3.2)(@prisma/client@7.2.0(prisma@7.2.0(@types/react@19.2.17)(magicast@0.3.5)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@5.8.3))(typescript@5.8.3))(@types/pg@8.16.0)(kysely@0.28.11)(mysql2@3.15.3)(pg@8.16.3)(postgres@3.4.7)(prisma@7.2.0(@types/react@19.2.17)(magicast@0.3.5)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@5.8.3))
+      tslib:
+        specifier: ^2.8.1
+        version: 2.8.1
+      zod:
+        specifier: ^4.0.0
+        version: 4.4.3
+    devDependencies:
+      '@types/pg':
+        specifier: ^8.16.0
+        version: 8.16.0
+      pg:
+        specifier: ^8.16.3
+        version: 8.16.3
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.1.2
+      tsdown:
+        specifier: 0.17.0-beta.6
+        version: 0.17.0-beta.6(typescript@5.8.3)
+      typescript:
+        specifier: ^5.7.3
+        version: 5.8.3
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@types/node@25.9.3)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@7.2.4(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))
+
   libs/db:
     dependencies:
       drizzle-orm:


### PR DESCRIPTION
## Summary

A copyable, production-grade **backend foundation** for the workbench, proven end-to-end by a `datasets` CRUD vertical slice. Business logic is runtime-agnostic in `libs/`; apps are thin shells.

- **`libs/db` (`@rfjs/db`)** — Drizzle plumbing: connection, `datasets` table, migration, demo seed. Follows the `libs/orm-drizzle` template lineage (workspace-native); demo `libs/orm-drizzle` untouched.
- **`libs/core` (`@rfjs/core`)** — light-functional `dataset` module: zod contract + `makeDatasetRepository` (the only ORM-aware layer) + `create`/`list`/`get` usecases (factory + explicit DI, no classes).
- **`apps/api`** — thin Fastify `datasets` HTTP module (auto-discovered), composition root wiring the usecases, and a `ZodError → 400` error handler (no internal leak).
- **`apps/workbench`** — datasets page fetches the list from the API over HTTP (pure frontend; degrades gracefully).

Architecture, ORM choice (Drizzle), light-functional style, and the workflow/story future direction are recorded in `docs/superpowers/specs/2026-06-14-workbench-backend-foundation-design.md`; task breakdown in `docs/superpowers/plans/`.

## `@rfjs/*` applied
`jsonb-query` pre-wired into `@rfjs/core` (first use: filtering the `data` jsonb column, next iteration). `pg-toolkit` deliberately deferred (its published surface is `pure`-only) — inline bootstrap scripts used meanwhile.

## Test Plan
- [x] Unit: `@rfjs/db` 2, `@rfjs/core` 6 (fake-repo usecases + zod), `apps/api` 6 (route tests incl. 201/404/400) — all pass
- [x] Integration: `@rfjs/core` repository real-PG test via `docker-compose.test.yml`
- [x] Typecheck: `@rfjs/db`, `@rfjs/core`, `api`, `workbench` — clean
- [x] Full-stack e2e (recorded in `docs/superpowers/notes/2026-06-14-workbench-backend-e2e.md`): migrate + seed → `POST /datasets` 201 → `GET /datasets` returns 3 rows → bad id 404 → workbench server-rendered HTML shows seeded names
- [ ] Reviewer: spin up `docker compose -f docker-compose.test.yml up -d` and run `pnpm --filter @rfjs/core vitest:e2e:run`

## Notes / follow-ups (non-blocking)
- All new/changed packages are `private` → no changeset needed.
- Deferred: graceful DB-pool shutdown (`onClose`) in apps/api; workbench distinguishing "API down" vs "no datasets"; swap inline bootstrap scripts to `@rfjs/pg-toolkit` admin surface once exposed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)