### PR TITLE
feat(datasets): jsonb filtering via @rfjs/jsonb-query (POST /datasets/query)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -86,6 +86,7 @@
   "dependencies": {
     "@rfjs/core": "workspace:*",
     "@rfjs/db": "workspace:*",
+    "@rfjs/jsonb-query": "workspace:*",
     "zod": "^4.0.0",
     "@fastify/cors": "^11.1.0",
     "@fastify/formbody": "^8.0.2",

--- a/apps/api/src/delivery/http/dataset/dataset.route.spec.ts
+++ b/apps/api/src/delivery/http/dataset/dataset.route.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeAll } from 'vitest';
 import type { FastifyInstance } from 'fastify';
 import { CreateDatasetInputSchema } from '@rfjs/core';
+import { JsonbQueryError } from '@rfjs/jsonb-query';
 
 vi.mock('@/infrastructures/datasource', () => ({
   datasetUsecases: {
@@ -25,6 +26,16 @@ vi.mock('@/infrastructures/datasource', () => ({
         ...input,
       }),
     ),
+    search: vi.fn().mockResolvedValue([
+      {
+        id: '1',
+        name: 'A',
+        description: null,
+        data: { region: 'apac' },
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ]),
   },
 }));
 
@@ -86,6 +97,37 @@ describe('dataset routes', () => {
       CreateDatasetInputSchema.safeParse({}).error!,
     );
     const res = await app.inject({ method: 'POST', url: '/datasets', payload: {} });
+    expect(res.statusCode).toBe(400);
+    expect(res.json<{ error: string }>().error).toBe('Bad Request');
+  });
+
+  it('POST /datasets/query returns 200 with the filtered list', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/datasets/query',
+      payload: {
+        filter: {
+          logic: 'and',
+          filters: [
+            { field: 'region', dataType: 'string', operator: 'eq', value: 'apac' },
+          ],
+        },
+      },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toHaveLength(1);
+  });
+
+  it('POST /datasets/query maps JsonbQueryError to 400', async () => {
+    const { datasetUsecases } = await import('@/infrastructures/datasource');
+    vi.mocked(datasetUsecases.search).mockRejectedValueOnce(
+      new JsonbQueryError('bad operator', 'UNSUPPORTED_OPERATOR'),
+    );
+    const res = await app.inject({
+      method: 'POST',
+      url: '/datasets/query',
+      payload: { filter: { logic: 'and', filters: [] } },
+    });
     expect(res.statusCode).toBe(400);
     expect(res.json<{ error: string }>().error).toBe('Bad Request');
   });

--- a/apps/api/src/delivery/http/dataset/handlers/dataset.handler.ts
+++ b/apps/api/src/delivery/http/dataset/handlers/dataset.handler.ts
@@ -16,3 +16,7 @@ export const createDatasetHandler: RouteHandlerMethod = async (req, reply) => {
   const created = await datasetUsecases.create(req.body);
   reply.code(201).send(created);
 };
+
+export const searchDatasetsHandler: RouteHandlerMethod = async (req, reply) => {
+  reply.send(await datasetUsecases.search(req.body));
+};

--- a/apps/api/src/delivery/http/dataset/routes.ts
+++ b/apps/api/src/delivery/http/dataset/routes.ts
@@ -1,8 +1,34 @@
 import { RouteOptions } from 'fastify';
-import { listDatasetsHandler, getDatasetHandler, createDatasetHandler } from './handlers';
+import {
+  listDatasetsHandler,
+  getDatasetHandler,
+  createDatasetHandler,
+  searchDatasetsHandler,
+} from './handlers';
 
 export const datasetRoutes: RouteOptions[] = [
-  { method: 'GET', url: '/datasets', schema: { tags: ['dataset'] }, handler: listDatasetsHandler },
-  { method: 'GET', url: '/datasets/:id', schema: { tags: ['dataset'] }, handler: getDatasetHandler },
-  { method: 'POST', url: '/datasets', schema: { tags: ['dataset'] }, handler: createDatasetHandler },
+  {
+    method: 'GET',
+    url: '/datasets',
+    schema: { tags: ['dataset'] },
+    handler: listDatasetsHandler,
+  },
+  {
+    method: 'GET',
+    url: '/datasets/:id',
+    schema: { tags: ['dataset'] },
+    handler: getDatasetHandler,
+  },
+  {
+    method: 'POST',
+    url: '/datasets',
+    schema: { tags: ['dataset'] },
+    handler: createDatasetHandler,
+  },
+  {
+    method: 'POST',
+    url: '/datasets/query',
+    schema: { tags: ['dataset'] },
+    handler: searchDatasetsHandler,
+  },
 ];

--- a/apps/api/src/infrastructures/datasource/index.ts
+++ b/apps/api/src/infrastructures/datasource/index.ts
@@ -4,6 +4,7 @@ import {
   makeListDatasets,
   makeGetDataset,
   makeCreateDataset,
+  makeSearchDatasets,
 } from '@rfjs/core';
 import { configs } from '@/configs';
 
@@ -14,4 +15,5 @@ export const datasetUsecases = {
   list: makeListDatasets({ repo: datasetRepository }),
   get: makeGetDataset({ repo: datasetRepository }),
   create: makeCreateDataset({ repo: datasetRepository }),
+  search: makeSearchDatasets({ repo: datasetRepository }),
 };

--- a/apps/api/src/infrastructures/fastify/registers/register-error-handler.ts
+++ b/apps/api/src/infrastructures/fastify/registers/register-error-handler.ts
@@ -1,5 +1,6 @@
 import { FastifyInstance } from 'fastify';
 import { ZodError } from 'zod';
+import { JsonbQueryError } from '@rfjs/jsonb-query';
 
 /**
  * Maps known error types to HTTP responses. ZodError (validation) -> 400,
@@ -16,6 +17,15 @@ export function registerErrorHandler(app: FastifyInstance): void {
         error: 'Bad Request',
         message: 'Request validation failed',
         issues: error.issues.map((i) => ({ path: i.path, message: i.message })),
+      });
+    }
+    if (error instanceof JsonbQueryError) {
+      request.log.info({ code: error.code }, 'jsonb filter build failed');
+      return reply.status(400).send({
+        statusCode: 400,
+        error: 'Bad Request',
+        message: 'Invalid filter',
+        code: error.code,
       });
     }
     // Preserve default behavior for all other errors.

--- a/docs/superpowers/notes/2026-06-14-datasets-jsonb-filter-e2e.md
+++ b/docs/superpowers/notes/2026-06-14-datasets-jsonb-filter-e2e.md
@@ -1,0 +1,159 @@
+# Datasets JSONB Filter — Full-Stack E2E Run Log
+
+**Date:** 2026-06-14  
+**Branch:** feat/datasets-jsonb-filter  
+**Worktree:** `.claude/worktrees/feat+datasets-jsonb-filter`
+
+---
+
+## Step 1: Build libs
+
+```bash
+pnpm --filter @rfjs/jsonb-query build
+pnpm --filter @rfjs/db build
+pnpm --filter @rfjs/core build
+```
+
+All three built successfully (tsdown, ~400–630 ms each).
+
+---
+
+## Step 2: Postgres up, migrate, seed
+
+```bash
+docker compose -f docker-compose.test.yml up -d && sleep 6
+export DBURL='postgresql://user:password@localhost:5433/workbench?options=-csearch_path=workbench'
+DATABASE_URL="$DBURL" pnpm --filter @rfjs/db migrate
+DATABASE_URL="$DBURL" pnpm --filter @rfjs/db seed
+```
+
+**Observed output:**
+
+```
+Database "workbench" does not exist. Creating...
+Database "workbench" created successfully.
+Migrations completed.
+Seeded 2 datasets.
+```
+
+---
+
+## Step 3: Start API
+
+```bash
+DATABASE_URL="$DBURL" pnpm --filter api tsx > /tmp/api.log 2>&1 &
+for i in $(seq 1 30); do curl -sf localhost:3000/health >/dev/null && break; sleep 1; done
+```
+
+API ready after 1 s.
+
+---
+
+## Step 4: Curl exercises
+
+### Health
+
+```bash
+curl -s localhost:3000/health
+```
+
+```json
+{"status":"ok","timestamp":"2026-06-14T11:43:33.513Z","uptime":8.781869818,"version":"0.0.0","environment":"local"}
+```
+
+---
+
+### Filter: region = apac (expect Sales — Q1 only)
+
+```bash
+curl -s -X POST localhost:3000/datasets/query \
+  -H 'content-type: application/json' \
+  -d '{"filter":{"logic":"and","filters":[{"field":"region","dataType":"string","operator":"eq","value":"apac"}]}}'
+```
+
+```json
+[{"id":"491f9b0f-720a-4be9-a73d-816e1fc9130b","name":"Sales — Q1","description":"Demo seed","data":{"rows":120,"region":"apac"},"createdAt":"2026-06-14T11:43:17.351Z","updatedAt":"2026-06-14T11:43:17.351Z"}]
+```
+
+Result: 1 row — "Sales — Q1" only. "Signups" (region=emea) excluded. PASS.
+
+---
+
+### Filter: rows >= 100 numeric (expect Sales — Q1 only)
+
+```bash
+curl -s -X POST localhost:3000/datasets/query \
+  -H 'content-type: application/json' \
+  -d '{"filter":{"logic":"and","filters":[{"field":"rows","dataType":"numeric","operator":"gte","value":100}]}}'
+```
+
+```json
+[{"id":"491f9b0f-720a-4be9-a73d-816e1fc9130b","name":"Sales — Q1","description":"Demo seed","data":{"rows":120,"region":"apac"},"createdAt":"2026-06-14T11:43:17.351Z","updatedAt":"2026-06-14T11:43:17.351Z"}]
+```
+
+Result: 1 row — "Sales — Q1" (rows=120 >= 100). "Signups" (rows=42) excluded. PASS.
+
+---
+
+### Malformed operator -> expect 400
+
+```bash
+curl -s -X POST localhost:3000/datasets/query \
+  -H 'content-type: application/json' \
+  -d '{"filter":{"logic":"and","filters":[{"field":"region","dataType":"string","operator":"NOPE","value":"x"}]}}'
+```
+
+HTTP status: `400`
+
+Response body:
+```json
+{"statusCode":400,"error":"Bad Request","message":"Invalid filter","code":"UNSUPPORTED_OPERATOR"}
+```
+
+PASS — JsonbQueryError caught at route layer, translated to 400.
+
+---
+
+### Malformed body shape (bad logic value) -> expect 400
+
+```bash
+curl -s -X POST localhost:3000/datasets/query \
+  -H 'content-type: application/json' \
+  -d '{"filter":{"logic":"xor","filters":[]}}'
+```
+
+HTTP status: `400`
+
+Response body:
+```json
+{"statusCode":400,"error":"Bad Request","message":"Request validation failed","issues":[{"path":["filter","logic"],"message":"Invalid option: expected one of \"and\"|\"or\"|\"nor\"|\"not\""}]}
+```
+
+PASS — Zod schema validation at route entry, translated to 400.
+
+---
+
+## Step 5: Tear down
+
+```bash
+pkill -f 'apps/api' 2>/dev/null || true
+docker compose -f docker-compose.test.yml down
+```
+
+Container `featdatasets-jsonb-filter-postgres-test-1` stopped and removed. Network removed.
+
+---
+
+## Summary
+
+| Check | Expected | Observed | Result |
+|---|---|---|---|
+| Build (@rfjs/jsonb-query, @rfjs/db, @rfjs/core) | success | success | PASS |
+| Migrate + Seed | "Migrations completed." + "Seeded 2 datasets." | exact match | PASS |
+| Health | 200 `{"status":"ok"}` | 200 `{"status":"ok"}` | PASS |
+| `region=apac` filter | `[{"name":"Sales — Q1",...}]` (1 row) | exact match | PASS |
+| `rows >= 100` numeric filter | `[{"name":"Sales — Q1",...}]` (1 row) | exact match | PASS |
+| Unknown operator `NOPE` | 400 `UNSUPPORTED_OPERATOR` | 400 `UNSUPPORTED_OPERATOR` | PASS |
+| Bad logic value `xor` | 400 Zod validation error | 400 Zod validation error | PASS |
+
+All checks PASS. Full chain verified: real Postgres → @rfjs/db seed → @rfjs/core search → apps/api POST /datasets/query.

--- a/docs/superpowers/plans/2026-06-14-datasets-jsonb-filter.md
+++ b/docs/superpowers/plans/2026-06-14-datasets-jsonb-filter.md
@@ -1,0 +1,499 @@
+# Datasets jsonb Filtering Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `POST /datasets/query` that filters datasets over the `data` jsonb column using `@rfjs/jsonb-query`, end to end.
+
+**Architecture:** A new `repository.search(filter)` runs `buildJsonbQuery('data', filter, { dialect: 'jsonpath' })` and executes the resulting positional SQL on Drizzle's underlying pool (`db.$client.query`), mapping aliased rows back to `Dataset`. A `makeSearchDatasets` usecase zod-validates the `{ filter }` body before calling the repo. `apps/api` exposes `POST /datasets/query` and maps `JsonbQueryError → 400` (alongside the existing `ZodError → 400`).
+
+**Tech Stack:** TypeScript, Drizzle (node-postgres, `db.$client`), `@rfjs/jsonb-query`, zod v4, Fastify 5, Vitest, pnpm/turbo. Real-PG integration via `docker-compose.test.yml` (port 5433).
+
+**Spec:** `docs/superpowers/specs/2026-06-14-datasets-jsonb-filter-design.md`
+
+---
+
+## File Structure
+
+- `libs/core/src/dataset/repository.ts` (modify) — add `search` to the `DatasetRepository` interface + factory.
+- `libs/core/src/dataset/repository.e2e.spec.ts` (modify) — add a real-PG search test.
+- `libs/core/src/dataset/filter-schema.ts` (new) — recursive zod `FilterGroupSchema` for the `JsonbFilterGroup` shape.
+- `libs/core/src/dataset/usecase/search-datasets.ts` (new) — `makeSearchDatasets`.
+- `libs/core/src/dataset/usecase/search-datasets.spec.ts` (new) — fake-repo unit tests.
+- `libs/core/src/dataset/usecase/index.ts` (modify) — export search-datasets.
+- `apps/api/package.json` (modify) — add `@rfjs/jsonb-query`.
+- `apps/api/src/infrastructures/datasource/index.ts` (modify) — add `search` to `datasetUsecases`.
+- `apps/api/src/delivery/http/dataset/handlers/dataset.handler.ts` (modify) — add `searchDatasetsHandler`.
+- `apps/api/src/delivery/http/dataset/routes.ts` (modify) — add `POST /datasets/query`.
+- `apps/api/src/infrastructures/fastify/registers/register-error-handler.ts` (modify) — map `JsonbQueryError → 400`.
+- `apps/api/src/delivery/http/dataset/dataset.route.spec.ts` (modify) — add `search` to the mock + 200/400 tests.
+
+---
+
+## Task 1: `repository.search` + real-PG integration test
+
+**Files:**
+- Modify: `libs/core/src/dataset/repository.ts`
+- Test: `libs/core/src/dataset/repository.e2e.spec.ts`
+
+- [ ] **Step 1: Build the workspace deps the e2e test imports**
+
+`repository.ts` will import `buildJsonbQuery` (a runtime value) from `@rfjs/jsonb-query`, and the e2e test imports `@rfjs/db` — both are consumed via their built `dist/`.
+
+Run: `pnpm --filter @rfjs/jsonb-query build && pnpm --filter @rfjs/db build`
+Expected: both build clean.
+
+- [ ] **Step 2: Add the failing search test to `libs/core/src/dataset/repository.e2e.spec.ts`**
+
+Add this `it` block inside the existing `describe('makeDatasetRepository (real PG)', ...)` (after the "lists datasets" test):
+
+```ts
+  it('filters by a data jsonb field via jsonb-query', async () => {
+    await repo.create({ name: 'APAC', data: { region: 'apac' } });
+    await repo.create({ name: 'EMEA', data: { region: 'emea' } });
+    const results = await repo.search({
+      logic: 'and',
+      filters: [{ field: 'region', dataType: 'string', operator: 'eq', value: 'apac' }],
+    });
+    expect(results.length).toBeGreaterThanOrEqual(1);
+    expect(results.every((d) => d.data.region === 'apac')).toBe(true);
+    expect(results.some((d) => d.data.region === 'emea')).toBe(false);
+  });
+```
+
+- [ ] **Step 3: Run it to verify it fails**
+
+```bash
+docker compose -f docker-compose.test.yml up -d && sleep 5
+pnpm --filter @rfjs/core vitest:e2e:run
+```
+Expected: FAIL — `repo.search is not a function` (and a TS/type error that `search` is missing). Leave Postgres up for Step 5.
+
+- [ ] **Step 4: Implement `search` in `libs/core/src/dataset/repository.ts`**
+
+Replace the file's top imports and add `search` to both the interface and the factory:
+
+```ts
+import { eq } from 'drizzle-orm';
+import { buildJsonbQuery, type JsonbFilterGroup } from '@rfjs/jsonb-query';
+import { type Db, datasetsTable } from '@rfjs/db';
+import type { Dataset, CreateDatasetInput } from './schema';
+
+export interface DatasetRepository {
+  list(): Promise<Dataset[]>;
+  getById(id: string): Promise<Dataset | undefined>;
+  create(input: CreateDatasetInput): Promise<Dataset>;
+  search(filter: JsonbFilterGroup): Promise<Dataset[]>;
+}
+```
+
+Add this method to the object returned by `makeDatasetRepository` (after `create`):
+
+```ts
+  async search(filter) {
+    const { where, values } = buildJsonbQuery('data', filter, { dialect: 'jsonpath' });
+    const { rows } = await db.$client.query(
+      `SELECT dataset_id AS id, name, description, data,
+              created_at AS "createdAt", updated_at AS "updatedAt"
+       FROM datasets WHERE ${where}`,
+      values,
+    );
+    return (rows as (typeof datasetsTable.$inferSelect)[]).map(toDataset);
+  },
+```
+
+(The aliased `SELECT` returns the exact `Dataset` field names, so the existing `toDataset` mapper is reused. `db.$client` is the node-postgres `Pool` Drizzle was constructed with; `search_path=workbench` resolves the unqualified `datasets`.)
+
+- [ ] **Step 5: Run the e2e test to verify it passes, then tear down**
+
+```bash
+pnpm --filter @rfjs/db build           # repository.ts changed -> rebuild dep consumed by the test
+pnpm --filter @rfjs/core vitest:e2e:run
+docker compose -f docker-compose.test.yml down
+```
+Expected: PASS (3 e2e tests: create/get, list, filter).
+
+- [ ] **Step 6: Typecheck**
+
+Run: `pnpm --filter @rfjs/core typecheck`
+Expected: clean. If `db.$client` is not typed, confirm drizzle-orm 0.45.1 (it exposes `$client`); do not work around with `any` unless typecheck genuinely fails — report it instead.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add libs/core/src/dataset/repository.ts libs/core/src/dataset/repository.e2e.spec.ts
+git commit -m "feat(core): dataset repository.search via @rfjs/jsonb-query (data jsonb)"
+```
+
+---
+
+## Task 2: `FilterGroupSchema` + `search-datasets` usecase
+
+**Files:**
+- Create: `libs/core/src/dataset/filter-schema.ts`
+- Create: `libs/core/src/dataset/usecase/search-datasets.ts`
+- Modify: `libs/core/src/dataset/usecase/index.ts`
+- Test: `libs/core/src/dataset/usecase/search-datasets.spec.ts`
+
+- [ ] **Step 1: Write the failing test — `libs/core/src/dataset/usecase/search-datasets.spec.ts`**
+
+```ts
+import { describe, it, expect, vi } from 'vitest';
+import { makeSearchDatasets } from './search-datasets';
+import type { DatasetRepository } from '../repository';
+
+const validBody = {
+  filter: {
+    logic: 'and',
+    filters: [{ field: 'region', dataType: 'string', operator: 'eq', value: 'apac' }],
+  },
+};
+
+describe('makeSearchDatasets', () => {
+  it('validates the body then delegates the filter to repository.search', async () => {
+    const repo = {
+      list: vi.fn(),
+      getById: vi.fn(),
+      create: vi.fn(),
+      search: vi.fn().mockResolvedValue([]),
+    } satisfies DatasetRepository;
+    const searchDatasets = makeSearchDatasets({ repo });
+    await searchDatasets(validBody);
+    expect(repo.search).toHaveBeenCalledWith(validBody.filter);
+  });
+
+  it('throws on an invalid body shape without calling the repository', async () => {
+    const repo = {
+      list: vi.fn(),
+      getById: vi.fn(),
+      create: vi.fn(),
+      search: vi.fn(),
+    } satisfies DatasetRepository;
+    const searchDatasets = makeSearchDatasets({ repo });
+    await expect(searchDatasets({ filter: { logic: 'xor', filters: [] } })).rejects.toThrow();
+    await expect(searchDatasets({})).rejects.toThrow();
+    expect(repo.search).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `pnpm --filter @rfjs/core vitest:run`
+Expected: FAIL — cannot find module './search-datasets'.
+
+- [ ] **Step 3: Write `libs/core/src/dataset/filter-schema.ts`**
+
+```ts
+import { z } from 'zod';
+import type { JsonbFilterGroup } from '@rfjs/jsonb-query';
+
+const LOGIC = ['and', 'or', 'nor', 'not'] as const;
+const DATA_TYPE = ['string', 'numeric', 'date', 'boolean', 'object', 'array'] as const;
+
+// Loose condition shape: deep grammar (operator/dataType validity) is enforced by
+// @rfjs/jsonb-query at build time. This gate only rejects gross malformation.
+const ConditionSchema = z.object({
+  field: z.string().min(1),
+  dataType: z.enum(DATA_TYPE),
+  operator: z.string().min(1),
+  value: z.unknown().optional(),
+  elementType: z.enum(['string', 'numeric', 'date', 'boolean', 'object']).optional(),
+  filters: z.unknown().optional(), // nested group for elemmatch; validated by jsonb-query
+});
+
+export const FilterGroupSchema: z.ZodType<JsonbFilterGroup> = z.lazy(() =>
+  z.object({
+    logic: z.enum(LOGIC),
+    filters: z.array(z.union([ConditionSchema, FilterGroupSchema])),
+  }),
+) as z.ZodType<JsonbFilterGroup>;
+
+export const SearchBodySchema = z.object({ filter: FilterGroupSchema });
+export type SearchBody = z.infer<typeof SearchBodySchema>;
+```
+
+- [ ] **Step 4: Write `libs/core/src/dataset/usecase/search-datasets.ts`**
+
+```ts
+import type { Dataset } from '../schema';
+import type { DatasetRepository } from '../repository';
+import { SearchBodySchema } from '../filter-schema';
+
+export const makeSearchDatasets =
+  (deps: { repo: DatasetRepository }) =>
+  async (input: unknown): Promise<Dataset[]> => {
+    const { filter } = SearchBodySchema.parse(input);
+    return deps.repo.search(filter);
+  };
+```
+
+- [ ] **Step 5: Export it — append to `libs/core/src/dataset/usecase/index.ts`**
+
+```ts
+export * from './create-dataset';
+export * from './list-datasets';
+export * from './get-dataset';
+export * from './search-datasets';
+```
+
+(`filter-schema.ts` is reachable through the existing `dataset/index.ts` → `./schema`? No — add it: also append `export * from './filter-schema';` to `libs/core/src/dataset/index.ts` so `FilterGroupSchema`/`SearchBodySchema` are part of the package surface.)
+
+- [ ] **Step 6: Append to `libs/core/src/dataset/index.ts`**
+
+The file currently is:
+```ts
+export * from './schema';
+export * from './repository';
+export * from './usecase';
+```
+Add a line:
+```ts
+export * from './filter-schema';
+```
+
+- [ ] **Step 7: Run tests + typecheck**
+
+Run: `pnpm --filter @rfjs/core vitest:run && pnpm --filter @rfjs/core typecheck`
+Expected: PASS (unit tier: schema + 3 usecases + 2 new search tests). The e2e spec stays excluded from the unit tier.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add libs/core/src/dataset/filter-schema.ts libs/core/src/dataset/usecase/search-datasets.ts libs/core/src/dataset/usecase/search-datasets.spec.ts libs/core/src/dataset/usecase/index.ts libs/core/src/dataset/index.ts
+git commit -m "feat(core): search-datasets usecase + zod FilterGroupSchema"
+```
+
+---
+
+## Task 3: api `POST /datasets/query` + `JsonbQueryError → 400`
+
+**Files:**
+- Modify: `apps/api/package.json`
+- Modify: `apps/api/src/infrastructures/datasource/index.ts`
+- Modify: `apps/api/src/delivery/http/dataset/handlers/dataset.handler.ts`
+- Modify: `apps/api/src/delivery/http/dataset/routes.ts`
+- Modify: `apps/api/src/infrastructures/fastify/registers/register-error-handler.ts`
+- Test: `apps/api/src/delivery/http/dataset/dataset.route.spec.ts`
+
+- [ ] **Step 1: Add `@rfjs/jsonb-query` to apps/api and install**
+
+Add `"@rfjs/jsonb-query": "workspace:*"` to `apps/api/package.json` `dependencies` (next to `@rfjs/core`). Then:
+
+Run: `pnpm install`
+Expected: links `@rfjs/jsonb-query` into apps/api.
+
+- [ ] **Step 2: Write the failing route tests — edit `apps/api/src/delivery/http/dataset/dataset.route.spec.ts`**
+
+(a) Add `import { JsonbQueryError } from '@rfjs/jsonb-query';` to the top imports.
+
+(b) Add a `search` mock to the `vi.mock('@/infrastructures/datasource', ...)` `datasetUsecases` object:
+
+```ts
+    search: vi.fn().mockResolvedValue([
+      {
+        id: '1',
+        name: 'A',
+        description: null,
+        data: { region: 'apac' },
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ]),
+```
+
+(c) Add two `it` blocks inside `describe('dataset routes', ...)`:
+
+```ts
+  it('POST /datasets/query returns 200 with the filtered list', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/datasets/query',
+      payload: {
+        filter: {
+          logic: 'and',
+          filters: [{ field: 'region', dataType: 'string', operator: 'eq', value: 'apac' }],
+        },
+      },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toHaveLength(1);
+  });
+
+  it('POST /datasets/query maps JsonbQueryError to 400', async () => {
+    const { datasetUsecases } = await import('@/infrastructures/datasource');
+    vi.mocked(datasetUsecases.search).mockRejectedValueOnce(
+      new JsonbQueryError('bad operator', 'INVALID_OPERATOR'),
+    );
+    const res = await app.inject({
+      method: 'POST',
+      url: '/datasets/query',
+      payload: { filter: { logic: 'and', filters: [] } },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json<{ error: string }>().error).toBe('Bad Request');
+  });
+```
+
+(Verify `'INVALID_OPERATOR'` is a real `JsonbQueryErrorCode` by checking `packages/jsonb-query/src/errors.ts`; if not, use any exported code such as `'INVALID_DIALECT'`. The exact code doesn't affect the 400 mapping.)
+
+- [ ] **Step 3: Run it to verify it fails**
+
+Run: `pnpm --filter @rfjs/jsonb-query build && pnpm --filter @rfjs/core build && pnpm --filter api vitest:run`
+Expected: FAIL — `POST /datasets/query` returns 404 (route not registered) and/or `datasetUsecases.search` undefined.
+
+- [ ] **Step 4: Add `search` to the composition root — `apps/api/src/infrastructures/datasource/index.ts`**
+
+```ts
+import { createDb } from '@rfjs/db';
+import {
+  makeDatasetRepository,
+  makeListDatasets,
+  makeGetDataset,
+  makeCreateDataset,
+  makeSearchDatasets,
+} from '@rfjs/core';
+import { configs } from '@/configs';
+
+const { db } = createDb(configs.databaseUrl);
+const datasetRepository = makeDatasetRepository(db);
+
+export const datasetUsecases = {
+  list: makeListDatasets({ repo: datasetRepository }),
+  get: makeGetDataset({ repo: datasetRepository }),
+  create: makeCreateDataset({ repo: datasetRepository }),
+  search: makeSearchDatasets({ repo: datasetRepository }),
+};
+```
+
+- [ ] **Step 5: Add the handler — `apps/api/src/delivery/http/dataset/handlers/dataset.handler.ts`**
+
+Append:
+```ts
+export const searchDatasetsHandler: RouteHandlerMethod = async (req, reply) => {
+  reply.send(await datasetUsecases.search(req.body));
+};
+```
+
+- [ ] **Step 6: Add the route — `apps/api/src/delivery/http/dataset/routes.ts`**
+
+```ts
+import { RouteOptions } from 'fastify';
+import {
+  listDatasetsHandler,
+  getDatasetHandler,
+  createDatasetHandler,
+  searchDatasetsHandler,
+} from './handlers';
+
+export const datasetRoutes: RouteOptions[] = [
+  { method: 'GET', url: '/datasets', schema: { tags: ['dataset'] }, handler: listDatasetsHandler },
+  { method: 'GET', url: '/datasets/:id', schema: { tags: ['dataset'] }, handler: getDatasetHandler },
+  { method: 'POST', url: '/datasets', schema: { tags: ['dataset'] }, handler: createDatasetHandler },
+  { method: 'POST', url: '/datasets/query', schema: { tags: ['dataset'] }, handler: searchDatasetsHandler },
+];
+```
+
+- [ ] **Step 7: Map `JsonbQueryError → 400` — edit `apps/api/src/infrastructures/fastify/registers/register-error-handler.ts`**
+
+Add the import and a branch before the ZodError branch (or after — order is independent):
+
+```ts
+import { FastifyInstance } from 'fastify';
+import { ZodError } from 'zod';
+import { JsonbQueryError } from '@rfjs/jsonb-query';
+```
+
+Inside `setErrorHandler`, before `// Preserve default behavior`:
+
+```ts
+    if (error instanceof JsonbQueryError) {
+      request.log.info({ code: error.code }, 'jsonb filter build failed');
+      return reply.status(400).send({
+        statusCode: 400,
+        error: 'Bad Request',
+        message: 'Invalid filter',
+        code: error.code,
+      });
+    }
+```
+
+(`JsonbQueryError` carries a `code: JsonbQueryErrorCode` — confirm in `packages/jsonb-query/src/errors.ts`.)
+
+- [ ] **Step 8: Run tests + typecheck**
+
+```bash
+pnpm --filter @rfjs/jsonb-query build && pnpm --filter @rfjs/core build
+pnpm --filter api vitest:run
+pnpm --filter api typecheck
+```
+Expected: PASS — all dataset route tests including the new 200 + 400 (now 7 in that file: list, create-201, get-200, get-404, create-400, query-200, query-400) plus the demo test.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add apps/api/package.json apps/api/src/infrastructures/datasource/index.ts apps/api/src/delivery/http/dataset/handlers/dataset.handler.ts apps/api/src/delivery/http/dataset/routes.ts apps/api/src/infrastructures/fastify/registers/register-error-handler.ts apps/api/src/delivery/http/dataset/dataset.route.spec.ts pnpm-lock.yaml
+git commit -m "feat(api): POST /datasets/query + map JsonbQueryError to 400"
+```
+
+---
+
+## Task 4: full-stack e2e verification + run log
+
+**Files:**
+- Create: `docs/superpowers/notes/2026-06-14-datasets-jsonb-filter-e2e.md`
+
+- [ ] **Step 1: Build libs, bring up PG, migrate + seed**
+
+```bash
+pnpm --filter @rfjs/jsonb-query build && pnpm --filter @rfjs/db build && pnpm --filter @rfjs/core build
+docker compose -f docker-compose.test.yml up -d && sleep 5
+export DBURL='postgresql://user:password@localhost:5433/workbench?options=-csearch_path=workbench'
+DATABASE_URL="$DBURL" pnpm --filter @rfjs/db migrate
+DATABASE_URL="$DBURL" pnpm --filter @rfjs/db seed
+```
+Expected: "Migrations completed." then "Seeded 2 datasets." (the seed rows have `data.region` `apac` and `emea`).
+
+- [ ] **Step 2: Start the API and exercise the filter**
+
+```bash
+DATABASE_URL="$DBURL" pnpm --filter api tsx > /tmp/api.log 2>&1 &
+for i in $(seq 1 30); do curl -sf localhost:3000/health && break; sleep 1; done
+echo "--- filter region=apac ---"
+curl -s -X POST localhost:3000/datasets/query -H 'content-type: application/json' \
+  -d '{"filter":{"logic":"and","filters":[{"field":"region","dataType":"string","operator":"eq","value":"apac"}]}}'
+echo ""
+echo "--- malformed filter -> 400 ---"
+curl -s -o /dev/null -w "%{http_code}" -X POST localhost:3000/datasets/query -H 'content-type: application/json' \
+  -d '{"filter":{"logic":"and","filters":[{"field":"region","dataType":"string","operator":"NOPE","value":"x"}]}}'
+echo ""
+```
+Expected: the first returns a JSON array containing only the `apac` seed row ("Sales — Q1"); the malformed-operator request returns `400`.
+
+- [ ] **Step 3: Tear down**
+
+```bash
+pkill -f 'apps/api' 2>/dev/null || true
+docker compose -f docker-compose.test.yml down
+```
+
+- [ ] **Step 4: Write the run log + commit**
+
+Record the real observed outputs into `docs/superpowers/notes/2026-06-14-datasets-jsonb-filter-e2e.md`, then:
+
+```bash
+git add docs/superpowers/notes/2026-06-14-datasets-jsonb-filter-e2e.md
+git commit -m "docs(datasets): record jsonb filter e2e run log"
+```
+
+---
+
+## Final verification
+
+- [ ] **Unit tier:** `pnpm --filter @rfjs/core vitest:run && pnpm --filter api vitest:run` — all pass.
+- [ ] **Integration tier (Docker):** PG up → `pnpm --filter @rfjs/core vitest:e2e:run` — 3 pass.
+- [ ] **Builds + typecheck:** `pnpm --filter @rfjs/jsonb-query build && pnpm --filter @rfjs/db build && pnpm --filter @rfjs/core build && pnpm --filter @rfjs/core typecheck && pnpm --filter api typecheck` — clean.
+
+## Notes / out of scope (per spec)
+
+- Sorting (`@rfjs/jsonb-query` ORDER BY builder) + pagination — next iteration; the `{ filter }` body leaves room for `{ filter, sort?, page? }`.
+- Top-level column filtering (`name`/`description`) and a workbench filter UI — later.

--- a/docs/superpowers/specs/2026-06-14-datasets-jsonb-filter-design.md
+++ b/docs/superpowers/specs/2026-06-14-datasets-jsonb-filter-design.md
@@ -1,0 +1,76 @@
+# Datasets jsonb Filtering via `@rfjs/jsonb-query` — Design
+
+**Date:** 2026-06-14
+**Status:** Approved (brainstorming complete; pending writing-plans)
+**Scope:** Add server-side filtering of `datasets` over the `data` jsonb column, powered by `@rfjs/jsonb-query`. Extends the datasets vertical slice shipped in PR #159.
+
+## Context
+
+PR #159 built the workbench backend foundation with a `datasets` CRUD slice. `@rfjs/jsonb-query`
+was deliberately pre-wired as a `@rfjs/core` dependency but not yet used; the spec noted its first
+real use would be "filtering the `data` jsonb column." This is that iteration — it both delivers
+useful filtering and showcases the `@rfjs/jsonb-query` package end to end.
+
+## Key facts that shaped the design
+
+- `@rfjs/jsonb-query` input is a structured `JsonbFilterGroup` (`{ logic, filters: [{ field, dataType, operator, value }] }`); output is **standard Postgres positional SQL** (`{ where, values }`).
+- Signature: `buildJsonbQuery(column, filter, options)` → `{ where, values, from }`; `options.dialect` defaults to `legacy`.
+- It is a SQL builder meant to be executed by a raw PG driver. Drizzle's node-postgres exposes the
+  underlying pool via **`db.$client`** (confirmed in 0.45.1), so the repository can run jsonb-query's
+  SQL on `db.$client.query(text, values)` **without changing the `makeDatasetRepository(db)` signature**.
+
+## Architecture & data flow
+
+```
+POST /datasets/query   body: { filter: JsonbFilterGroup }
+  → createDatasetQueryHandler: datasetUsecases.search(req.body)
+  → makeSearchDatasets({ repo }): zod-validate the body shape → repo.search(filter)
+  → repository.search(filter):
+       const { where, values } = buildJsonbQuery('data', filter, { dialect: 'jsonpath' })
+       const { rows } = await db.$client.query(
+         `SELECT dataset_id AS id, name, description, data,
+                 created_at AS "createdAt", updated_at AS "updatedAt"
+          FROM datasets WHERE ${where}`, values)
+       return rows.map(toDataset)
+```
+
+The aliased `SELECT` returns rows in the exact `Dataset` shape (`id/name/description/data/createdAt/updatedAt`),
+so the existing `toDataset` mapper is reused. `search_path=workbench` (on the connection string) resolves
+the unqualified `datasets` to `workbench.datasets`, consistent with the rest of the slice.
+
+## Decisions
+
+- **New endpoint `POST /datasets/query`** (not overloading `GET /datasets`) — the filter is a rich nested
+  object that belongs in a JSON body, and jsonb-query's native input is that structured group.
+- **Dialect = `jsonpath`** — the richer dialect (nested elemmatch support); best showcase. Centralised so it's a one-line switch.
+- **Filtering targets only the `data` jsonb column.** Filtering on top-level `name`/`description` is out of scope for this slice.
+- **Execution via `db.$client`** — keeps the repository ORM-isolation boundary intact (only `repository.ts` touches drizzle/pg) and avoids threading jsonb-query's positional params through Drizzle's query builder.
+
+## Components (small, focused)
+
+- `libs/core/src/dataset/filter-schema.ts` (new) — a zod `FilterGroupSchema` (recursive via `z.lazy`) validating the outer `JsonbFilterGroup` shape (logic enum + filters array of condition|group). Deep grammar validation is delegated to jsonb-query.
+- `libs/core/src/dataset/repository.ts` — add `search(filter: JsonbFilterGroup): Promise<Dataset[]>` to the `DatasetRepository` interface + factory; import `buildJsonbQuery` and the `JsonbFilterGroup` type from `@rfjs/jsonb-query`.
+- `libs/core/src/dataset/usecase/search-datasets.ts` (new) — `makeSearchDatasets({ repo })` → validates `{ filter }` with `FilterGroupSchema` then calls `repo.search(filter)`; export via `usecase/index.ts`.
+- `apps/api/src/infrastructures/datasource/index.ts` — add `search: makeSearchDatasets({ repo: datasetRepository })` to `datasetUsecases`.
+- `apps/api/src/delivery/http/dataset/handlers/dataset.handler.ts` — add `searchDatasetsHandler` → `datasetUsecases.search(req.body)`.
+- `apps/api/src/delivery/http/dataset/routes.ts` — add `{ method: 'POST', url: '/datasets/query', ... }`.
+- `apps/api/src/infrastructures/fastify/registers/register-error-handler.ts` — add `JsonbQueryError → 400` (alongside `ZodError → 400`), mapping a clean body (no internal leak).
+- `apps/api/package.json` — add `@rfjs/jsonb-query` (workspace:\*) so the error handler can `instanceof JsonbQueryError`.
+
+## Error handling
+
+Two untrusted-input gates, both surfacing as **400**:
+- `FilterGroupSchema` (zod) rejects gross shape errors at the usecase boundary → `ZodError` → 400 (existing handler).
+- jsonb-query throws `JsonbQueryError` on bad operator/dataType/grammar → mapped to 400 by the extended handler (no raw internals leaked). All other errors keep current behavior.
+
+## Testing
+
+- **Unit (fake repo):** `search-datasets.spec.ts` — valid filter delegates to `repo.search`; invalid shape throws without calling the repo.
+- **Repository real-PG e2e:** extend `repository.e2e.spec.ts` — seed rows with distinct `data` (e.g. `{region:'apac'}`, `{region:'emea'}`), `search({ logic:'and', filters:[{ field:'region', dataType:'string', operator:'eq', value:'apac' }] })`, assert only matching rows return.
+- **Route test (mock):** `dataset.route.spec.ts` — `POST /datasets/query` with a valid filter → 200 (mock `search`); a malformed filter where the mocked `search` throws `JsonbQueryError` → 400.
+
+## Out of scope (this iteration)
+
+- Sorting (`@rfjs/jsonb-query` ORDER BY builder) and pagination — natural next iteration; the `POST /datasets/query` body leaves room (`{ filter, sort?, page? }`).
+- Filtering on top-level columns (`name`, `description`).
+- Exposing the filter UI in workbench (this slice is API-only; a workbench filter form is a later step).

--- a/libs/core/src/dataset/filter-schema.ts
+++ b/libs/core/src/dataset/filter-schema.ts
@@ -1,0 +1,26 @@
+import { z } from 'zod';
+import type { JsonbFilterGroup } from '@rfjs/jsonb-query';
+
+const LOGIC = ['and', 'or', 'nor', 'not'] as const;
+const DATA_TYPE = ['string', 'numeric', 'date', 'boolean', 'object', 'array'] as const;
+
+// Loose condition shape: deep grammar (operator/dataType validity) is enforced by
+// @rfjs/jsonb-query at build time. This gate only rejects gross malformation.
+const ConditionSchema = z.object({
+  field: z.string().min(1),
+  dataType: z.enum(DATA_TYPE),
+  operator: z.string().min(1),
+  value: z.unknown().optional(),
+  elementType: z.enum(['string', 'numeric', 'date', 'boolean', 'object']).optional(),
+  filters: z.unknown().optional(), // nested group for elemmatch; validated by jsonb-query
+});
+
+export const FilterGroupSchema: z.ZodType<JsonbFilterGroup> = z.lazy(() =>
+  z.object({
+    logic: z.enum(LOGIC),
+    filters: z.array(z.union([ConditionSchema, FilterGroupSchema])),
+  }),
+) as z.ZodType<JsonbFilterGroup>;
+
+export const SearchBodySchema = z.object({ filter: FilterGroupSchema });
+export type SearchBody = z.infer<typeof SearchBodySchema>;

--- a/libs/core/src/dataset/index.ts
+++ b/libs/core/src/dataset/index.ts
@@ -1,3 +1,4 @@
 export * from './schema';
 export * from './repository';
 export * from './usecase';
+export * from './filter-schema';

--- a/libs/core/src/dataset/repository.e2e.spec.ts
+++ b/libs/core/src/dataset/repository.e2e.spec.ts
@@ -39,4 +39,16 @@ describe('makeDatasetRepository (real PG)', () => {
     const all = await repo.list();
     expect(all.length).toBeGreaterThanOrEqual(1);
   });
+
+  it('filters by a data jsonb field via jsonb-query', async () => {
+    await repo.create({ name: 'APAC', data: { region: 'apac' } });
+    await repo.create({ name: 'EMEA', data: { region: 'emea' } });
+    const results = await repo.search({
+      logic: 'and',
+      filters: [{ field: 'region', dataType: 'string', operator: 'eq', value: 'apac' }],
+    });
+    expect(results.length).toBeGreaterThanOrEqual(1);
+    expect(results.every((d) => d.data.region === 'apac')).toBe(true);
+    expect(results.some((d) => d.data.region === 'emea')).toBe(false);
+  });
 });

--- a/libs/core/src/dataset/repository.ts
+++ b/libs/core/src/dataset/repository.ts
@@ -1,4 +1,5 @@
 import { eq } from 'drizzle-orm';
+import { buildJsonbQuery, type JsonbFilterGroup } from '@rfjs/jsonb-query';
 import { type Db, datasetsTable } from '@rfjs/db';
 import type { Dataset, CreateDatasetInput } from './schema';
 
@@ -6,6 +7,7 @@ export interface DatasetRepository {
   list(): Promise<Dataset[]>;
   getById(id: string): Promise<Dataset | undefined>;
   create(input: CreateDatasetInput): Promise<Dataset>;
+  search(filter: JsonbFilterGroup): Promise<Dataset[]>;
 }
 
 const toDataset = (row: typeof datasetsTable.$inferSelect): Dataset => ({
@@ -36,5 +38,15 @@ export const makeDatasetRepository = (db: Db): DatasetRepository => ({
       })
       .returning();
     return toDataset(row);
+  },
+  async search(filter) {
+    const { where, values } = buildJsonbQuery('data', filter, { dialect: 'jsonpath' });
+    const { rows } = await db.$client.query(
+      `SELECT dataset_id AS id, name, description, data,
+              created_at AS "createdAt", updated_at AS "updatedAt"
+       FROM datasets WHERE ${where}`,
+      values,
+    );
+    return (rows as (typeof datasetsTable.$inferSelect)[]).map(toDataset);
   },
 });

--- a/libs/core/src/dataset/usecase/create-dataset.spec.ts
+++ b/libs/core/src/dataset/usecase/create-dataset.spec.ts
@@ -18,6 +18,7 @@ describe('makeCreateDataset', () => {
       list: vi.fn(),
       getById: vi.fn(),
       create: vi.fn().mockResolvedValue(fakeDataset),
+      search: vi.fn(),
     };
     const createDataset = makeCreateDataset({ repo });
     const result = await createDataset({ name: 'X' });
@@ -30,6 +31,7 @@ describe('makeCreateDataset', () => {
       list: vi.fn(),
       getById: vi.fn(),
       create: vi.fn(),
+      search: vi.fn(),
     };
     const createDataset = makeCreateDataset({ repo });
     await expect(createDataset({ name: '' })).rejects.toThrow();

--- a/libs/core/src/dataset/usecase/get-dataset.spec.ts
+++ b/libs/core/src/dataset/usecase/get-dataset.spec.ts
@@ -4,7 +4,7 @@ import type { DatasetRepository } from '../repository';
 
 describe('makeGetDataset', () => {
   it('delegates to repository.getById', async () => {
-    const repo = { list: vi.fn(), getById: vi.fn().mockResolvedValue(undefined), create: vi.fn() } satisfies DatasetRepository;
+    const repo = { list: vi.fn(), getById: vi.fn().mockResolvedValue(undefined), create: vi.fn(), search: vi.fn() } satisfies DatasetRepository;
     const getDataset = makeGetDataset({ repo });
     expect(await getDataset('abc')).toBeUndefined();
     expect(repo.getById).toHaveBeenCalledWith('abc');

--- a/libs/core/src/dataset/usecase/index.ts
+++ b/libs/core/src/dataset/usecase/index.ts
@@ -1,3 +1,4 @@
 export * from './create-dataset';
 export * from './list-datasets';
 export * from './get-dataset';
+export * from './search-datasets';

--- a/libs/core/src/dataset/usecase/list-datasets.spec.ts
+++ b/libs/core/src/dataset/usecase/list-datasets.spec.ts
@@ -4,7 +4,7 @@ import type { DatasetRepository } from '../repository';
 
 describe('makeListDatasets', () => {
   it('returns whatever the repository lists', async () => {
-    const repo = { list: vi.fn().mockResolvedValue([]), getById: vi.fn(), create: vi.fn() } satisfies DatasetRepository;
+    const repo = { list: vi.fn().mockResolvedValue([]), getById: vi.fn(), create: vi.fn(), search: vi.fn() } satisfies DatasetRepository;
     const listDatasets = makeListDatasets({ repo });
     expect(await listDatasets()).toEqual([]);
     expect(repo.list).toHaveBeenCalledOnce();

--- a/libs/core/src/dataset/usecase/search-datasets.spec.ts
+++ b/libs/core/src/dataset/usecase/search-datasets.spec.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from 'vitest';
+import { makeSearchDatasets } from './search-datasets';
+import type { DatasetRepository } from '../repository';
+
+const validBody = {
+  filter: {
+    logic: 'and',
+    filters: [{ field: 'region', dataType: 'string', operator: 'eq', value: 'apac' }],
+  },
+};
+
+describe('makeSearchDatasets', () => {
+  it('validates the body then delegates the filter to repository.search', async () => {
+    const repo = {
+      list: vi.fn(),
+      getById: vi.fn(),
+      create: vi.fn(),
+      search: vi.fn().mockResolvedValue([]),
+    } satisfies DatasetRepository;
+    const searchDatasets = makeSearchDatasets({ repo });
+    await searchDatasets(validBody);
+    expect(repo.search).toHaveBeenCalledWith(validBody.filter);
+  });
+
+  it('throws on an invalid body shape without calling the repository', async () => {
+    const repo = {
+      list: vi.fn(),
+      getById: vi.fn(),
+      create: vi.fn(),
+      search: vi.fn(),
+    } satisfies DatasetRepository;
+    const searchDatasets = makeSearchDatasets({ repo });
+    await expect(searchDatasets({ filter: { logic: 'xor', filters: [] } })).rejects.toThrow();
+    await expect(searchDatasets({})).rejects.toThrow();
+    expect(repo.search).not.toHaveBeenCalled();
+  });
+});

--- a/libs/core/src/dataset/usecase/search-datasets.ts
+++ b/libs/core/src/dataset/usecase/search-datasets.ts
@@ -1,0 +1,10 @@
+import type { Dataset } from '../schema';
+import type { DatasetRepository } from '../repository';
+import { SearchBodySchema } from '../filter-schema';
+
+export const makeSearchDatasets =
+  (deps: { repo: DatasetRepository }) =>
+  async (input: unknown): Promise<Dataset[]> => {
+    const { filter } = SearchBodySchema.parse(input);
+    return deps.repo.search(filter);
+  };

--- a/libs/db/src/db.ts
+++ b/libs/db/src/db.ts
@@ -4,7 +4,7 @@ import * as schema from '@/schema';
 import { getConnectionStringInfo } from '@/utils';
 
 export type Schema = typeof schema;
-export type Db = NodePgDatabase<Schema>;
+export type Db = NodePgDatabase<Schema> & { $client: Pool };
 
 export function createDb(
   connectionString: string,

--- a/libs/db/src/db.ts
+++ b/libs/db/src/db.ts
@@ -4,7 +4,7 @@ import * as schema from '@/schema';
 import { getConnectionStringInfo } from '@/utils';
 
 export type Schema = typeof schema;
-export type Db = NodePgDatabase<Schema> & { $client: Pool };
+export type Db = NodePgDatabase<Schema> & { $client: Pool | Client };
 
 export function createDb(
   connectionString: string,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
       '@rfjs/db':
         specifier: workspace:*
         version: link:../../libs/db
+      '@rfjs/jsonb-query':
+        specifier: workspace:*
+        version: link:../../packages/jsonb-query
       dotenv-flow:
         specifier: ^4.1.0
         version: 4.1.0


### PR DESCRIPTION
## Summary

Adds server-side filtering of datasets over the `data` jsonb column, powered by `@rfjs/jsonb-query`. Extends the datasets vertical slice from #159 and is the first real use of the pre-wired `@rfjs/jsonb-query` dependency.

- **`libs/core`** — `repository.search(filter)` builds SQL with `buildJsonbQuery('data', filter, { dialect: 'jsonpath' })` and executes it on Drizzle's underlying pg pool (`db.$client.query`); the aliased `SELECT` reuses the existing `toDataset` mapper, keeping the ORM-isolation boundary intact (only `repository.ts` touches drizzle/db/jsonb-query). A `makeSearchDatasets` usecase zod-validates the `{ filter }` body via a recursive `FilterGroupSchema` (gross-shape gate; deep grammar is jsonb-query's job).
- **`apps/api`** — new `POST /datasets/query`; the global error handler now maps **both** untrusted-input gates to **400**: `ZodError` (bad body shape) and `JsonbQueryError` (bad operator/dataType), with no internal leak.
- **`libs/db`** — `Db.$client` typed honestly as `Pool | Client`.

## Design / plan
- Spec: `docs/superpowers/specs/2026-06-14-datasets-jsonb-filter-design.md`
- Plan: `docs/superpowers/plans/2026-06-14-datasets-jsonb-filter.md`
- E2E run log: `docs/superpowers/notes/2026-06-14-datasets-jsonb-filter-e2e.md`

## Test Plan
- [x] Unit: `@rfjs/core` 8 (usecases incl. search valid/invalid), `apps/api` 8 (route incl. query-200 + JsonbQueryError-400) — pass
- [x] Integration: `@rfjs/core` repository real-PG e2e (3, incl. the jsonb filter) via `docker-compose.test.yml`
- [x] Typecheck/build: `@rfjs/jsonb-query`, `@rfjs/db`, `@rfjs/core`, `api` — clean
- [x] Full-stack e2e (run log): `region=apac` and numeric `rows>=100` filter correctly; bad operator → 400 `{"code":"UNSUPPORTED_OPERATOR"}`; bad `logic` → 400 (Zod)
- [ ] Reviewer: `docker compose -f docker-compose.test.yml up -d && pnpm --filter @rfjs/core vitest:e2e:run`

## Security
SQL-injection safe: all user values flow as positional params from `buildJsonbQuery`; only the hardcoded `data` column (validated by `quoteJsonbColumn`), table, and aliases are interpolated into the SQL string.

## Notes / follow-ups (non-blocking)
- All affected packages are `private` → no changeset needed.
- Deferred (per spec): sort/pagination (`@rfjs/jsonb-query` ORDER BY builder), top-level-column filtering, workbench filter UI. The `{ filter }` body leaves room for `{ filter, sort?, page? }`.
- `repository.search` maps raw pg rows via an aliased SELECT + cast; a future schema column requires updating the SELECT list in lockstep (drizzle won't catch drift) — worth a comment when sort/pagination lands.
- Unrelated: apps/api pino timestamps show a month/day-swapped format — pre-existing, worth a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)