### PR TITLE
chore(workbench,api): harden #159 foundation — graceful pool shutdown + API-down state

### DIFF
--- a/apps/api/src/infrastructures/datasource/index.ts
+++ b/apps/api/src/infrastructures/datasource/index.ts
@@ -7,7 +7,7 @@ import {
 } from '@rfjs/core';
 import { configs } from '@/configs';
 
-const { db } = createDb(configs.databaseUrl);
+const { db, pool } = createDb(configs.databaseUrl);
 const datasetRepository = makeDatasetRepository(db);
 
 export const datasetUsecases = {
@@ -15,3 +15,6 @@ export const datasetUsecases = {
   get: makeGetDataset({ repo: datasetRepository }),
   create: makeCreateDataset({ repo: datasetRepository }),
 };
+
+/** Drains and closes the shared PG pool — wired into Fastify's `onClose` for graceful shutdown. */
+export const closeDatasource = (): Promise<void> => pool.end();

--- a/apps/api/src/infrastructures/fastify/initialize-app.spec.ts
+++ b/apps/api/src/infrastructures/fastify/initialize-app.spec.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect, vi } from 'vitest';
+import { initializeFastifyApp } from './initialize-app';
+
+describe('initializeFastifyApp graceful shutdown wiring', () => {
+  it('runs the provided onClose callback when the app closes', async () => {
+    const onClose = vi.fn().mockResolvedValue(undefined);
+    const app = await initializeFastifyApp({ isApiDocEnabled: false, onClose });
+    await app.ready();
+    await app.close();
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes cleanly when no onClose callback is provided', async () => {
+    const app = await initializeFastifyApp({ isApiDocEnabled: false });
+    await app.ready();
+    await expect(app.close()).resolves.toBeUndefined();
+  });
+});

--- a/apps/api/src/infrastructures/fastify/initialize-app.ts
+++ b/apps/api/src/infrastructures/fastify/initialize-app.ts
@@ -17,7 +17,12 @@ import { pinoTransport } from '@/helpers/pino';
 export async function initializeFastifyApp(
   options: FastifyAppOptions = {},
 ): Promise<FastifyInstance> {
-  const { httpRouteModules = [], middlewares = [], isApiDocEnabled = true } = options;
+  const {
+    httpRouteModules = [],
+    middlewares = [],
+    isApiDocEnabled = true,
+    onClose,
+  } = options;
 
   // Fastify 伺服器選項
   const fastifyOptions: FastifyServerOptions = {
@@ -46,6 +51,11 @@ export async function initializeFastifyApp(
 
   // 註冊 HTTP 路由模組
   await registerHttpRouteModules(app, httpRouteModules);
+
+  // 註冊優雅關閉清理（例如關閉 DB 連線池）
+  if (onClose) {
+    app.addHook('onClose', onClose);
+  }
 
   return app;
 }

--- a/apps/api/src/infrastructures/fastify/types.ts
+++ b/apps/api/src/infrastructures/fastify/types.ts
@@ -15,4 +15,6 @@ export interface FastifyAppOptions {
   httpRouteModules?: HttpRouteModule[];
   middlewares?: Middleware[];
   isApiDocEnabled?: boolean;
+  /** Cleanup run on Fastify `onClose` (e.g. closing the DB pool) during graceful shutdown. */
+  onClose?: () => void | Promise<void>;
 }

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -9,6 +9,7 @@
  */
 // import 'module-alias/register';
 import { FastifyServerManager, HttpRouteModule } from '@/infrastructures';
+import { closeDatasource } from '@/infrastructures/datasource';
 import * as _indexHttpRouteModules from '@/delivery/http';
 
 const main = async () => {
@@ -18,6 +19,7 @@ const main = async () => {
 
   const serverManager = new FastifyServerManager({
     httpRouteModules,
+    onClose: closeDatasource,
   });
 
   try {

--- a/apps/workbench/src/app/[locale]/(shell)/datasets/page.tsx
+++ b/apps/workbench/src/app/[locale]/(shell)/datasets/page.tsx
@@ -1,18 +1,7 @@
 import { Panel } from "@rfjs/web-ui/components/panel";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 
-type Dataset = { id: string; name: string; description: string | null };
-
-async function fetchDatasets(): Promise<Dataset[]> {
-  const base = process.env.API_BASE_URL ?? "http://localhost:3000";
-  try {
-    const res = await fetch(`${base}/datasets`, { cache: "no-store" });
-    if (!res.ok) return [];
-    return (await res.json()) as Dataset[];
-  } catch {
-    return [];
-  }
-}
+import { fetchDatasets } from "@/lib/datasets";
 
 export default async function DatasetsPage({
   params,
@@ -22,18 +11,20 @@ export default async function DatasetsPage({
   const { locale } = await params;
   setRequestLocale(locale);
   const t = await getTranslations("Pages");
-  const datasets = await fetchDatasets();
+  const result = await fetchDatasets();
 
   return (
     <div className="flex flex-col gap-4">
       <h1 className="text-xl font-semibold">{t("datasetsTitle")}</h1>
       <p className="text-sm text-muted-foreground">{t("datasetsDescription")}</p>
       <Panel>
-        {datasets.length === 0 ? (
-          <span className="text-sm text-muted-foreground">No datasets yet.</span>
+        {!result.ok ? (
+          <span className="text-sm text-destructive">{t("datasetsError")}</span>
+        ) : result.datasets.length === 0 ? (
+          <span className="text-sm text-muted-foreground">{t("datasetsEmpty")}</span>
         ) : (
           <ul className="flex flex-col gap-2">
-            {datasets.map((d) => (
+            {result.datasets.map((d) => (
               <li key={d.id} className="text-sm">
                 <span className="font-medium">{d.name}</span>
                 {d.description ? (

--- a/apps/workbench/src/lib/datasets.spec.ts
+++ b/apps/workbench/src/lib/datasets.spec.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { fetchDatasets } from "./datasets";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("fetchDatasets", () => {
+  it("returns ok with datasets on a 2xx response", async () => {
+    const rows = [{ id: "1", name: "A", description: null }];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve(rows) }),
+    );
+    expect(await fetchDatasets()).toEqual({ ok: true, datasets: rows });
+  });
+
+  it("returns ok with an empty array when the API has no datasets", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve([]) }),
+    );
+    expect(await fetchDatasets()).toEqual({ ok: true, datasets: [] });
+  });
+
+  it("returns not-ok on a non-2xx response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: false, json: () => Promise.resolve({}) }),
+    );
+    expect(await fetchDatasets()).toEqual({ ok: false });
+  });
+
+  it("returns not-ok when fetch throws (API unreachable)", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("ECONNREFUSED")));
+    expect(await fetchDatasets()).toEqual({ ok: false });
+  });
+});

--- a/apps/workbench/src/lib/datasets.ts
+++ b/apps/workbench/src/lib/datasets.ts
@@ -1,0 +1,18 @@
+export type Dataset = { id: string; name: string; description: string | null };
+
+/**
+ * Distinguishes a reachable-but-empty API (`ok: true, datasets: []`) from an
+ * unreachable/erroring one (`ok: false`) so the page can show different states.
+ */
+export type DatasetsResult = { ok: true; datasets: Dataset[] } | { ok: false };
+
+export async function fetchDatasets(): Promise<DatasetsResult> {
+  const base = process.env.API_BASE_URL ?? "http://localhost:3000";
+  try {
+    const res = await fetch(`${base}/datasets`, { cache: "no-store" });
+    if (!res.ok) return { ok: false };
+    return { ok: true, datasets: (await res.json()) as Dataset[] };
+  } catch {
+    return { ok: false };
+  }
+}

--- a/apps/workbench/src/messages/en.json
+++ b/apps/workbench/src/messages/en.json
@@ -20,6 +20,8 @@
     "dashboardDescription": "Datasets at a glance and shortcuts into the apps.",
     "datasetsTitle": "Datasets",
     "datasetsDescription": "Built-in samples and imported JSON/CSV datasets. Management arrives in a later phase.",
+    "datasetsEmpty": "No datasets yet.",
+    "datasetsError": "Couldn't reach the datasets API.",
     "appsTitle": "Apps",
     "appsDescription": "Dataset-driven applications composing the @rfjs packages.",
     "adminTitle": "Admin",

--- a/apps/workbench/src/messages/zh-TW.json
+++ b/apps/workbench/src/messages/zh-TW.json
@@ -20,6 +20,8 @@
     "dashboardDescription": "資料集總覽與應用捷徑。",
     "datasetsTitle": "資料集",
     "datasetsDescription": "內建範例與匯入的 JSON/CSV 資料集。管理功能將於後續階段推出。",
+    "datasetsEmpty": "尚無資料集。",
+    "datasetsError": "無法連線資料集 API。",
     "appsTitle": "應用",
     "appsDescription": "以資料集驅動、組合 @rfjs 套件的應用。",
     "adminTitle": "管理",


### PR DESCRIPTION
## Summary

Two deferred follow-ups from the workbench backend foundation (PR #159):

1. **apps/api — graceful DB-pool shutdown.** The server already had SIGTERM/SIGINT → `app.close()`, but it never closed the pg pool. Now:
   - `datasource/index.ts` exports `closeDatasource = () => pool.end()` (destructures `pool` from `createDb`).
   - `FastifyAppOptions` gains an optional `onClose`; `initialize-app` registers it as a Fastify `onClose` hook.
   - `main.ts` (composition root) wires `onClose: closeDatasource`.
   - `initialize-app` stays decoupled from `datasource` (no new import) — only the composition root knows the pool.

2. **apps/workbench — distinguish "API down" from "no datasets".** Previously both rendered the same empty state (and a hardcoded English string). Now:
   - `fetchDatasets` (extracted to `lib/datasets.ts`) returns a discriminated `{ ok: true; datasets } | { ok: false }` — `!res.ok` or a thrown fetch → `ok:false`; reachable+`[]` → genuinely empty.
   - The page renders three states: API-error / empty / list.
   - New i18n keys `datasetsEmpty` + `datasetsError` (en + zh-TW), replacing the hardcoded `"No datasets yet."`.

## Test plan
- [x] TDD: `initialize-app.spec.ts` (2) + `datasets.spec.ts` (4) written red→green
- [x] `pnpm -F api vitest:run` → 8/8; `typecheck` + `lint` clean
- [x] `pnpm -F workbench vitest:run` → 6/6; `check-types` + `lint` (--max-warnings 0) clean
- [x] `turbo build --filter=api --filter=workbench` → 5/5
- [x] workbench i18n en/zh-TW parity (26 = 26)
- [x] pre-commit hook (`lint-staged test --affected`) passed

## Coordination
Runs parallel to the active `feat/datasets-jsonb-filter` line. The only shared file is `apps/api/src/infrastructures/datasource/index.ts`, where the edits sit in non-overlapping regions (they add `search:` inside `datasetUsecases` + a `@rfjs/core` import; this adds a `{ db, pool }` destructure + an appended `closeDatasource` export). **Recommend merging this *after* the jsonb-filter PR**; I'll rebase if needed (expected near-automatic). Their `libs/db` `$client` type change is orthogonal to `pool.end()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)