### PR TITLE
chore(husky): move heavy checks from pre-commit to pre-push

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-pnpm exec turbo run lint-staged test --affected
+pnpm exec turbo run lint-staged --affected

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,1 @@
+pnpm exec turbo run test --affected

--- a/templates/apps/app-esbuild/.husky/pre-commit
+++ b/templates/apps/app-esbuild/.husky/pre-commit
@@ -1,1 +1,1 @@
-pnpm typecheck && pnpm lint-staged
+pnpm lint-staged

--- a/templates/apps/app-esbuild/.husky/pre-push
+++ b/templates/apps/app-esbuild/.husky/pre-push
@@ -1,0 +1,1 @@
+pnpm typecheck

--- a/templates/apps/app-tsdown/.husky/pre-commit
+++ b/templates/apps/app-tsdown/.husky/pre-commit
@@ -1,1 +1,1 @@
-pnpm typecheck && pnpm lint-staged
+pnpm lint-staged

--- a/templates/apps/app-tsdown/.husky/pre-push
+++ b/templates/apps/app-tsdown/.husky/pre-push
@@ -1,0 +1,1 @@
+pnpm typecheck

--- a/templates/apps/fastify-esbuild/.husky/pre-commit
+++ b/templates/apps/fastify-esbuild/.husky/pre-commit
@@ -1,1 +1,1 @@
-pnpm typecheck && pnpm lint-staged
+pnpm lint-staged

--- a/templates/apps/fastify-esbuild/.husky/pre-push
+++ b/templates/apps/fastify-esbuild/.husky/pre-push
@@ -1,0 +1,1 @@
+pnpm typecheck

--- a/templates/apps/fastify-gql-tsdown/.husky/pre-commit
+++ b/templates/apps/fastify-gql-tsdown/.husky/pre-commit
@@ -1,1 +1,1 @@
-pnpm typecheck && pnpm lint-staged
+pnpm lint-staged

--- a/templates/apps/fastify-gql-tsdown/.husky/pre-push
+++ b/templates/apps/fastify-gql-tsdown/.husky/pre-push
@@ -1,0 +1,1 @@
+pnpm typecheck

--- a/templates/apps/fastify-tsdown/.husky/pre-commit
+++ b/templates/apps/fastify-tsdown/.husky/pre-commit
@@ -1,1 +1,1 @@
-pnpm typecheck && pnpm lint-staged
+pnpm lint-staged

--- a/templates/apps/fastify-tsdown/.husky/pre-push
+++ b/templates/apps/fastify-tsdown/.husky/pre-push
@@ -1,0 +1,1 @@
+pnpm typecheck

--- a/templates/apps/koa-esbuild/.husky/pre-commit
+++ b/templates/apps/koa-esbuild/.husky/pre-commit
@@ -1,1 +1,1 @@
-pnpm typecheck && pnpm lint-staged
+pnpm lint-staged

--- a/templates/apps/koa-esbuild/.husky/pre-push
+++ b/templates/apps/koa-esbuild/.husky/pre-push
@@ -1,0 +1,1 @@
+pnpm typecheck

--- a/templates/bins/bin-tsdown/.husky/pre-commit
+++ b/templates/bins/bin-tsdown/.husky/pre-commit
@@ -1,1 +1,1 @@
-pnpm typecheck && pnpm lint-staged
+pnpm lint-staged

--- a/templates/bins/bin-tsdown/.husky/pre-push
+++ b/templates/bins/bin-tsdown/.husky/pre-push
@@ -1,0 +1,1 @@
+pnpm typecheck

--- a/templates/docs/docs-docsify/.husky/pre-commit
+++ b/templates/docs/docs-docsify/.husky/pre-commit
@@ -1,1 +1,1 @@
-npx tsc --noEmit && pnpm lint-staged && pnpm test
+pnpm lint-staged

--- a/templates/docs/docs-docsify/.husky/pre-push
+++ b/templates/docs/docs-docsify/.husky/pre-push
@@ -1,0 +1,1 @@
+npx tsc --noEmit && pnpm test

--- a/templates/docs/docs-vitepress/.husky/pre-commit
+++ b/templates/docs/docs-vitepress/.husky/pre-commit
@@ -1,1 +1,1 @@
-npx tsc --noEmit && pnpm lint-staged && pnpm test
+pnpm lint-staged

--- a/templates/docs/docs-vitepress/.husky/pre-push
+++ b/templates/docs/docs-vitepress/.husky/pre-push
@@ -1,0 +1,1 @@
+npx tsc --noEmit && pnpm test

--- a/templates/libs/lib-esbuild/.husky/pre-commit
+++ b/templates/libs/lib-esbuild/.husky/pre-commit
@@ -1,1 +1,1 @@
-pnpm typecheck && pnpm lint-staged
+pnpm lint-staged

--- a/templates/libs/lib-esbuild/.husky/pre-push
+++ b/templates/libs/lib-esbuild/.husky/pre-push
@@ -1,0 +1,1 @@
+pnpm typecheck

--- a/templates/libs/lib-rolldown/.husky/pre-commit
+++ b/templates/libs/lib-rolldown/.husky/pre-commit
@@ -1,1 +1,1 @@
-pnpm typecheck && pnpm lint-staged
+pnpm lint-staged

--- a/templates/libs/lib-rolldown/.husky/pre-push
+++ b/templates/libs/lib-rolldown/.husky/pre-push
@@ -1,0 +1,1 @@
+pnpm typecheck

--- a/templates/libs/lib-rollup/.husky/pre-commit
+++ b/templates/libs/lib-rollup/.husky/pre-commit
@@ -1,1 +1,1 @@
-pnpm typecheck && pnpm lint-staged
+pnpm lint-staged

--- a/templates/libs/lib-rollup/.husky/pre-push
+++ b/templates/libs/lib-rollup/.husky/pre-push
@@ -1,0 +1,1 @@
+pnpm typecheck

--- a/templates/libs/lib-tsdown/.husky/pre-commit
+++ b/templates/libs/lib-tsdown/.husky/pre-commit
@@ -1,1 +1,1 @@
-pnpm typecheck && pnpm lint-staged
+pnpm lint-staged

--- a/templates/libs/lib-tsdown/.husky/pre-push
+++ b/templates/libs/lib-tsdown/.husky/pre-push
@@ -1,0 +1,1 @@
+pnpm typecheck

--- a/templates/monorepo/turbo/stack/base/.husky/pre-commit
+++ b/templates/monorepo/turbo/stack/base/.husky/pre-commit
@@ -1,1 +1,1 @@
-pnpm exec turbo run lint-staged test --affected
+pnpm exec turbo run lint-staged --affected

--- a/templates/monorepo/turbo/stack/base/.husky/pre-push
+++ b/templates/monorepo/turbo/stack/base/.husky/pre-push
@@ -1,0 +1,1 @@
+pnpm exec turbo run test --affected


### PR DESCRIPTION
## What

Make `pre-commit` fast by running **only `lint-staged`**, and move the heavy checks (typecheck / tests) to a new **`pre-push`** hook — across the root repo and all 14 templates.

## Why

`git stash list` had accumulated 11 orphaned `lint-staged automatic backup` stashes. Root cause: heavy/flaky tasks (`test --affected`, `typecheck`) running inside `pre-commit` alongside `lint-staged`. When such a run is interrupted or fails, lint-staged can't clean up its backup stash, so it leaks — one per interrupted commit.

Keeping `pre-commit` to `lint-staged` only makes commits fast and far less likely to be interrupted; the heavier verification still runs, just at `pre-push` time.

## Changes (30 files: 15 `pre-commit` edited + 15 `pre-push` added)

| Group | pre-commit | pre-push (new) |
|-------|-----------|----------------|
| root + `monorepo/turbo/stack/base` | `turbo run lint-staged --affected` | `turbo run test --affected` |
| app / lib / bin templates (×11) | `lint-staged` | `typecheck` |
| docs templates (×2) | `lint-staged` | `tsc --noEmit && test` |

## Notes

- husky v9 auto-routes every git hook via `.husky/_/<hook>`, so the new `pre-push` needs **zero registration** — it activates after `pnpm install` runs husky's `prepare`.
- Hooks stay committed as `100644` (husky v9 doesn't require executable hooks); no mode changes.
- `orm/*` and `bullmq/*` templates have no committed `.husky/` hooks, so they're untouched.
- No changeset: only husky config + template scaffolding change, no published `@rfjs/*` package code is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)