### PR TITLE
feat(web): jwt-decoder tool — decode-only, dogfooding @rfjs/jwt

### DIFF
--- a/.changeset/jwt-decode-complete.md
+++ b/.changeset/jwt-decode-complete.md
@@ -1,0 +1,5 @@
+---
+"@rfjs/jwt": minor
+---
+
+Add `Jwt.decodeComplete(token)` — a static, no-secret full decode returning `{ header, payload, signature } | null` (wraps `jsonwebtoken.decode` with `{ complete: true }`).

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,6 +16,7 @@
     "@rfjs/data-filter": "workspace:*",
     "@rfjs/data-transform": "workspace:*",
     "@rfjs/jsonb-query": "workspace:*",
+    "@rfjs/jwt": "workspace:*",
     "@rfjs/mongo-query": "workspace:*",
     "@rfjs/object-utils": "workspace:*",
     "@rfjs/web-core": "workspace:*",

--- a/apps/web/src/app/api/tools/jwt-decode/route.spec.ts
+++ b/apps/web/src/app/api/tools/jwt-decode/route.spec.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { Jwt } from "@rfjs/jwt";
+
+import { POST } from "./route";
+
+function post(body: unknown) {
+  return POST(
+    new Request("http://test/api/tools/jwt-decode", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+  );
+}
+
+describe("POST /api/tools/jwt-decode", () => {
+  it("decodes a valid token", async () => {
+    const token = Jwt.initial("secret").createToken({ id: 1 });
+    const res = await post({ token });
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.ok).toBe(true);
+    expect(json.header).toMatchObject({ alg: "HS256" });
+    expect(json.payload).toMatchObject({ id: 1 });
+    expect(typeof json.signature).toBe("string");
+  });
+
+  it("returns ok:false for a malformed token", async () => {
+    const res = await post({ token: "not-a-jwt" });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: false, error: "invalidJwt" });
+  });
+
+  it("returns 400 for a bad body", async () => {
+    const res = await post({});
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ ok: false, error: "badRequest" });
+  });
+
+  it("returns 400 for a non-JSON body", async () => {
+    const res = await POST(
+      new Request("http://test/api/tools/jwt-decode", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "not json",
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/web/src/app/api/tools/jwt-decode/route.ts
+++ b/apps/web/src/app/api/tools/jwt-decode/route.ts
@@ -1,0 +1,24 @@
+import { Jwt } from "@rfjs/jwt";
+
+// @rfjs/jwt wraps jsonwebtoken (require('crypto')) → Node runtime only.
+export const runtime = "nodejs";
+
+export async function POST(req: Request): Promise<Response> {
+  const body: unknown = await req.json().catch(() => null);
+  const token =
+    body && typeof body === "object" && typeof (body as { token?: unknown }).token === "string"
+      ? (body as { token: string }).token
+      : null;
+
+  if (!token) {
+    return Response.json({ ok: false, error: "badRequest" }, { status: 400 });
+  }
+
+  const decoded = Jwt.decodeComplete(token);
+  if (!decoded) {
+    return Response.json({ ok: false, error: "invalidJwt" });
+  }
+
+  const { header, payload, signature } = decoded;
+  return Response.json({ ok: true, header, payload, signature });
+}

--- a/apps/web/src/components/tools/jwt-decoder.tsx
+++ b/apps/web/src/components/tools/jwt-decoder.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { Panel } from "@rfjs/web-ui/components/panel";
+import { useTranslations } from "next-intl";
+import { useEffect, useState } from "react";
+
+import { decodeJwt, describeExp, formatDuration, type DecodeResult } from "@/lib/tools/jwt-decoder";
+
+import { ToolShell } from "./tool-shell";
+
+const SAMPLE =
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
+
+export function JwtDecoder() {
+  const t = useTranslations("ToolUI");
+  const [token, setToken] = useState(SAMPLE);
+  const [result, setResult] = useState<DecodeResult | null>(null);
+  const [nowSec, setNowSec] = useState(() => Math.floor(Date.now() / 1000));
+
+  // Re-decode (server fetch) only when the token input changes, debounced.
+  useEffect(() => {
+    const trimmed = token.trim();
+    if (!trimmed) {
+      setResult(null);
+      return;
+    }
+    const id = setTimeout(() => {
+      void decodeJwt(trimmed).then(setResult);
+    }, 300);
+    return () => clearTimeout(id);
+  }, [token]);
+
+  const exp =
+    result?.ok && result.payload && typeof result.payload === "object"
+      ? (result.payload as { exp?: number }).exp
+      : undefined;
+
+  // Live expiry: re-tick `now` every second (chip only — no re-fetch). Runs only
+  // while a decoded payload carries an `exp`.
+  useEffect(() => {
+    if (typeof exp !== "number") return;
+    const id = setInterval(() => setNowSec(Math.floor(Date.now() / 1000)), 1000);
+    return () => clearInterval(id);
+  }, [exp]);
+
+  const info = describeExp(exp, nowSec);
+  const expLabel =
+    info.state === "none"
+      ? t("noExpiry")
+      : info.state === "expired"
+        ? t("expired")
+        : t("expiresIn", { duration: formatDuration(info.secondsLeft) });
+
+  return (
+    <ToolShell
+      operation="decodeComplete()"
+      input={
+        <Panel title={t("token")}>
+          <textarea
+            aria-label={t("token")}
+            value={token}
+            onChange={(e) => setToken(e.target.value)}
+            spellCheck={false}
+            rows={8}
+            className="w-full resize-y break-all rounded-sm border bg-transparent p-2 font-mono text-sm"
+          />
+        </Panel>
+      }
+      output={
+        <Panel title={t("output")}>
+          {result === null ? null : !result.ok ? (
+            <p className="font-mono text-sm text-fault">{t(`error.${result.error}`)}</p>
+          ) : (
+            <div className="flex flex-col gap-3">
+              <span
+                className={`font-mono text-xs ${info.state === "expired" ? "text-fault" : "text-muted-foreground"}`}
+              >
+                {expLabel}
+              </span>
+              <JsonBlock label={t("header")} value={result.header} />
+              <JsonBlock label={t("payload")} value={result.payload} />
+              <div className="flex flex-col gap-1">
+                <span className="font-mono text-[10px] uppercase tracking-wide text-muted-foreground">
+                  {t("signature")}
+                </span>
+                <pre className="overflow-x-auto break-all font-mono text-xs text-muted-foreground">
+                  {result.signature}
+                </pre>
+              </div>
+            </div>
+          )}
+        </Panel>
+      }
+    />
+  );
+}
+
+function JsonBlock({ label, value }: { label: string; value: unknown }) {
+  return (
+    <div className="flex flex-col gap-1">
+      <span className="font-mono text-[10px] uppercase tracking-wide text-muted-foreground">
+        {label}
+      </span>
+      <pre className="overflow-x-auto font-mono text-sm text-signal">
+        {JSON.stringify(value, null, 2)}
+      </pre>
+    </div>
+  );
+}

--- a/apps/web/src/components/tools/registry.tsx
+++ b/apps/web/src/components/tools/registry.tsx
@@ -2,6 +2,7 @@ import type { ComponentType } from "react";
 
 import { DataFilterTester } from "./data-filter-tester";
 import { JsonbQueryGenerator } from "./jsonb-query-generator";
+import { JwtDecoder } from "./jwt-decoder";
 import { MongoQueryGenerator } from "./mongo-query-generator";
 import { ObjectFlatten } from "./object-flatten";
 import { TypeConverter } from "./type-converter";
@@ -14,4 +15,5 @@ export const TOOL_COMPONENTS: Record<string, ComponentType> = {
   "data-filter-tester": DataFilterTester,
   "mongo-query-generator": MongoQueryGenerator,
   "jsonb-query-generator": JsonbQueryGenerator,
+  "jwt-decoder": JwtDecoder,
 };

--- a/apps/web/src/lib/tool-href.spec.ts
+++ b/apps/web/src/lib/tool-href.spec.ts
@@ -7,14 +7,12 @@ const webTool: ToolDefinition = {
   id: "jwt-decoder",
   category: "inspect",
   surface: "web",
-  href: "/legacy",
   status: "planned",
 };
 const wbApp: ToolDefinition = {
   id: "data-filter-builder",
   category: "filter",
   surface: "workbench",
-  href: "/legacy",
   status: "planned",
 };
 

--- a/apps/web/src/lib/tools/jwt-decoder.spec.ts
+++ b/apps/web/src/lib/tools/jwt-decoder.spec.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+
+import { describeExp, formatDuration } from "./jwt-decoder";
+
+describe("describeExp", () => {
+  it("reports valid with seconds left when exp is in the future", () => {
+    expect(describeExp(1000, 400)).toEqual({ state: "valid", secondsLeft: 600 });
+  });
+  it("reports expired when exp is in the past", () => {
+    expect(describeExp(400, 1000)).toEqual({ state: "expired", secondsLeft: -600 });
+  });
+  it("reports none when there is no exp", () => {
+    expect(describeExp(undefined, 1000)).toEqual({ state: "none" });
+  });
+});
+
+describe("formatDuration", () => {
+  it("formats hours, minutes and seconds, dropping empty leading units", () => {
+    expect(formatDuration(3661)).toBe("1h 1m 1s");
+    expect(formatDuration(65)).toBe("1m 5s");
+    expect(formatDuration(9)).toBe("9s");
+  });
+  it("uses the magnitude regardless of sign", () => {
+    expect(formatDuration(-65)).toBe("1m 5s");
+  });
+});

--- a/apps/web/src/lib/tools/jwt-decoder.ts
+++ b/apps/web/src/lib/tools/jwt-decoder.ts
@@ -1,0 +1,40 @@
+export type DecodeResult =
+  | { ok: true; header: unknown; payload: unknown; signature: string }
+  | { ok: false; error: "invalidJwt" | "request" };
+
+export async function decodeJwt(token: string): Promise<DecodeResult> {
+  try {
+    const res = await fetch("/api/tools/jwt-decode", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ token }),
+    });
+    if (!res.ok) return { ok: false, error: "request" };
+    return (await res.json()) as DecodeResult;
+  } catch {
+    return { ok: false, error: "request" };
+  }
+}
+
+export type ExpInfo =
+  | { state: "valid"; secondsLeft: number }
+  | { state: "expired"; secondsLeft: number }
+  | { state: "none" };
+
+/** Pure: classifies a JWT `exp` (seconds) against an injected `now` (seconds). */
+export function describeExp(expSec: number | undefined, nowSec: number): ExpInfo {
+  if (typeof expSec !== "number") return { state: "none" };
+  const secondsLeft = expSec - nowSec;
+  return secondsLeft > 0
+    ? { state: "valid", secondsLeft }
+    : { state: "expired", secondsLeft };
+}
+
+/** Pure: "1h 1m 1s" from a (possibly negative) second count; drops empty leading units. */
+export function formatDuration(totalSeconds: number): string {
+  const s = Math.abs(Math.trunc(totalSeconds));
+  const h = Math.floor(s / 3600);
+  const m = Math.floor((s % 3600) / 60);
+  const sec = s % 60;
+  return [h ? `${h}h` : "", m ? `${m}m` : "", `${sec}s`].filter(Boolean).join(" ");
+}

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -63,6 +63,13 @@
     "filter": "Filter",
     "column": "Column",
     "dialect": "Dialect",
+    "token": "JWT",
+    "header": "Header",
+    "payload": "Payload",
+    "signature": "Signature",
+    "expiresIn": "expires in {duration}",
+    "expired": "expired",
+    "noExpiry": "no expiry",
     "matched": "{count} matched",
     "types": {
       "string": "String",
@@ -78,7 +85,9 @@
       "invalidJson": "Invalid JSON",
       "notObject": "Expected a JSON object",
       "notArray": "Expected a JSON array",
-      "queryFailed": "Could not build the query"
+      "queryFailed": "Could not build the query",
+      "invalidJwt": "Not a valid JWT",
+      "request": "Decode request failed"
     }
   },
   "Packages": {

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -46,7 +46,7 @@
     "object-flatten": { "title": "Object Flatten / Unflatten", "description": "Flatten nested objects to dot-path keys and back." },
     "type-converter": { "title": "Data Type Converter", "description": "Convert values between string, number, boolean, and date." },
     "data-filter-tester": { "title": "JSONPath Filter Tester", "description": "Run @rfjs/data-filter conditions against sample data live." },
-    "jwt-decoder": { "title": "JWT Decoder", "description": "Decode JWT header and payload locally — nothing leaves your browser." },
+    "jwt-decoder": { "title": "JWT Decoder", "description": "Decode a JWT's header and payload, with a live expiry status." },
     "jsonb-query-generator": { "title": "Filter → JSONB SQL", "description": "Generate PostgreSQL JSONB queries from filter metadata." },
     "mongo-query-generator": { "title": "Filter → Mongo Query", "description": "Generate MongoDB queries from filter metadata." },
     "data-filter-builder": { "title": "Data Filter Builder", "description": "Compose nested filter conditions visually and export them." },

--- a/apps/web/src/messages/zh-TW.json
+++ b/apps/web/src/messages/zh-TW.json
@@ -46,7 +46,7 @@
     "object-flatten": { "title": "物件壓平 / 還原", "description": "把巢狀物件壓平成點路徑鍵,並可還原。" },
     "type-converter": { "title": "資料型別轉換器", "description": "在字串、數字、布林、日期之間轉換值。" },
     "data-filter-tester": { "title": "JSONPath 篩選測試器", "description": "對範例資料即時執行 @rfjs/data-filter 條件。" },
-    "jwt-decoder": { "title": "JWT 解碼器", "description": "在本機解碼 JWT 標頭與內容 —— 資料不離開瀏覽器。" },
+    "jwt-decoder": { "title": "JWT 解碼器", "description": "解碼 JWT 的 header 與 payload，並顯示即時有效期狀態。" },
     "jsonb-query-generator": { "title": "篩選 → JSONB SQL", "description": "從篩選 metadata 產生 PostgreSQL JSONB 查詢。" },
     "mongo-query-generator": { "title": "篩選 → Mongo 查詢", "description": "從篩選 metadata 產生 MongoDB 查詢。" },
     "data-filter-builder": { "title": "資料篩選建構器", "description": "視覺化組合巢狀篩選條件並匯出。" },

--- a/apps/web/src/messages/zh-TW.json
+++ b/apps/web/src/messages/zh-TW.json
@@ -63,6 +63,13 @@
     "filter": "篩選條件",
     "column": "欄位",
     "dialect": "方言",
+    "token": "JWT",
+    "header": "Header",
+    "payload": "Payload",
+    "signature": "簽章",
+    "expiresIn": "{duration}後過期",
+    "expired": "已過期",
+    "noExpiry": "無有效期",
     "matched": "命中 {count} 筆",
     "types": {
       "string": "字串",
@@ -78,7 +85,9 @@
       "invalidJson": "無效的 JSON",
       "notObject": "需要 JSON 物件",
       "notArray": "需要 JSON 陣列",
-      "queryFailed": "無法產生查詢"
+      "queryFailed": "無法產生查詢",
+      "invalidJwt": "不是有效的 JWT",
+      "request": "解碼請求失敗"
     }
   },
   "Packages": {

--- a/docs/superpowers/plans/2026-06-15-jwt-decoder.md
+++ b/docs/superpowers/plans/2026-06-15-jwt-decoder.md
@@ -1,0 +1,535 @@
+# jwt-decoder Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the `jwt-decoder` web quick tool live — paste a JWT, see its header + payload + signature and a live expiry status — dogfooding `@rfjs/jwt`.
+
+**Architecture:** `@rfjs/jwt` gains a static `decodeComplete`. A Node-runtime Next route handler (`POST /api/tools/jwt-decode`) calls it server-side (the package is not client-safe). A client component (ToolShell) debounces input → fetches the route; a 1 s interval re-computes only the expiry chip from the cached payload.
+
+**Tech Stack:** Next.js App Router (route handler + client component), `@rfjs/jwt` (wraps `jsonwebtoken`), next-intl, Vitest.
+
+**Context:** Working in worktree `feat-jwt-decoder`. Spec: `docs/superpowers/specs/2026-06-14-jwt-decoder-design.md`. Run all commands from the worktree root. `pnpm install` has already been run here.
+
+---
+
+## File Structure
+
+- `packages/jwt/src/jwt.ts` — add static `Jwt.decodeComplete` (modify)
+- `packages/jwt/src/jwt.spec.ts` — add `decodeComplete` tests (modify)
+- `.changeset/jwt-decode-complete.md` — minor bump for `@rfjs/jwt` (create)
+- `apps/web/package.json` + `pnpm-lock.yaml` — add `@rfjs/jwt` dep (modify)
+- `apps/web/src/app/api/tools/jwt-decode/route.ts` — POST handler (create)
+- `apps/web/src/app/api/tools/jwt-decode/route.spec.ts` — handler tests (create)
+- `apps/web/src/lib/tools/jwt-decoder.ts` — `decodeJwt` fetch wrapper + pure `describeExp`/`formatDuration` (create)
+- `apps/web/src/lib/tools/jwt-decoder.spec.ts` — pure-helper tests (create)
+- `apps/web/src/components/tools/jwt-decoder.tsx` — client component (create)
+- `apps/web/src/components/tools/registry.tsx` — register the component (modify)
+- `apps/web/src/messages/{en,zh-TW}.json` — `ToolUI` keys (modify)
+
+---
+
+### Task 1: `Jwt.decodeComplete` in `@rfjs/jwt`
+
+**Files:**
+- Modify: `packages/jwt/src/jwt.ts`
+- Test: `packages/jwt/src/jwt.spec.ts`
+- Create: `.changeset/jwt-decode-complete.md`
+
+- [ ] **Step 1: Write the failing test** — append to `packages/jwt/src/jwt.spec.ts` (inside the top-level `describe`, after the existing blocks):
+
+```ts
+  describe('decodeComplete', () => {
+    it('returns header, payload and signature for a valid token', () => {
+      const token = Jwt.initial('secret').createToken({ id: 1 });
+      const decoded = Jwt.decodeComplete(token);
+      expect(decoded).not.toBeNull();
+      expect(decoded?.header).toMatchObject({ alg: 'HS256', typ: 'JWT' });
+      expect(decoded?.payload).toMatchObject({ id: 1 });
+      expect(typeof decoded?.signature).toBe('string');
+    });
+
+    it('returns null for a malformed token', () => {
+      expect(Jwt.decodeComplete('not-a-jwt')).toBeNull();
+    });
+  });
+```
+
+- [ ] **Step 2: Run the test, verify it fails**
+
+Run: `pnpm -F @rfjs/jwt vitest:run`
+Expected: FAIL — `Jwt.decodeComplete is not a function`.
+
+- [ ] **Step 3: Implement** — in `packages/jwt/src/jwt.ts`, add this static method to the `Jwt` class (e.g. directly after the `static initial(...)` method). `decode` is already imported at the top of the file:
+
+```ts
+  /**
+   * Full decode (header + payload + signature) WITHOUT verifying the signature.
+   * Static because decoding needs no secret. Returns `null` for a malformed
+   * token (`jsonwebtoken.decode` returns null rather than throwing).
+   */
+  static decodeComplete(token: string) {
+    return decode(token, { complete: true });
+  }
+```
+
+- [ ] **Step 4: Run the test, verify it passes**
+
+Run: `pnpm -F @rfjs/jwt vitest:run`
+Expected: PASS (all existing tests + the 2 new ones).
+
+- [ ] **Step 5: Create the changeset** — `.changeset/jwt-decode-complete.md`:
+
+```md
+---
+"@rfjs/jwt": minor
+---
+
+Add `Jwt.decodeComplete(token)` — a static, no-secret full decode returning `{ header, payload, signature } | null` (wraps `jsonwebtoken.decode` with `{ complete: true }`).
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/jwt/src/jwt.ts packages/jwt/src/jwt.spec.ts .changeset/jwt-decode-complete.md
+git commit -m "feat(jwt): add Jwt.decodeComplete static (header+payload+signature)"
+```
+
+---
+
+### Task 2: `apps/web` depends on `@rfjs/jwt`
+
+**Files:**
+- Modify: `apps/web/package.json`, `pnpm-lock.yaml`
+
+- [ ] **Step 1: Add the dependency** — in `apps/web/package.json`, add to `dependencies` (keep the `@rfjs/*` entries alphabetical; it sorts before `@rfjs/mongo-query`):
+
+```json
+    "@rfjs/jwt": "workspace:*",
+```
+
+- [ ] **Step 2: Update the lockfile**
+
+Run: `pnpm install`
+Expected: lockfile updated, install succeeds.
+
+- [ ] **Step 3: Build `@rfjs/jwt`** so `apps/web` (and the route test) resolve its `dist` with the new method:
+
+Run: `pnpm -F @rfjs/jwt build`
+Expected: build succeeds; `packages/jwt/dist` exists.
+
+- [ ] **Step 4: Verify the lockfile is consistent**
+
+Run: `pnpm install --frozen-lockfile`
+Expected: succeeds with no changes ("Already up to date" / no lockfile diff).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/package.json pnpm-lock.yaml
+git commit -m "chore(web): add @rfjs/jwt dependency"
+```
+
+---
+
+### Task 3: Route handler `POST /api/tools/jwt-decode`
+
+**Files:**
+- Create: `apps/web/src/app/api/tools/jwt-decode/route.ts`
+- Test: `apps/web/src/app/api/tools/jwt-decode/route.spec.ts`
+
+- [ ] **Step 1: Write the failing test** — `apps/web/src/app/api/tools/jwt-decode/route.spec.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { Jwt } from "@rfjs/jwt";
+
+import { POST } from "./route";
+
+function post(body: unknown) {
+  return POST(
+    new Request("http://test/api/tools/jwt-decode", {
+      method: "POST",
+      body: JSON.stringify(body),
+    }),
+  );
+}
+
+describe("POST /api/tools/jwt-decode", () => {
+  it("decodes a valid token", async () => {
+    const token = Jwt.initial("secret").createToken({ id: 1 });
+    const res = await post({ token });
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.ok).toBe(true);
+    expect(json.header).toMatchObject({ alg: "HS256" });
+    expect(json.payload).toMatchObject({ id: 1 });
+    expect(typeof json.signature).toBe("string");
+  });
+
+  it("returns ok:false for a malformed token", async () => {
+    const res = await post({ token: "not-a-jwt" });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: false, error: "invalidJwt" });
+  });
+
+  it("returns 400 for a bad body", async () => {
+    const res = await post({});
+    expect(res.status).toBe(400);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test, verify it fails**
+
+Run: `pnpm -F web vitest:run route`
+Expected: FAIL — cannot resolve `./route` (file does not exist).
+
+- [ ] **Step 3: Implement** — `apps/web/src/app/api/tools/jwt-decode/route.ts`. A plain guard validates the one-field body (no zod dependency needed for a single string):
+
+```ts
+import { Jwt } from "@rfjs/jwt";
+
+// @rfjs/jwt wraps jsonwebtoken (require('crypto')) → Node runtime only.
+export const runtime = "nodejs";
+
+export async function POST(req: Request): Promise<Response> {
+  const body: unknown = await req.json().catch(() => null);
+  const token =
+    body && typeof body === "object" && typeof (body as { token?: unknown }).token === "string"
+      ? (body as { token: string }).token
+      : null;
+
+  if (!token) {
+    return Response.json({ ok: false, error: "badRequest" }, { status: 400 });
+  }
+
+  const decoded = Jwt.decodeComplete(token);
+  if (!decoded) {
+    return Response.json({ ok: false, error: "invalidJwt" });
+  }
+
+  const { header, payload, signature } = decoded;
+  return Response.json({ ok: true, header, payload, signature });
+}
+```
+
+- [ ] **Step 4: Run the test, verify it passes**
+
+Run: `pnpm -F web vitest:run route`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/app/api/tools/jwt-decode/route.ts apps/web/src/app/api/tools/jwt-decode/route.spec.ts
+git commit -m "feat(web): add /api/tools/jwt-decode route handler"
+```
+
+---
+
+### Task 4: Client lib — `decodeJwt` + pure `describeExp`/`formatDuration`
+
+**Files:**
+- Create: `apps/web/src/lib/tools/jwt-decoder.ts`
+- Test: `apps/web/src/lib/tools/jwt-decoder.spec.ts`
+
+- [ ] **Step 1: Write the failing test** — `apps/web/src/lib/tools/jwt-decoder.spec.ts` (only the pure helpers are tested; `decodeJwt` is a thin fetch wrapper exercised via the route + the browser):
+
+```ts
+import { describe, it, expect } from "vitest";
+
+import { describeExp, formatDuration } from "./jwt-decoder";
+
+describe("describeExp", () => {
+  it("reports valid with seconds left when exp is in the future", () => {
+    expect(describeExp(1000, 400)).toEqual({ state: "valid", secondsLeft: 600 });
+  });
+  it("reports expired when exp is in the past", () => {
+    expect(describeExp(400, 1000)).toEqual({ state: "expired", secondsLeft: -600 });
+  });
+  it("reports none when there is no exp", () => {
+    expect(describeExp(undefined, 1000)).toEqual({ state: "none" });
+  });
+});
+
+describe("formatDuration", () => {
+  it("formats hours, minutes and seconds, dropping empty leading units", () => {
+    expect(formatDuration(3661)).toBe("1h 1m 1s");
+    expect(formatDuration(65)).toBe("1m 5s");
+    expect(formatDuration(9)).toBe("9s");
+  });
+  it("uses the magnitude regardless of sign", () => {
+    expect(formatDuration(-65)).toBe("1m 5s");
+  });
+});
+```
+
+- [ ] **Step 2: Run the test, verify it fails**
+
+Run: `pnpm -F web vitest:run jwt-decoder`
+Expected: FAIL — cannot resolve `./jwt-decoder`.
+
+- [ ] **Step 3: Implement** — `apps/web/src/lib/tools/jwt-decoder.ts`:
+
+```ts
+export type DecodeResult =
+  | { ok: true; header: unknown; payload: unknown; signature: string }
+  | { ok: false; error: "invalidJwt" | "request" };
+
+export async function decodeJwt(token: string): Promise<DecodeResult> {
+  try {
+    const res = await fetch("/api/tools/jwt-decode", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ token }),
+    });
+    if (!res.ok) return { ok: false, error: "request" };
+    return (await res.json()) as DecodeResult;
+  } catch {
+    return { ok: false, error: "request" };
+  }
+}
+
+export type ExpInfo =
+  | { state: "valid"; secondsLeft: number }
+  | { state: "expired"; secondsLeft: number }
+  | { state: "none" };
+
+/** Pure: classifies a JWT `exp` (seconds) against an injected `now` (seconds). */
+export function describeExp(expSec: number | undefined, nowSec: number): ExpInfo {
+  if (typeof expSec !== "number") return { state: "none" };
+  const secondsLeft = expSec - nowSec;
+  return secondsLeft > 0
+    ? { state: "valid", secondsLeft }
+    : { state: "expired", secondsLeft };
+}
+
+/** Pure: "1h 1m 1s" from a (possibly negative) second count; drops empty leading units. */
+export function formatDuration(totalSeconds: number): string {
+  const s = Math.abs(Math.trunc(totalSeconds));
+  const h = Math.floor(s / 3600);
+  const m = Math.floor((s % 3600) / 60);
+  const sec = s % 60;
+  return [h ? `${h}h` : "", m ? `${m}m` : "", `${sec}s`].filter(Boolean).join(" ");
+}
+```
+
+- [ ] **Step 4: Run the test, verify it passes**
+
+Run: `pnpm -F web vitest:run jwt-decoder`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/lib/tools/jwt-decoder.ts apps/web/src/lib/tools/jwt-decoder.spec.ts
+git commit -m "feat(web): add jwt-decoder client lib (decodeJwt + describeExp)"
+```
+
+---
+
+### Task 5: Client component + registry + i18n
+
+**Files:**
+- Create: `apps/web/src/components/tools/jwt-decoder.tsx`
+- Modify: `apps/web/src/components/tools/registry.tsx`
+- Modify: `apps/web/src/messages/en.json`, `apps/web/src/messages/zh-TW.json`
+
+- [ ] **Step 1: Add i18n keys** — in `apps/web/src/messages/en.json`, inside the `"ToolUI"` object, add these keys alongside the existing flat keys (e.g. after `"dialect"`):
+
+```json
+    "token": "JWT",
+    "header": "Header",
+    "payload": "Payload",
+    "signature": "Signature",
+    "expiresIn": "expires in {duration}",
+    "expired": "expired",
+    "noExpiry": "no expiry",
+```
+
+and inside the existing `"ToolUI"` → `"error"` object, add:
+
+```json
+      "invalidJwt": "Not a valid JWT",
+      "request": "Decode request failed",
+```
+
+- [ ] **Step 2: Add the same keys to `apps/web/src/messages/zh-TW.json`** — `"ToolUI"` flat keys:
+
+```json
+    "token": "JWT",
+    "header": "Header",
+    "payload": "Payload",
+    "signature": "簽章",
+    "expiresIn": "{duration}後過期",
+    "expired": "已過期",
+    "noExpiry": "無有效期",
+```
+
+and `"ToolUI"` → `"error"`:
+
+```json
+      "invalidJwt": "不是有效的 JWT",
+      "request": "解碼請求失敗",
+```
+
+- [ ] **Step 3: Create the component** — `apps/web/src/components/tools/jwt-decoder.tsx`. The default `SAMPLE` is the well-known public jwt.io demo token (no secret, no `exp` → expiry chip shows "no expiry"):
+
+```tsx
+"use client";
+
+import { Panel } from "@rfjs/web-ui/components/panel";
+import { useTranslations } from "next-intl";
+import { useEffect, useState } from "react";
+
+import { decodeJwt, describeExp, formatDuration, type DecodeResult } from "@/lib/tools/jwt-decoder";
+
+import { ToolShell } from "./tool-shell";
+
+const SAMPLE =
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
+
+export function JwtDecoder() {
+  const t = useTranslations("ToolUI");
+  const [token, setToken] = useState(SAMPLE);
+  const [result, setResult] = useState<DecodeResult | null>(null);
+  const [nowSec, setNowSec] = useState(() => Math.floor(Date.now() / 1000));
+
+  // Re-decode (server fetch) only when the token input changes, debounced.
+  useEffect(() => {
+    const trimmed = token.trim();
+    if (!trimmed) {
+      setResult(null);
+      return;
+    }
+    const id = setTimeout(() => {
+      void decodeJwt(trimmed).then(setResult);
+    }, 300);
+    return () => clearTimeout(id);
+  }, [token]);
+
+  const exp =
+    result?.ok && result.payload && typeof result.payload === "object"
+      ? (result.payload as { exp?: number }).exp
+      : undefined;
+
+  // Live expiry: re-tick `now` every second (chip only — no re-fetch). Runs only
+  // while a decoded payload carries an `exp`.
+  useEffect(() => {
+    if (typeof exp !== "number") return;
+    const id = setInterval(() => setNowSec(Math.floor(Date.now() / 1000)), 1000);
+    return () => clearInterval(id);
+  }, [exp]);
+
+  const info = describeExp(exp, nowSec);
+  const expLabel =
+    info.state === "none"
+      ? t("noExpiry")
+      : info.state === "expired"
+        ? t("expired")
+        : t("expiresIn", { duration: formatDuration(info.secondsLeft) });
+
+  return (
+    <ToolShell
+      operation="decodeComplete()"
+      input={
+        <Panel title={t("token")}>
+          <textarea
+            aria-label={t("token")}
+            value={token}
+            onChange={(e) => setToken(e.target.value)}
+            spellCheck={false}
+            rows={8}
+            className="w-full resize-y break-all rounded-sm border bg-transparent p-2 font-mono text-sm"
+          />
+        </Panel>
+      }
+      output={
+        <Panel title={t("output")}>
+          {result === null ? null : !result.ok ? (
+            <p className="font-mono text-sm text-fault">{t(`error.${result.error}`)}</p>
+          ) : (
+            <div className="flex flex-col gap-3">
+              <span
+                className={`font-mono text-xs ${info.state === "expired" ? "text-fault" : "text-muted-foreground"}`}
+              >
+                {expLabel}
+              </span>
+              <JsonBlock label={t("header")} value={result.header} />
+              <JsonBlock label={t("payload")} value={result.payload} />
+              <div className="flex flex-col gap-1">
+                <span className="font-mono text-[10px] uppercase tracking-wide text-muted-foreground">
+                  {t("signature")}
+                </span>
+                <pre className="overflow-x-auto break-all font-mono text-xs text-muted-foreground">
+                  {result.signature}
+                </pre>
+              </div>
+            </div>
+          )}
+        </Panel>
+      }
+    />
+  );
+}
+
+function JsonBlock({ label, value }: { label: string; value: unknown }) {
+  return (
+    <div className="flex flex-col gap-1">
+      <span className="font-mono text-[10px] uppercase tracking-wide text-muted-foreground">
+        {label}
+      </span>
+      <pre className="overflow-x-auto font-mono text-sm text-signal">
+        {JSON.stringify(value, null, 2)}
+      </pre>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Register the component** — in `apps/web/src/components/tools/registry.tsx`, add the import and the map entry:
+
+```tsx
+import { JwtDecoder } from "./jwt-decoder";
+```
+
+and add to the `TOOL_COMPONENTS` object:
+
+```tsx
+  "jwt-decoder": JwtDecoder,
+```
+
+- [ ] **Step 5: Verify the whole tool** — run each and confirm:
+
+```bash
+pnpm -F @rfjs/jwt vitest:run        # decodeComplete tests pass
+pnpm -F web vitest:run              # route (3) + jwt-decoder lib (5) + existing tools all pass
+pnpm -F web typecheck               # tsc --noEmit clean
+pnpm -F web lint                    # eslint clean
+pnpm -F web build                   # SSG builds; /tools/jwt-decoder prerendered, /api/tools/jwt-decode present
+```
+
+Expected: all pass; build output lists `/[locale]/tools/jwt-decoder` under SSG (×2 locales) and the `/api/tools/jwt-decode` route.
+
+- [ ] **Step 6: Verify i18n parity**
+
+```bash
+node -e "const en=require('./apps/web/src/messages/en.json'),zh=require('./apps/web/src/messages/zh-TW.json');const k=o=>{const a=[];(function w(o,p){for(const x in o){const n=p?p+'.'+x:x;o[x]&&typeof o[x]==='object'?w(o[x],n):a.push(n)}})(o,'');return a.sort()};const e=k(en),z=k(zh);console.log('MATCH',JSON.stringify(e)===JSON.stringify(z))"
+```
+
+Expected: `MATCH true`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web/src/components/tools/jwt-decoder.tsx apps/web/src/components/tools/registry.tsx apps/web/src/messages/en.json apps/web/src/messages/zh-TW.json
+git commit -m "feat(web): make jwt-decoder tool live"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** decode-only (no verify/secret) ✓ Task 3/5; extend `@rfjs/jwt` ✓ Task 1; route handler + Node runtime ✓ Task 3; client component + 300ms debounce ✓ Task 5; exp 1s live tick, no re-fetch ✓ Task 5; pure `describeExp` ✓ Task 4; registry + i18n (incl. `error.request`) + dep ✓ Task 2/5; header+payload+signature shown ✓ Task 5; tests for decodeComplete/route/describeExp ✓ Tasks 1/3/4. Refresh-token explicitly out of scope ✓.
+- **Deviation from spec:** body validation uses a plain type guard instead of zod — a single `string` field does not warrant a new dependency (YAGNI); still returns 400 on a bad shape. Bad-body error key is `badRequest` (not surfaced in the UI; it indicates a malformed client request, not user input).
+- **Type consistency:** `DecodeResult`, `ExpInfo`, `describeExp(expSec, nowSec)`, `formatDuration`, `decodeJwt` names match across Tasks 4 and 5. The route returns `{ ok, header, payload, signature }` matching `DecodeResult`'s success shape.

--- a/docs/superpowers/specs/2026-06-14-jwt-decoder-design.md
+++ b/docs/superpowers/specs/2026-06-14-jwt-decoder-design.md
@@ -1,0 +1,90 @@
+# jwt-decoder 網頁工具 — 設計
+
+**日期：** 2026-06-14
+**狀態：** 已批准（brainstorming 完成；待 writing-plans）
+**範圍：** 讓 `jwt-decoder` 網頁快速工具上線（`/tools` 底下最後一個 coming-soon 工具），dogfood `@rfjs/jwt`。**僅 decode** —— 貼上 JWT，看 header + payload + signature 與即時的有效期狀態。不驗章、不需 secret、不做 refresh flow。
+
+## 背景
+
+`jwt-decoder` 已登記在 `@rfjs/web-core`（`surface: 'web'`、`status: 'planned'`、`relatedPackages: ['@rfjs/jwt']`），但沒有對應元件，所以 `/tools/[slug]` 頁面顯示 coming-soon 狀態。其餘六個網頁工具都已上線；這個補完成 7/7。
+
+跟其他工具（純 client 端的 `lib/tools/*.ts`）不同，`@rfjs/jwt` 在 module 頂層 import `jsonwebtoken`，而它會 `require('crypto')` —— **非 client-safe**。因此 decode 必須在 server 端執行，透過 Next.js route handler。
+
+## 決策（brainstorm 中鎖定）
+
+- **僅 decode。** 不做簽章驗證、不需 secret 輸入。對應工具名稱與 jwt.io 的預設 decode 行為。
+- **顯示 header + payload + signature**，外加人話化的有效期狀態。
+- **擴充 `@rfjs/jwt`** 以暴露 complete decode（目前只回 payload）。加法、非 breaking。
+- **架構：Next route handler**（`POST /api/tools/jwt-decode`），由 client 元件呼叫。`/api/*` 被 next-intl middleware matcher 排除（`(?!api|_next|_vercel|.*\..*)`），無 locale 中介層干擾。
+- **兩個獨立的刷新機制：** decode 重跑（server fetch）只在 token 輸入改變時（300ms debounce）；有效期狀態則由 client 端每 1s interval 從已快取的 payload 重算（不額外打 server）。
+- **refresh-token / grant flow 不在範圍** —— 那是 Phase 6「demo auth」（sign/verify + login/refresh 端點），獨立功能。
+
+## 架構與資料流
+
+```
+components/tools/jwt-decoder.tsx (client)
+   │  token 輸入 → 300ms debounce
+   ▼
+POST /api/tools/jwt-decode  { token }
+   │  Jwt.decodeComplete(token)
+   ▼
+{ ok: true, header, payload, signature } | { ok: false, error: 'invalidJwt' }
+   │
+   ▼  client 端快取
+render: Header Panel + Payload Panel（pretty JSON）+ 有效期 chip
+   └─ 1s interval 重算 describeExp(payload.exp, now) —— 只更新 chip，不重打 server
+```
+
+## 元件（小而專注）
+
+### 套件層
+- **`packages/jwt/src/jwt.ts`** —— 新增 static `Jwt.decodeComplete(token: string)`，包 `jsonwebtoken.decode(token, { complete: true })`。回 `{ header, payload, signature } | null`（malformed token 回 null —— `decode` 是回 null 而非 throw）。static 因為 decode 不需 secret。隨 bump 附一個 changeset（發布是另一步；apps/web 吃 workspace 版）。
+
+### apps/web —— server
+- **`apps/web/src/app/api/tools/jwt-decode/route.ts`** —— `export const runtime = 'nodejs'`；`POST` handler：
+  - 驗證 body `{ token: string }`（長度 ≥ 1）→ 形狀錯回 **400**。
+  - `Jwt.decodeComplete(token)` → `null` → `{ ok: false, error: 'invalidJwt' }`（HTTP 200，request 形狀正確、只是 token 無效）。
+  - 否則 `{ ok: true, header, payload, signature }`。
+
+### apps/web —— client 邏輯（盡量純函式）
+- **`apps/web/src/lib/tools/jwt-decoder.ts`**
+  - `type DecodeResult = { ok: true; header: unknown; payload: unknown; signature: string } | { ok: false; error: 'invalidJwt' | 'request' }`
+  - `async function decodeJwt(token: string): Promise<DecodeResult>` —— POST 到 route；非 2xx / 網路失敗對應到 `{ ok: false, error: 'request' }`。
+  - `function describeExp(expSec: number | undefined, nowSec: number): { state: 'valid' | 'expired' | 'none'; secondsLeft?: number }` —— **純函式**；`now` 由外部注入（內部不用 `Date.now()`，可測）。人話標籤（如「expires in 23m」）由元件用 `state` + `secondsLeft` + i18n 組出。
+
+### apps/web —— 元件
+- **`apps/web/src/components/tools/jwt-decoder.tsx`** —— client 元件，ToolShell 版面：
+  - 輸入：token 的 textarea；change 時 300ms debounce → `decodeJwt`。
+  - 輸出：`Header` Panel + `Payload` Panel（pretty JSON）+ 有效期 chip。
+  - 有效期 chip：1s `setInterval` 從快取結果重算 `describeExp(payload.exp, Math.floor(Date.now()/1000))`；卸載時與無 payload 時清掉。
+  - 輸出狀態互斥：空輸入 → 中性；decode 錯誤 → 輸出區顯示錯誤訊息；成功 → Header/Payload/有效期。（每次新的 debounced decode 取代前一次輸出。）
+
+### 接線
+- **`apps/web/src/components/tools/registry.tsx`** —— 在 `TOOL_COMPONENTS` 加 `"jwt-decoder": JwtDecoder`（這就是 live 的閘）。
+- **`apps/web/src/messages/{en,zh-TW}.json`** —— 在 `ToolUI` 加：`token`、`header`、`payload`、`signature`、`expiresIn`（`"expires in {duration}"`）、`expired`、`noExpiry`、`error.invalidJwt`、`error.request`。（`Tools.jwt-decoder.title/description` 已存在。）
+- **`apps/web/package.json`** + `pnpm-lock.yaml` —— 加 `@rfjs/jwt`（`workspace:*`），同一 commit；驗證 `pnpm install --frozen-lockfile`。
+
+## 錯誤處理（皆非破壞性）
+
+| 情況 | 行為 |
+|---|---|
+| 空輸入 | 不發 request；中性狀態 |
+| malformed token（`decode` → null） | route `{ ok:false, error:'invalidJwt' }` → 錯誤訊息 |
+| 網路 / 非 2xx | `{ ok:false, error:'request' }` → 通用錯誤訊息 |
+| body 形狀錯 | route 回 400 |
+
+client 端永不 import `@rfjs/jwt`（server-only），只有 route handler 用它，保持 client bundle 乾淨。
+
+## 測試
+
+- **`@rfjs/jwt`**（`packages/jwt/src/jwt.spec.ts`，co-located）：`decodeComplete` —— 合法 HS256 token → `{ header:{alg,typ}, payload, signature }`；malformed 字串 → `null`。
+- **route handler**（`apps/web/src/app/api/tools/jwt-decode/route.spec.ts`）：import `POST`，餵 `Request` —— 合法 token → 200 `{ ok:true, header, payload }`；malformed → 200 `{ ok:false, error:'invalidJwt' }`；壞 body → 400。
+- **`describeExp`**（`apps/web/src/lib/tools/jwt-decoder.spec.ts`）：expired（`exp < now`）、valid（`exp > now`，斷言 `secondsLeft`）、none（`exp` undefined）。`now` 注入。
+- 元件：不強求輕量 render —— 有意義的邏輯都在純 helper + route。
+
+## 不在本輪範圍
+
+- 簽章驗證 + secret 輸入。
+- refresh-token / grant flow（→ Phase 6 demo auth）。
+- 編輯 / 重新編碼 token。
+- `tools.ts` 的 `status` 維持 `'planned'`（與已上線的 batch-2 工具一致）；live 的閘是 `TOOL_COMPONENTS` 是否註冊。

--- a/packages/jwt/src/jwt.spec.ts
+++ b/packages/jwt/src/jwt.spec.ts
@@ -101,4 +101,19 @@ describe('helpers jwt test', () => {
       expect(result.err).toHaveProperty('name', 'JsonWebTokenError');
     });
   });
+
+  describe('decodeComplete', () => {
+    it('returns header, payload and signature for a valid token', () => {
+      const token = Jwt.initial('secret').createToken({ id: 1 });
+      const decoded = Jwt.decodeComplete(token);
+      expect(decoded).not.toBeNull();
+      expect(decoded?.header).toMatchObject({ alg: 'HS256', typ: 'JWT' });
+      expect(decoded?.payload).toMatchObject({ id: 1 });
+      expect(typeof decoded?.signature).toBe('string');
+    });
+
+    it('returns null for a malformed token', () => {
+      expect(Jwt.decodeComplete('not-a-jwt')).toBeNull();
+    });
+  });
 });

--- a/packages/jwt/src/jwt.ts
+++ b/packages/jwt/src/jwt.ts
@@ -2,6 +2,7 @@ import {
   sign,
   verify,
   decode,
+  Jwt as DecodedJwt,
   JwtPayload,
   VerifyErrors,
   SignOptions,
@@ -76,6 +77,15 @@ export class Jwt {
 
   static initial(secret: Secret, option?: SignOptions): Jwt {
     return new Jwt(secret, option);
+  }
+
+  /**
+   * Full decode (header + payload + signature) WITHOUT verifying the signature.
+   * Static because decoding needs no secret. Returns `null` for a malformed
+   * token (`jsonwebtoken.decode` returns null rather than throwing).
+   */
+  static decodeComplete(token: string): DecodedJwt | null {
+    return decode(token, { complete: true });
   }
 
   createToken(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -302,6 +302,9 @@ importers:
       '@rfjs/jsonb-query':
         specifier: workspace:*
         version: link:../../packages/jsonb-query
+      '@rfjs/jwt':
+        specifier: workspace:*
+        version: link:../../packages/jwt
       '@rfjs/mongo-query':
         specifier: workspace:*
         version: link:../../packages/mongo-query


### PR DESCRIPTION
## Summary

Makes the `jwt-decoder` web quick tool live — the last coming-soon tool under `/tools` (now 6/6 web tools live). Paste a JWT → see its **header + payload + signature** and a **live expiry status**. Decode-only: no verification, no secret, no refresh flow. Dogfoods `@rfjs/jwt`.

Because `@rfjs/jwt` wraps `jsonwebtoken` (`require('crypto')` → not client-safe), decoding runs server-side via a Node-runtime route handler; the client only `fetch`es it.

### What changed
- **`@rfjs/jwt`**: new static `Jwt.decodeComplete(token)` → `{ header, payload, signature } | null` (wraps `decode(token, { complete:true })`). **Minor** changeset included.
- **apps/web**:
  - `POST /api/tools/jwt-decode` route handler (`runtime = "nodejs"`) — validates body, calls `decodeComplete`, returns `{ ok, header, payload, signature }` / `{ ok:false, error:"invalidJwt" }` / 400.
  - `lib/tools/jwt-decoder.ts` — `decodeJwt` fetch wrapper + pure `describeExp`/`formatDuration`.
  - `components/tools/jwt-decoder.tsx` — ToolShell client component: 300 ms-debounced decode on input change; a **1 s interval re-computes only the expiry chip from the cached payload (no re-fetch)**.
  - registry wiring + `ToolUI` i18n keys (en + zh-TW).
- **fix(web)**: removed a vestigial `href` from `tool-href.spec.ts` (a #158 leftover that was failing `tsc`); corrected the jwt-decoder description (it decodes server-side, so the old "nothing leaves your browser" claim was false).

Refresh-token / grant flow is deliberately out of scope → Phase 6 demo auth.

## Process
Full superpowers flow: brainstorming → spec (Traditional Chinese, `docs/superpowers/specs/2026-06-14-jwt-decoder-design.md`) → plan (`docs/superpowers/plans/2026-06-15-jwt-decoder.md`) → subagent-driven TDD, two-stage review per task + final whole-feature review.

## Test plan
- [x] `@rfjs/jwt` 16/16 (incl. `decodeComplete` valid + malformed)
- [x] apps/web 39/39 (route handler valid/malformed/bad-body/non-JSON; `describeExp`/`formatDuration` pure tests; existing tools)
- [x] `pnpm -F web check-types` clean (also fixed the pre-existing #158 typecheck breakage)
- [x] `pnpm -F web lint` clean
- [x] `pnpm -F web build` — `/tools/jwt-decoder` prerendered ×2 locales; `/api/tools/jwt-decode` dynamic route present
- [x] i18n en/zh-TW parity (MATCH)
- [x] `@rfjs/jwt` imported only server-side (route handler); client bundle stays clean

## Note
Independent of the parallel `feat/datasets-jsonb-filter` line (different files). Contains a `@rfjs/jwt` minor bump (changeset) → will publish on the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)