### PR TITLE
feat(sql-filter): @rfjs/sql-filter — generic filter-group → SQL builder

### DIFF
--- a/docs/superpowers/plans/2026-06-15-sql-filter.md
+++ b/docs/superpowers/plans/2026-06-15-sql-filter.md
@@ -1,0 +1,847 @@
+# `@rfjs/sql-filter` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build `@rfjs/sql-filter` — a generic boolean filter-group engine (and/or/nor/not, nesting, empty-group identity, param offsetting) with a pluggable leaf renderer and a built-in column leaf that emits parameterized PostgreSQL WHERE/ORDER BY.
+
+**Architecture:** A leaf-agnostic engine (`buildFilterGroup`) mirrors `@rfjs/jsonb-query`'s group machinery; the jsonb-specific leaf is replaced by a pluggable `renderLeaf` callback. A built-in column leaf renders `"col" <op> $n` against a consumer-declared `ColumnConfig` (allowlist + type). Pure string/param building — no DB, no runtime deps.
+
+**Tech Stack:** TypeScript 5.7, tsdown (esm+cjs), Vitest 3, pnpm workspace. Mirrors `packages/jsonb-query` package shape. Public/ISC package, version 0.0.0 (publish later via changesets).
+
+**Spec:** `docs/superpowers/specs/2026-06-15-sql-filter-design.md`
+
+---
+
+## File Structure
+
+```
+packages/sql-filter/
+  package.json            @rfjs/sql-filter (public), mirror jsonb-query minus pg/e2e
+  tsconfig.json, tsconfig.build.json, tsdown.config.ts, vitest.config.mts   (copied from jsonb-query)
+  README.md
+  src/
+    types.ts              LogicalOperator, FilterGroup<L>
+    param-builder.ts      ParamBuilder
+    errors.ts             ColumnQueryError + ColumnQueryErrorCode
+    engine.ts             buildFilterGroup<L>(group, renderLeaf, params)
+    column/
+      config.ts           ColumnType, ColumnConfig
+      ident.ts            quoteIdent (internal)
+      operators.ts        ColumnOperator, applicability table, renderColumnCondition
+      leaf.ts             ColumnCondition, makeColumnLeafRenderer
+      build.ts            buildColumnQuery
+      order-by.ts         ColumnSortSpec, buildColumnOrderBy
+      index.ts            column barrel
+    index.ts              package barrel
+```
+
+---
+
+## Task 1: Scaffold `packages/sql-filter` + ParamBuilder
+
+**Files:**
+- Copy from `packages/jsonb-query`: `tsconfig.json`, `tsconfig.build.json`, `tsdown.config.ts`, `vitest.config.mts`
+- Create: `packages/sql-filter/package.json`, `README.md`, `src/index.ts`, `src/param-builder.ts`
+- Test: `src/param-builder.spec.ts`
+
+- [ ] **Step 1: Copy config files from jsonb-query**
+
+```bash
+mkdir -p packages/sql-filter/src/column
+cp packages/jsonb-query/tsconfig.json packages/sql-filter/tsconfig.json
+cp packages/jsonb-query/tsconfig.build.json packages/sql-filter/tsconfig.build.json
+cp packages/jsonb-query/tsdown.config.ts packages/sql-filter/tsdown.config.ts
+cp packages/jsonb-query/vitest.config.mts packages/sql-filter/vitest.config.mts
+```
+(If `tsconfig.build.json` does not exist in jsonb-query, check what `tsdown.config.ts` references via its `tsconfig:` field and copy that file instead; report what you found.)
+
+- [ ] **Step 2: Write `packages/sql-filter/package.json`**
+
+```json
+{
+  "name": "@rfjs/sql-filter",
+  "version": "0.0.0",
+  "description": "Generic boolean filter-group to SQL builder with pluggable leaf renderers (built-in column leaf)",
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
+  },
+  "sideEffects": false,
+  "publishConfig": { "access": "public" },
+  "scripts": {
+    "clean": "pnpm exec npm-run-all --parallel clean:dist clean:types",
+    "clean:types": "pnpm exec rimraf ./types",
+    "clean:dist": "pnpm exec rimraf ./dist",
+    "build": "pnpm run build:tsdown",
+    "build:tsdown": "pnpm run clean && tsdown --config-loader unrun",
+    "typecheck": "tsc --noEmit",
+    "typecheck:watch": "tsc --noEmit --watch",
+    "lint": "eslint \"{src,apps,libs,test}/**/*.ts\"",
+    "lint:fix": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
+    "test": "pnpm run vitest:run",
+    "vitest:run": "vitest --passWithNoTests --run"
+  },
+  "keywords": ["sql", "filter", "query-builder", "where", "postgresql"],
+  "author": "Roy Chuang",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git+https://github.com/royfw/rfjs.git", "directory": "packages/sql-filter" },
+  "bugs": "https://github.com/royfw/rfjs/issues",
+  "homepage": "https://github.com/royfw/rfjs/tree/main/packages/sql-filter#readme",
+  "files": ["dist", "README.md"],
+  "devDependencies": {
+    "@eslint/js": "^9.20.0",
+    "eslint": "^9.20.1",
+    "eslint-config-prettier": "^10.0.1",
+    "npm-run-all": "^4.1.5",
+    "prettier": "^3.5.1",
+    "rimraf": "^6.0.1",
+    "tsdown": "0.17.0-beta.6",
+    "typescript": "^5.7.3",
+    "typescript-eslint": "^8.24.0",
+    "vitest": "^3.2.3"
+  }
+}
+```
+
+- [ ] **Step 3: Write a minimal `packages/sql-filter/README.md`**
+
+```markdown
+# @rfjs/sql-filter
+
+Generic boolean filter-group → SQL builder with pluggable leaf renderers. Built-in column leaf renders parameterized PostgreSQL `WHERE` / `ORDER BY` against a declared column allowlist.
+
+See `docs/superpowers/specs/2026-06-15-sql-filter-design.md`.
+```
+
+- [ ] **Step 4: Write the failing test — `packages/sql-filter/src/param-builder.spec.ts`**
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { ParamBuilder } from './param-builder';
+
+describe('ParamBuilder', () => {
+  it('emits sequential placeholders and collects values', () => {
+    const p = new ParamBuilder();
+    expect(p.add('a')).toBe('$1');
+    expect(p.add('b')).toBe('$2');
+    expect(p.values).toEqual(['a', 'b']);
+  });
+
+  it('honors a starting offset', () => {
+    const p = new ParamBuilder(2);
+    expect(p.add('x')).toBe('$3');
+    expect(p.values).toEqual(['x']);
+  });
+});
+```
+
+- [ ] **Step 5: Run it to verify it fails**
+
+Run: `pnpm install && pnpm --filter @rfjs/sql-filter vitest:run`
+Expected: FAIL — cannot find module './param-builder'.
+
+- [ ] **Step 6: Write `packages/sql-filter/src/param-builder.ts`**
+
+```ts
+export class ParamBuilder {
+  private _values: unknown[] = [];
+
+  constructor(private readonly offset = 0) {}
+
+  add(value: unknown): string {
+    this._values.push(value);
+    return `$${this.offset + this._values.length}`;
+  }
+
+  get values(): unknown[] {
+    return [...this._values];
+  }
+}
+```
+
+- [ ] **Step 7: Write `packages/sql-filter/src/index.ts`** (placeholder barrel; grows in Task 7)
+
+```ts
+export * from './param-builder';
+```
+
+- [ ] **Step 8: Run test + typecheck**
+
+Run: `pnpm --filter @rfjs/sql-filter vitest:run && pnpm --filter @rfjs/sql-filter typecheck`
+Expected: PASS (2 tests), typecheck clean.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add packages/sql-filter pnpm-lock.yaml
+git commit -m "feat(sql-filter): scaffold package + ParamBuilder"
+```
+
+---
+
+## Task 2: types + errors
+
+**Files:**
+- Create: `packages/sql-filter/src/types.ts`, `packages/sql-filter/src/errors.ts`
+- Test: `packages/sql-filter/src/errors.spec.ts`
+
+- [ ] **Step 1: Write the failing test — `packages/sql-filter/src/errors.spec.ts`**
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { ColumnQueryError } from './errors';
+
+describe('ColumnQueryError', () => {
+  it('is an Error carrying a typed code and name', () => {
+    const err = new ColumnQueryError('nope', 'UNKNOWN_COLUMN');
+    expect(err).toBeInstanceOf(Error);
+    expect(err.code).toBe('UNKNOWN_COLUMN');
+    expect(err.name).toBe('ColumnQueryError');
+    expect(err.message).toBe('nope');
+  });
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `pnpm --filter @rfjs/sql-filter vitest:run`
+Expected: FAIL — cannot find module './errors'.
+
+- [ ] **Step 3: Write `packages/sql-filter/src/types.ts`**
+
+```ts
+export type LogicalOperator = 'and' | 'or' | 'nor' | 'not';
+
+export type FilterGroup<L> = {
+  logic: LogicalOperator;
+  filters: Array<L | FilterGroup<L>>;
+};
+```
+
+- [ ] **Step 4: Write `packages/sql-filter/src/errors.ts`**
+
+```ts
+export type ColumnQueryErrorCode =
+  | 'UNKNOWN_COLUMN'
+  | 'UNSUPPORTED_OPERATOR'
+  | 'INVALID_VALUE'
+  | 'INVALID_SORT'
+  | 'INVALID_PARAM_OFFSET';
+
+export class ColumnQueryError extends Error {
+  constructor(
+    message: string,
+    readonly code: ColumnQueryErrorCode,
+  ) {
+    super(message);
+    this.name = 'ColumnQueryError';
+  }
+}
+```
+
+- [ ] **Step 5: Run test + typecheck**
+
+Run: `pnpm --filter @rfjs/sql-filter vitest:run && pnpm --filter @rfjs/sql-filter typecheck`
+Expected: PASS, clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/sql-filter/src/types.ts packages/sql-filter/src/errors.ts packages/sql-filter/src/errors.spec.ts
+git commit -m "feat(sql-filter): LogicalOperator/FilterGroup types + ColumnQueryError"
+```
+
+---
+
+## Task 3: the generic engine (`buildFilterGroup`)
+
+**Files:**
+- Create: `packages/sql-filter/src/engine.ts`
+- Test: `packages/sql-filter/src/engine.spec.ts`
+
+- [ ] **Step 1: Write the failing test — `packages/sql-filter/src/engine.spec.ts`**
+
+(Uses a fake leaf renderer so the engine is tested independently of any leaf type. The fake leaf is `{ sql: string }` and renders its `sql`, pushing one param so offset behavior is observable.)
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { ParamBuilder } from './param-builder';
+import { buildFilterGroup } from './engine';
+import type { FilterGroup } from './types';
+
+type FakeLeaf = { token: string };
+const renderFake = (leaf: FakeLeaf, p: ParamBuilder) => `${leaf.token}=${p.add(leaf.token)}`;
+const g = (group: FilterGroup<FakeLeaf>) => {
+  const p = new ParamBuilder();
+  return { sql: buildFilterGroup(group, renderFake, p), values: p.values };
+};
+
+describe('buildFilterGroup', () => {
+  it('joins leaves with the group logic', () => {
+    expect(g({ logic: 'and', filters: [{ token: 'a' }, { token: 'b' }] }).sql).toBe('a=$1 and b=$2');
+    expect(g({ logic: 'or', filters: [{ token: 'a' }, { token: 'b' }] }).sql).toBe('a=$1 or b=$2');
+  });
+
+  it('negates not/nor', () => {
+    expect(g({ logic: 'not', filters: [{ token: 'a' }, { token: 'b' }] }).sql).toBe('not (a=$1 and b=$2)');
+    expect(g({ logic: 'nor', filters: [{ token: 'a' }, { token: 'b' }] }).sql).toBe('not (a=$1 or b=$2)');
+  });
+
+  it('applies empty-group identity', () => {
+    expect(g({ logic: 'and', filters: [] }).sql).toBe('true');
+    expect(g({ logic: 'or', filters: [] }).sql).toBe('false');
+    expect(g({ logic: 'not', filters: [] }).sql).toBe('false');
+    expect(g({ logic: 'nor', filters: [] }).sql).toBe('true');
+  });
+
+  it('wraps nested groups in parentheses', () => {
+    const r = g({
+      logic: 'and',
+      filters: [{ token: 'a' }, { logic: 'or', filters: [{ token: 'b' }, { token: 'c' }] }],
+    });
+    expect(r.sql).toBe('a=$1 and (b=$2 or c=$3)');
+    expect(r.values).toEqual(['a', 'b', 'c']);
+  });
+
+  it('continues placeholder numbering from the ParamBuilder offset', () => {
+    const p = new ParamBuilder(5);
+    const sql = buildFilterGroup({ logic: 'and', filters: [{ token: 'a' }] }, renderFake, p);
+    expect(sql).toBe('a=$6');
+  });
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `pnpm --filter @rfjs/sql-filter vitest:run`
+Expected: FAIL — cannot find module './engine'.
+
+- [ ] **Step 3: Write `packages/sql-filter/src/engine.ts`**
+
+```ts
+import { ParamBuilder } from './param-builder';
+import type { FilterGroup, LogicalOperator } from './types';
+
+const EMPTY_GROUP_IDENTITY: Record<LogicalOperator, string> = {
+  and: 'true',
+  or: 'false',
+  not: 'false', // not(AND of nothing) = not(true)
+  nor: 'true', // not(OR of nothing) = not(false)
+};
+
+function isFilterGroup<L>(node: L | FilterGroup<L>): node is FilterGroup<L> {
+  return (
+    typeof node === 'object' &&
+    node !== null &&
+    'logic' in node &&
+    'filters' in node &&
+    Array.isArray((node as { filters: unknown }).filters)
+  );
+}
+
+function joinLogic(parts: string[], logic: LogicalOperator): string {
+  if (parts.length === 0) return EMPTY_GROUP_IDENTITY[logic];
+  const joined = parts.join(logic === 'or' || logic === 'nor' ? ' or ' : ' and ');
+  return logic === 'not' || logic === 'nor' ? `not (${joined})` : joined;
+}
+
+function wrap(sql: string): string {
+  return sql.length > 0 ? `(${sql})` : '';
+}
+
+/**
+ * Render a nested filter group to a parameterized SQL boolean expression.
+ * Leaf rendering is delegated to `renderLeaf`, making the engine independent of
+ * what a leaf is (column condition, jsonb condition, etc.).
+ */
+export function buildFilterGroup<L>(
+  group: FilterGroup<L>,
+  renderLeaf: (leaf: L, params: ParamBuilder) => string,
+  params: ParamBuilder,
+): string {
+  const parts = group.filters
+    .map((node) =>
+      isFilterGroup(node)
+        ? wrap(buildFilterGroup(node, renderLeaf, params))
+        : renderLeaf(node, params),
+    )
+    .filter((sql) => sql.length > 0);
+  return joinLogic(parts, group.logic);
+}
+```
+
+- [ ] **Step 4: Run test + typecheck**
+
+Run: `pnpm --filter @rfjs/sql-filter vitest:run && pnpm --filter @rfjs/sql-filter typecheck`
+Expected: PASS (5 engine tests), clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/sql-filter/src/engine.ts packages/sql-filter/src/engine.spec.ts packages/sql-filter/src/types.ts
+git commit -m "feat(sql-filter): generic buildFilterGroup engine (pluggable leaf)"
+```
+
+---
+
+## Task 4: column config + ident + operators
+
+**Files:**
+- Create: `packages/sql-filter/src/column/config.ts`, `packages/sql-filter/src/column/ident.ts`, `packages/sql-filter/src/column/operators.ts`
+- Test: `packages/sql-filter/src/column/operators.spec.ts`
+
+- [ ] **Step 1: Write the failing test — `packages/sql-filter/src/column/operators.spec.ts`**
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { ParamBuilder } from '../param-builder';
+import { ColumnQueryError } from '../errors';
+import { renderColumnCondition } from './operators';
+
+const render = (type: Parameters<typeof renderColumnCondition>[1], op: Parameters<typeof renderColumnCondition>[2], value?: unknown) => {
+  const p = new ParamBuilder();
+  const sql = renderColumnCondition('"name"', type, op, value, p);
+  return { sql, values: p.values };
+};
+
+describe('renderColumnCondition', () => {
+  it('renders comparison operators with a positional param', () => {
+    expect(render('text', 'eq', 'x')).toEqual({ sql: '"name" = $1', values: ['x'] });
+    expect(render('numeric', 'gte', 5)).toEqual({ sql: '"name" >= $1', values: [5] });
+    expect(render('text', 'neq', 'y')).toEqual({ sql: '"name" <> $1', values: ['y'] });
+  });
+
+  it('renders text contains/startswith as parameterized ILIKE', () => {
+    expect(render('text', 'contains', 'ab')).toEqual({ sql: "\"name\" ilike '%' || $1 || '%'", values: ['ab'] });
+    expect(render('text', 'startswith', 'ab')).toEqual({ sql: "\"name\" ilike $1 || '%'", values: ['ab'] });
+  });
+
+  it('renders nullary operators without a param', () => {
+    expect(render('uuid', 'isnull')).toEqual({ sql: '"name" is null', values: [] });
+    expect(render('uuid', 'isnotnull')).toEqual({ sql: '"name" is not null', values: [] });
+  });
+
+  it('rejects an operator not allowed for the column type', () => {
+    expect(() => render('numeric', 'contains', 'x')).toThrow(ColumnQueryError);
+    expect(() => render('boolean', 'gt', true)).toThrow(ColumnQueryError);
+  });
+
+  it('rejects a value on a nullary operator and a missing value on others', () => {
+    expect(() => render('text', 'isnull', 'x')).toThrow(ColumnQueryError);
+    expect(() => render('text', 'eq', undefined)).toThrow(ColumnQueryError);
+  });
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `pnpm --filter @rfjs/sql-filter vitest:run`
+Expected: FAIL — cannot find module './operators'.
+
+- [ ] **Step 3: Write `packages/sql-filter/src/column/config.ts`**
+
+```ts
+export type ColumnType = 'text' | 'numeric' | 'timestamp' | 'boolean' | 'uuid';
+
+export type ColumnConfig = Record<string, { column: string; type: ColumnType }>;
+```
+
+- [ ] **Step 4: Write `packages/sql-filter/src/column/ident.ts`**
+
+```ts
+/** Quote a SQL identifier. Identifiers come from ColumnConfig, never user input. */
+export function quoteIdent(ident: string): string {
+  return `"${ident.replace(/"/g, '""')}"`;
+}
+```
+
+- [ ] **Step 5: Write `packages/sql-filter/src/column/operators.ts`**
+
+```ts
+import { ParamBuilder } from '../param-builder';
+import { ColumnQueryError } from '../errors';
+import type { ColumnType } from './config';
+
+export type ColumnOperator =
+  | 'eq'
+  | 'neq'
+  | 'isnull'
+  | 'isnotnull'
+  | 'contains'
+  | 'startswith'
+  | 'gt'
+  | 'gte'
+  | 'lt'
+  | 'lte';
+
+const NULLARY = new Set<ColumnOperator>(['isnull', 'isnotnull']);
+
+const ALLOWED: Record<ColumnType, ReadonlySet<ColumnOperator>> = {
+  text: new Set(['eq', 'neq', 'isnull', 'isnotnull', 'contains', 'startswith', 'gt', 'gte', 'lt', 'lte']),
+  numeric: new Set(['eq', 'neq', 'isnull', 'isnotnull', 'gt', 'gte', 'lt', 'lte']),
+  timestamp: new Set(['eq', 'neq', 'isnull', 'isnotnull', 'gt', 'gte', 'lt', 'lte']),
+  boolean: new Set(['eq', 'neq', 'isnull', 'isnotnull']),
+  uuid: new Set(['eq', 'neq', 'isnull', 'isnotnull']),
+};
+
+const COMPARATORS: Partial<Record<ColumnOperator, string>> = {
+  eq: '=',
+  neq: '<>',
+  gt: '>',
+  gte: '>=',
+  lt: '<',
+  lte: '<=',
+};
+
+export function renderColumnCondition(
+  quotedColumn: string,
+  type: ColumnType,
+  operator: ColumnOperator,
+  value: unknown,
+  params: ParamBuilder,
+): string {
+  if (!ALLOWED[type].has(operator)) {
+    throw new ColumnQueryError(
+      `Operator "${operator}" is not supported for ${type} column`,
+      'UNSUPPORTED_OPERATOR',
+    );
+  }
+  if (NULLARY.has(operator)) {
+    if (value !== undefined) {
+      throw new ColumnQueryError(`Operator "${operator}" must not carry a value`, 'INVALID_VALUE');
+    }
+    return operator === 'isnull' ? `${quotedColumn} is null` : `${quotedColumn} is not null`;
+  }
+  if (value === undefined) {
+    throw new ColumnQueryError(`Operator "${operator}" requires a value`, 'INVALID_VALUE');
+  }
+  if (operator === 'contains') {
+    return `${quotedColumn} ilike '%' || ${params.add(value)} || '%'`;
+  }
+  if (operator === 'startswith') {
+    return `${quotedColumn} ilike ${params.add(value)} || '%'`;
+  }
+  return `${quotedColumn} ${COMPARATORS[operator]} ${params.add(value)}`;
+}
+```
+
+- [ ] **Step 6: Run test + typecheck**
+
+Run: `pnpm --filter @rfjs/sql-filter vitest:run && pnpm --filter @rfjs/sql-filter typecheck`
+Expected: PASS, clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/sql-filter/src/column/config.ts packages/sql-filter/src/column/ident.ts packages/sql-filter/src/column/operators.ts packages/sql-filter/src/column/operators.spec.ts
+git commit -m "feat(sql-filter): column config + operators (type-aware, parameterized)"
+```
+
+---
+
+## Task 5: column leaf + `buildColumnQuery`
+
+**Files:**
+- Create: `packages/sql-filter/src/column/leaf.ts`, `packages/sql-filter/src/column/build.ts`
+- Test: `packages/sql-filter/src/column/build.spec.ts`
+
+- [ ] **Step 1: Write the failing test — `packages/sql-filter/src/column/build.spec.ts`**
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { ColumnQueryError } from '../errors';
+import { buildColumnQuery } from './build';
+import type { ColumnConfig } from './config';
+
+const config: ColumnConfig = {
+  name: { column: 'name', type: 'text' },
+  createdAt: { column: 'created_at', type: 'timestamp' },
+};
+
+describe('buildColumnQuery', () => {
+  it('builds a parameterized WHERE over allowlisted columns', () => {
+    const r = buildColumnQuery(config, {
+      logic: 'and',
+      filters: [
+        { column: 'name', operator: 'contains', value: 'sales' },
+        { column: 'createdAt', operator: 'gte', value: '2026-01-01' },
+      ],
+    });
+    expect(r.where).toBe('"name" ilike \'%\' || $1 || \'%\' and "created_at" >= $2');
+    expect(r.values).toEqual(['sales', '2026-01-01']);
+  });
+
+  it('supports nested logic and the paramOffset option', () => {
+    const r = buildColumnQuery(
+      config,
+      {
+        logic: 'or',
+        filters: [
+          { column: 'name', operator: 'eq', value: 'a' },
+          { logic: 'and', filters: [{ column: 'name', operator: 'eq', value: 'b' }] },
+        ],
+      },
+      { paramOffset: 3 },
+    );
+    expect(r.where).toBe('"name" = $4 or ("name" = $5)');
+    expect(r.values).toEqual(['a', 'b']);
+  });
+
+  it('rejects a column not in the config', () => {
+    expect(() =>
+      buildColumnQuery(config, { logic: 'and', filters: [{ column: 'evil', operator: 'eq', value: 1 }] }),
+    ).toThrow(ColumnQueryError);
+  });
+
+  it('rejects a negative/non-integer paramOffset', () => {
+    expect(() => buildColumnQuery(config, { logic: 'and', filters: [] }, { paramOffset: -1 })).toThrow(
+      ColumnQueryError,
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `pnpm --filter @rfjs/sql-filter vitest:run`
+Expected: FAIL — cannot find module './build'.
+
+- [ ] **Step 3: Write `packages/sql-filter/src/column/leaf.ts`**
+
+```ts
+import { ParamBuilder } from '../param-builder';
+import { ColumnQueryError } from '../errors';
+import type { ColumnConfig } from './config';
+import { quoteIdent } from './ident';
+import { renderColumnCondition, type ColumnOperator } from './operators';
+
+export type ColumnCondition = {
+  column: string;
+  operator: ColumnOperator;
+  value?: unknown;
+};
+
+export function makeColumnLeafRenderer(
+  config: ColumnConfig,
+): (leaf: ColumnCondition, params: ParamBuilder) => string {
+  return (leaf, params) => {
+    const def = config[leaf.column];
+    if (!def) {
+      throw new ColumnQueryError(`Unknown column: ${JSON.stringify(leaf.column)}`, 'UNKNOWN_COLUMN');
+    }
+    return renderColumnCondition(quoteIdent(def.column), def.type, leaf.operator, leaf.value, params);
+  };
+}
+```
+
+- [ ] **Step 4: Write `packages/sql-filter/src/column/build.ts`**
+
+```ts
+import { ParamBuilder } from '../param-builder';
+import { buildFilterGroup } from '../engine';
+import { ColumnQueryError } from '../errors';
+import type { FilterGroup } from '../types';
+import type { ColumnConfig } from './config';
+import { makeColumnLeafRenderer, type ColumnCondition } from './leaf';
+
+export function buildColumnQuery(
+  config: ColumnConfig,
+  group: FilterGroup<ColumnCondition>,
+  options: { paramOffset?: number } = {},
+): { where: string; values: unknown[] } {
+  const offset = options.paramOffset ?? 0;
+  if (!Number.isInteger(offset) || offset < 0) {
+    throw new ColumnQueryError(`Invalid paramOffset: ${String(offset)}`, 'INVALID_PARAM_OFFSET');
+  }
+  const params = new ParamBuilder(offset);
+  const where = buildFilterGroup(group, makeColumnLeafRenderer(config), params);
+  return { where, values: params.values };
+}
+```
+
+- [ ] **Step 5: Run test + typecheck**
+
+Run: `pnpm --filter @rfjs/sql-filter vitest:run && pnpm --filter @rfjs/sql-filter typecheck`
+Expected: PASS, clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/sql-filter/src/column/leaf.ts packages/sql-filter/src/column/build.ts packages/sql-filter/src/column/build.spec.ts
+git commit -m "feat(sql-filter): column leaf renderer + buildColumnQuery"
+```
+
+---
+
+## Task 6: `buildColumnOrderBy`
+
+**Files:**
+- Create: `packages/sql-filter/src/column/order-by.ts`
+- Test: `packages/sql-filter/src/column/order-by.spec.ts`
+
+- [ ] **Step 1: Write the failing test — `packages/sql-filter/src/column/order-by.spec.ts`**
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { ColumnQueryError } from '../errors';
+import { buildColumnOrderBy } from './order-by';
+import type { ColumnConfig } from './config';
+
+const config: ColumnConfig = {
+  name: { column: 'name', type: 'text' },
+  createdAt: { column: 'created_at', type: 'timestamp' },
+};
+
+describe('buildColumnOrderBy', () => {
+  it('renders multiple sort keys with direction and nulls', () => {
+    const r = buildColumnOrderBy(config, [
+      { column: 'createdAt', direction: 'desc' },
+      { column: 'name', direction: 'asc', nulls: 'last' },
+    ]);
+    expect(r.orderBy).toBe('"created_at" desc, "name" asc nulls last');
+    expect(r.values).toEqual([]);
+  });
+
+  it('defaults direction to asc', () => {
+    expect(buildColumnOrderBy(config, [{ column: 'name' }]).orderBy).toBe('"name" asc');
+  });
+
+  it('rejects an unknown column and an invalid direction/nulls', () => {
+    expect(() => buildColumnOrderBy(config, [{ column: 'evil' }])).toThrow(ColumnQueryError);
+    expect(() =>
+      buildColumnOrderBy(config, [{ column: 'name', direction: 'sideways' as never }]),
+    ).toThrow(ColumnQueryError);
+    expect(() => buildColumnOrderBy(config, [{ column: 'name', nulls: 'middle' as never }])).toThrow(
+      ColumnQueryError,
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `pnpm --filter @rfjs/sql-filter vitest:run`
+Expected: FAIL — cannot find module './order-by'.
+
+- [ ] **Step 3: Write `packages/sql-filter/src/column/order-by.ts`**
+
+```ts
+import { ColumnQueryError } from '../errors';
+import type { ColumnConfig } from './config';
+import { quoteIdent } from './ident';
+
+export type ColumnSortSpec = {
+  column: string;
+  direction?: 'asc' | 'desc';
+  nulls?: 'first' | 'last';
+};
+
+export function buildColumnOrderBy(
+  config: ColumnConfig,
+  sorts: ColumnSortSpec[],
+): { orderBy: string; values: unknown[] } {
+  const parts = sorts.map((spec) => {
+    const def = config[spec.column];
+    if (!def) {
+      throw new ColumnQueryError(`Unknown column: ${JSON.stringify(spec.column)}`, 'UNKNOWN_COLUMN');
+    }
+    const direction = spec.direction ?? 'asc';
+    if (direction !== 'asc' && direction !== 'desc') {
+      throw new ColumnQueryError(`Invalid sort direction: ${JSON.stringify(direction)}`, 'INVALID_SORT');
+    }
+    let sql = `${quoteIdent(def.column)} ${direction}`;
+    if (spec.nulls !== undefined) {
+      if (spec.nulls !== 'first' && spec.nulls !== 'last') {
+        throw new ColumnQueryError(`Invalid sort nulls: ${JSON.stringify(spec.nulls)}`, 'INVALID_SORT');
+      }
+      sql += ` nulls ${spec.nulls}`;
+    }
+    return sql;
+  });
+  return { orderBy: parts.join(', '), values: [] };
+}
+```
+
+(Note: `buildColumnOrderBy` takes no `paramOffset` — column ORDER BY produces no parameters. The spec mentioned an offset option "for composition"; since there are zero params it is unnecessary, so it is omitted to avoid a dead parameter. The datasets layer composes ORDER BY positionally without needing it.)
+
+- [ ] **Step 4: Run test + typecheck**
+
+Run: `pnpm --filter @rfjs/sql-filter vitest:run && pnpm --filter @rfjs/sql-filter typecheck`
+Expected: PASS, clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/sql-filter/src/column/order-by.ts packages/sql-filter/src/column/order-by.spec.ts
+git commit -m "feat(sql-filter): buildColumnOrderBy"
+```
+
+---
+
+## Task 7: barrels, build, public surface
+
+**Files:**
+- Create: `packages/sql-filter/src/column/index.ts`
+- Modify: `packages/sql-filter/src/index.ts`
+
+- [ ] **Step 1: Write `packages/sql-filter/src/column/index.ts`** (note: `ident.ts` stays internal — not exported)
+
+```ts
+export * from './config';
+export * from './operators';
+export * from './leaf';
+export * from './build';
+export * from './order-by';
+```
+
+- [ ] **Step 2: Replace `packages/sql-filter/src/index.ts`**
+
+```ts
+export * from './types';
+export * from './param-builder';
+export * from './errors';
+export * from './engine';
+export * from './column';
+```
+
+- [ ] **Step 3: Typecheck, build, run full suite**
+
+```bash
+pnpm --filter @rfjs/sql-filter typecheck
+pnpm --filter @rfjs/sql-filter build
+pnpm --filter @rfjs/sql-filter vitest:run
+```
+Expected: all clean; build emits `dist/index.{js,mjs,d.ts}`.
+
+- [ ] **Step 4: Confirm the public surface in the built d.ts**
+
+Grep `dist/index.d.ts` (or `dist/index.d.mts`) and confirm these names are reachable: `buildFilterGroup`, `ParamBuilder`, `FilterGroup`, `LogicalOperator`, `ColumnQueryError`, `ColumnQueryErrorCode`, `ColumnConfig`, `ColumnType`, `ColumnCondition`, `ColumnOperator`, `makeColumnLeafRenderer`, `buildColumnQuery`, `buildColumnOrderBy`, `ColumnSortSpec`. Confirm `quoteIdent` is NOT exported (internal).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/sql-filter/src
+git commit -m "feat(sql-filter): package barrels + public surface"
+```
+
+---
+
+## Final verification
+
+- [ ] **Tests:** `pnpm --filter @rfjs/sql-filter vitest:run` — all pass (param-builder 2, errors 1, engine 5, operators 5, build 4, order-by 3).
+- [ ] **Build + typecheck:** `pnpm --filter @rfjs/sql-filter build && pnpm --filter @rfjs/sql-filter typecheck` — clean.
+- [ ] **Pure / no runtime deps:** `packages/sql-filter/package.json` has no `dependencies` block (pure string builder).
+- [ ] **No committed artifacts:** `dist/`, `types/` are gitignored (inherit root or add `packages/sql-filter/.gitignore` mirroring jsonb-query if its dist isn't covered by root gitignore — check `git status` after build).
+
+## Notes / out of scope (per spec)
+
+- Enhancement operators (`in`, `endswith`, `between/range`, case-insensitive variants, boolean/uuid comparisons) — deferred to a later "strengthen" iteration.
+- Sub-project 2 (datasets consuming `@rfjs/sql-filter` + `@rfjs/jsonb-query` for the unified column+jsonb tree, sort/pagination/total) — its own spec/plan.
+- Refactoring `@rfjs/jsonb-query` to reuse this engine — deferred.
+- npm publish (changeset flow) — separate.

--- a/docs/superpowers/specs/2026-06-15-sql-filter-design.md
+++ b/docs/superpowers/specs/2026-06-15-sql-filter-design.md
@@ -1,0 +1,138 @@
+# `@rfjs/sql-filter` 設計
+
+**日期:** 2026-06-15
+**狀態:** 已核可(brainstorming 完成;待 writing-plans)
+**範圍:** 一個通用的布林 filter-group 引擎(and/or/nor/not、巢狀、空組 identity、參數位移),搭配可插拔的 leaf renderer;內建一個 column leaf(對真實 SQL 欄位做 WHERE/ORDER BY)。輸出標準 PostgreSQL 定位參數 SQL。
+
+## 背景
+
+`@rfjs/jsonb-query` 把「巢狀 filter group → SQL」做在 jsonb 欄位上,但它的 group 引擎(and/or/nor/not、巢狀、空組 identity、參數位移)其實與葉節點無關——jsonb 專屬的只有葉節點渲染。本套件把這個**通用 group 引擎**正式化,並讓葉節點渲染**可插拔**:內建 column leaf(對真實欄位)為主力,消費端可注入其他 leaf。
+
+直接動機:workbench 的 `datasets` 需要對 **top-level 欄位**(`name`/`createdAt`…)做巢狀過濾與排序,並能與 jsonb 過濾**混在同一棵邏輯樹**(跨空間 OR)。`@rfjs/sql-filter` 提供 column 能力與可插拔引擎;datasets 之後注入一個委派給 jsonb-query 的 jsonb leaf 即可達成統一樹。這是子專案 1;datasets 的消費是獨立的子專案 2。
+
+## 架構
+
+兩層,刻意分離:
+
+- **通用 group 引擎(與葉節點無關):** `buildFilterGroup`、`ParamBuilder`、`ColumnQueryError`、型別。沿用 jsonb-query 的 `buildGroup`/`joinLogic`/空組 identity/`wrap` 模式。
+- **內建 column leaf(sub-domain,放 `column/`):** 用消費端宣告的 `ColumnConfig`(白名單 + 型別)把 `ColumnCondition` 渲染成參數化 SQL;附 `buildColumnQuery`(便利包裝)與 `buildColumnOrderBy`。
+
+```
+src/
+  types.ts          LogicalOperator、FilterGroup<L>
+  param-builder.ts  ParamBuilder（offset → $N、values）
+  errors.ts         ColumnQueryError + ColumnQueryErrorCode
+  engine.ts         buildFilterGroup<L>(group, renderLeaf, params): string
+  column/
+    config.ts       ColumnType、ColumnConfig
+    operators.ts    ColumnOperator、型別可用性表、單一條件 → SQL
+    leaf.ts         ColumnCondition、makeColumnLeafRenderer(config)
+    build.ts        buildColumnQuery(config, group, opts?)
+    order-by.ts     buildColumnOrderBy(config, sorts, opts?)
+    index.ts        column barrel
+  index.ts          套件 barrel
+```
+
+## 通用核心(API)
+
+```ts
+export type LogicalOperator = 'and' | 'or' | 'nor' | 'not';
+export type FilterGroup<L> = { logic: LogicalOperator; filters: Array<L | FilterGroup<L>> };
+
+export class ParamBuilder {            // 與 jsonb-query 同形,獨立一份
+  constructor(offset?: number);
+  add(value: unknown): string;          // 推入值,回傳 `$N`
+  get values(): unknown[];
+}
+
+// 葉節點渲染由呼叫端提供;引擎只負責邏輯/巢狀/空組 identity/否定/括號
+export function buildFilterGroup<L>(
+  group: FilterGroup<L>,
+  renderLeaf: (leaf: L, params: ParamBuilder) => string,
+  params: ParamBuilder,
+): string;
+
+export type ColumnQueryErrorCode =
+  | 'UNKNOWN_COLUMN'        // field 不在 ColumnConfig
+  | 'UNSUPPORTED_OPERATOR'  // operator 對該欄位型別不適用
+  | 'INVALID_VALUE'         // 例如 isnull 帶 value、range 不是長度 2
+  | 'INVALID_SORT'          // 排序 direction/nulls 不合法
+  | 'INVALID_PARAM_OFFSET';
+export class ColumnQueryError extends Error { readonly code: ColumnQueryErrorCode }
+```
+
+空組 identity 與 jsonb-query 一致:`and→'true'`、`or→'false'`、`not→'false'`、`nor→'true'`。
+
+## 內建 column leaf(API)
+
+```ts
+export type ColumnType = 'text' | 'numeric' | 'timestamp' | 'boolean' | 'uuid';
+export type ColumnConfig = Record<string, { column: string; type: ColumnType }>;
+
+export type ColumnOperator =
+  | 'eq' | 'neq' | 'isnull' | 'isnotnull'   // 全型別
+  | 'contains' | 'startswith'               // text
+  | 'gt' | 'gte' | 'lt' | 'lte';            // numeric / timestamp（text 也允許 gt..lte 作字典序）
+
+export type ColumnCondition = { column: string; operator: ColumnOperator; value?: unknown };
+
+export function makeColumnLeafRenderer(
+  config: ColumnConfig,
+): (leaf: ColumnCondition, params: ParamBuilder) => string;
+
+export function buildColumnQuery(
+  config: ColumnConfig,
+  group: FilterGroup<ColumnCondition>,
+  options?: { paramOffset?: number },
+): { where: string; values: unknown[] };
+
+export type ColumnSortSpec = { column: string; direction?: 'asc' | 'desc'; nulls?: 'first' | 'last' };
+export function buildColumnOrderBy(
+  config: ColumnConfig,
+  sorts: ColumnSortSpec[],
+  options?: { paramOffset?: number },   // 為與 WHERE 組合保留;column 排序本身不產生參數
+): { orderBy: string; values: unknown[] };
+```
+
+### v1 operator 範圍(先做一版,加強另議)
+
+- 全型別:`eq` `neq` `isnull` `isnotnull`
+- text:`+ contains`(`ILIKE '%' || $n || '%'`)、`startswith`(`ILIKE $n || '%'`)
+- numeric / timestamp / text:`+ gt` `gte` `lt` `lte`
+- **延後(加強階段):** `in`、`endswith`、`between/range`、大小寫不敏感變體、`boolean`/`uuid` 的比較運算等。
+
+operator × 型別的可用性由 `operators.ts` 的對照表決定;不適用即丟 `ColumnQueryError('UNSUPPORTED_OPERATOR')`。`isnull`/`isnotnull` 不得帶 `value`,否則 `INVALID_VALUE`。
+
+## 渲染與安全
+
+- 單一條件渲染:`"<config[field].column>" <opSql> <param>`。欄位識別字**只能**來自 `ColumnConfig`(以 `"..."` 加引號;`field` 不在 config 即 `UNKNOWN_COLUMN`),**絕不**取使用者輸入字串。
+- 所有比較值一律走 `ParamBuilder.add()` 變成 `$N`,值不進 SQL 字串 → 無 injection。
+- `contains`/`startswith` 用 `value || '%'` 串接是在 **SQL 端**對參數做(`$n || '%'`),不是字串拼接 → 仍安全。
+- `buildColumnOrderBy`:`column`/`direction`/`nulls` 皆驗證(direction ∈ asc/desc、nulls ∈ first/last),欄位名來自 config → 安全。
+
+## 可插拔路徑(供子專案 2 的統一樹)
+
+`buildFilterGroup` 與 `ParamBuilder` 為公開 API。datasets 可組一棵 `FilterGroup<ColumnCondition | JsonbLeaf>`,提供一個會分派的 `renderLeaf`:`ColumnCondition` → `makeColumnLeafRenderer(config)`;jsonb leaf → `buildJsonbQuery('data', { logic:'and', filters:[leaf] }, { paramOffset })` 取得單一條件片段。引擎負責 and/or/nor/not 與參數位移,達成跨空間混用。(此整合屬子專案 2,本 spec 不實作。)
+
+## 錯誤處理
+
+`buildColumnQuery`/`buildColumnOrderBy`/`makeColumnLeafRenderer` 對不合法輸入丟 `ColumnQueryError`(具 `code`),呼叫端(如 apps/api)可映射為 400——與 `JsonbQueryError` 同模式。
+
+## 測試
+
+純單元測試(無需 DB,與 jsonb-query 同):
+- **engine:** and/or/nor/not 連接、巢狀括號、空組 identity(四種)、not/nor 否定、`paramOffset` 起算正確、leaf renderer 被正確呼叫。
+- **column leaf / build:** 每個 operator × 型別組合的 SQL 與參數;`UNKNOWN_COLUMN`、`UNSUPPORTED_OPERATOR`、`INVALID_VALUE` 各自拋錯;injection 安全(欄位名只來自 config、值皆參數)。
+- **order-by:** 多欄排序、direction/nulls、非法值拋 `INVALID_SORT`、欄位名來自 config。
+- **pluggable:** 用一個假 leaf renderer 驗證 `buildFilterGroup` 與 leaf 種類無關。
+
+## 套件設定
+
+比照 `@rfjs/jsonb-query`:public(`publishConfig.access: public`、ISC、`version: 0.0.0`)、tsdown 雙輸出、`sideEffects: false`、vitest、co-located `*.spec.ts`、`src/index.ts` 為唯一 exports 入口。`packages/sql-filter/`。需要時加入 `templates/registry.json` / 套件清單 skill(屬發佈準備,非本輪)。
+
+## 不在本輪範圍
+
+- 加強版 operators(見上)。
+- 子專案 2:datasets 對 `@rfjs/sql-filter` + `@rfjs/jsonb-query` 的整合、sort/pagination/total、統一樹注入。
+- 把 jsonb-query 重構成共用 group 引擎(路線 3)——本套件先自帶引擎;未來若要消除重複再議。
+- npm 實際發佈(走既有 changeset 流程,另行處理)。

--- a/packages/sql-filter/README.md
+++ b/packages/sql-filter/README.md
@@ -1,0 +1,5 @@
+# @rfjs/sql-filter
+
+Generic boolean filter-group → SQL builder with pluggable leaf renderers. Built-in column leaf renders parameterized PostgreSQL `WHERE` / `ORDER BY` against a declared column allowlist.
+
+See `docs/superpowers/specs/2026-06-15-sql-filter-design.md`.

--- a/packages/sql-filter/package.json
+++ b/packages/sql-filter/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@rfjs/sql-filter",
+  "version": "0.0.0",
+  "description": "Generic boolean filter-group to SQL builder with pluggable leaf renderers (built-in column leaf)",
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
+  },
+  "sideEffects": false,
+  "publishConfig": { "access": "public" },
+  "scripts": {
+    "clean": "pnpm exec npm-run-all --parallel clean:dist clean:types",
+    "clean:types": "pnpm exec rimraf ./types",
+    "clean:dist": "pnpm exec rimraf ./dist",
+    "build": "pnpm run build:tsdown",
+    "build:tsdown": "pnpm run clean && tsdown --config-loader unrun",
+    "typecheck": "tsc --noEmit",
+    "typecheck:watch": "tsc --noEmit --watch",
+    "lint": "eslint \"{src,apps,libs,test}/**/*.ts\"",
+    "lint:fix": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
+    "test": "pnpm run vitest:run",
+    "vitest:run": "vitest --passWithNoTests --run"
+  },
+  "keywords": ["sql", "filter", "query-builder", "where", "postgresql"],
+  "author": "Roy Chuang",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git+https://github.com/royfw/rfjs.git", "directory": "packages/sql-filter" },
+  "bugs": "https://github.com/royfw/rfjs/issues",
+  "homepage": "https://github.com/royfw/rfjs/tree/main/packages/sql-filter#readme",
+  "files": ["dist", "README.md"],
+  "devDependencies": {
+    "@eslint/js": "^9.20.0",
+    "eslint": "^9.20.1",
+    "eslint-config-prettier": "^10.0.1",
+    "npm-run-all": "^4.1.5",
+    "prettier": "^3.5.1",
+    "rimraf": "^6.0.1",
+    "tsdown": "0.17.0-beta.6",
+    "typescript": "^5.7.3",
+    "typescript-eslint": "^8.24.0",
+    "vitest": "^3.2.3"
+  }
+}

--- a/packages/sql-filter/src/column/build.spec.ts
+++ b/packages/sql-filter/src/column/build.spec.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { ColumnQueryError } from '../errors';
+import { buildColumnQuery } from './build';
+import type { ColumnConfig } from './config';
+
+const config: ColumnConfig = {
+  name: { column: 'name', type: 'text' },
+  createdAt: { column: 'created_at', type: 'timestamp' },
+};
+
+describe('buildColumnQuery', () => {
+  it('builds a parameterized WHERE over allowlisted columns', () => {
+    const r = buildColumnQuery(config, {
+      logic: 'and',
+      filters: [
+        { column: 'name', operator: 'contains', value: 'sales' },
+        { column: 'createdAt', operator: 'gte', value: '2026-01-01' },
+      ],
+    });
+    expect(r.where).toBe('"name" ilike \'%\' || $1 || \'%\' and "created_at" >= $2');
+    expect(r.values).toEqual(['sales', '2026-01-01']);
+  });
+
+  it('supports nested logic and the paramOffset option', () => {
+    const r = buildColumnQuery(
+      config,
+      {
+        logic: 'or',
+        filters: [
+          { column: 'name', operator: 'eq', value: 'a' },
+          { logic: 'and', filters: [{ column: 'name', operator: 'eq', value: 'b' }] },
+        ],
+      },
+      { paramOffset: 3 },
+    );
+    expect(r.where).toBe('"name" = $4 or ("name" = $5)');
+    expect(r.values).toEqual(['a', 'b']);
+  });
+
+  it('rejects a column not in the config', () => {
+    expect(() =>
+      buildColumnQuery(config, { logic: 'and', filters: [{ column: 'evil', operator: 'eq', value: 1 }] }),
+    ).toThrow(ColumnQueryError);
+  });
+
+  it('rejects a negative/non-integer paramOffset', () => {
+    expect(() => buildColumnQuery(config, { logic: 'and', filters: [] }, { paramOffset: -1 })).toThrow(
+      ColumnQueryError,
+    );
+  });
+});

--- a/packages/sql-filter/src/column/build.ts
+++ b/packages/sql-filter/src/column/build.ts
@@ -1,0 +1,20 @@
+import { ParamBuilder } from '../param-builder';
+import { buildFilterGroup } from '../engine';
+import { ColumnQueryError } from '../errors';
+import type { FilterGroup } from '../types';
+import type { ColumnConfig } from './config';
+import { makeColumnLeafRenderer, type ColumnCondition } from './leaf';
+
+export function buildColumnQuery(
+  config: ColumnConfig,
+  group: FilterGroup<ColumnCondition>,
+  options: { paramOffset?: number } = {},
+): { where: string; values: unknown[] } {
+  const offset = options.paramOffset ?? 0;
+  if (!Number.isInteger(offset) || offset < 0) {
+    throw new ColumnQueryError(`Invalid paramOffset: ${String(offset)}`, 'INVALID_PARAM_OFFSET');
+  }
+  const params = new ParamBuilder(offset);
+  const where = buildFilterGroup(group, makeColumnLeafRenderer(config), params);
+  return { where, values: params.values };
+}

--- a/packages/sql-filter/src/column/config.ts
+++ b/packages/sql-filter/src/column/config.ts
@@ -1,0 +1,3 @@
+export type ColumnType = 'text' | 'numeric' | 'timestamp' | 'boolean' | 'uuid';
+
+export type ColumnConfig = Record<string, { column: string; type: ColumnType }>;

--- a/packages/sql-filter/src/column/ident.spec.ts
+++ b/packages/sql-filter/src/column/ident.spec.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import { quoteIdent } from './ident';
+
+describe('quoteIdent', () => {
+  it('wraps an identifier in double quotes', () => {
+    expect(quoteIdent('created_at')).toBe('"created_at"');
+  });
+
+  it('doubles embedded double-quotes so identifiers cannot break out', () => {
+    expect(quoteIdent('a"b')).toBe('"a""b"');
+    expect(quoteIdent('x"; drop table t; --')).toBe('"x""; drop table t; --"');
+  });
+});

--- a/packages/sql-filter/src/column/ident.ts
+++ b/packages/sql-filter/src/column/ident.ts
@@ -1,0 +1,4 @@
+/** Quote a SQL identifier. Identifiers come from ColumnConfig, never user input. */
+export function quoteIdent(ident: string): string {
+  return `"${ident.replace(/"/g, '""')}"`;
+}

--- a/packages/sql-filter/src/column/index.ts
+++ b/packages/sql-filter/src/column/index.ts
@@ -1,0 +1,5 @@
+export * from './config';
+export type { ColumnOperator } from './operators';
+export * from './leaf';
+export * from './build';
+export * from './order-by';

--- a/packages/sql-filter/src/column/leaf.ts
+++ b/packages/sql-filter/src/column/leaf.ts
@@ -1,0 +1,23 @@
+import { ParamBuilder } from '../param-builder';
+import { ColumnQueryError } from '../errors';
+import type { ColumnConfig } from './config';
+import { quoteIdent } from './ident';
+import { renderColumnCondition, type ColumnOperator } from './operators';
+
+export type ColumnCondition = {
+  column: string;
+  operator: ColumnOperator;
+  value?: unknown;
+};
+
+export function makeColumnLeafRenderer(
+  config: ColumnConfig,
+): (leaf: ColumnCondition, params: ParamBuilder) => string {
+  return (leaf, params) => {
+    const def = config[leaf.column];
+    if (!def) {
+      throw new ColumnQueryError(`Unknown column: ${JSON.stringify(leaf.column)}`, 'UNKNOWN_COLUMN');
+    }
+    return renderColumnCondition(quoteIdent(def.column), def.type, leaf.operator, leaf.value, params);
+  };
+}

--- a/packages/sql-filter/src/column/operators.spec.ts
+++ b/packages/sql-filter/src/column/operators.spec.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { ParamBuilder } from '../param-builder';
+import { ColumnQueryError } from '../errors';
+import { renderColumnCondition } from './operators';
+
+const render = (
+  type: Parameters<typeof renderColumnCondition>[1],
+  op: Parameters<typeof renderColumnCondition>[2],
+  value?: unknown,
+) => {
+  const p = new ParamBuilder();
+  const sql = renderColumnCondition('"name"', type, op, value, p);
+  return { sql, values: p.values };
+};
+
+describe('renderColumnCondition', () => {
+  it('renders comparison operators with a positional param', () => {
+    expect(render('text', 'eq', 'x')).toEqual({ sql: '"name" = $1', values: ['x'] });
+    expect(render('numeric', 'gte', 5)).toEqual({ sql: '"name" >= $1', values: [5] });
+    expect(render('text', 'neq', 'y')).toEqual({ sql: '"name" <> $1', values: ['y'] });
+  });
+
+  it('renders text contains/startswith as parameterized ILIKE', () => {
+    expect(render('text', 'contains', 'ab')).toEqual({ sql: "\"name\" ilike '%' || $1 || '%'", values: ['ab'] });
+    expect(render('text', 'startswith', 'ab')).toEqual({ sql: "\"name\" ilike $1 || '%'", values: ['ab'] });
+  });
+
+  it('renders nullary operators without a param', () => {
+    expect(render('uuid', 'isnull')).toEqual({ sql: '"name" is null', values: [] });
+    expect(render('uuid', 'isnotnull')).toEqual({ sql: '"name" is not null', values: [] });
+  });
+
+  it('rejects an operator not allowed for the column type', () => {
+    expect(() => render('numeric', 'contains', 'x')).toThrow(ColumnQueryError);
+    expect(() => render('boolean', 'gt', true)).toThrow(ColumnQueryError);
+  });
+
+  it('rejects a value on a nullary operator and a missing value on others', () => {
+    expect(() => render('text', 'isnull', 'x')).toThrow(ColumnQueryError);
+    expect(() => render('text', 'eq', undefined)).toThrow(ColumnQueryError);
+  });
+});

--- a/packages/sql-filter/src/column/operators.ts
+++ b/packages/sql-filter/src/column/operators.ts
@@ -1,0 +1,65 @@
+import { ParamBuilder } from '../param-builder';
+import { ColumnQueryError } from '../errors';
+import type { ColumnType } from './config';
+
+export type ColumnOperator =
+  | 'eq'
+  | 'neq'
+  | 'isnull'
+  | 'isnotnull'
+  | 'contains'
+  | 'startswith'
+  | 'gt'
+  | 'gte'
+  | 'lt'
+  | 'lte';
+
+const NULLARY = new Set<ColumnOperator>(['isnull', 'isnotnull']);
+
+const ALLOWED: Record<ColumnType, ReadonlySet<ColumnOperator>> = {
+  text: new Set(['eq', 'neq', 'isnull', 'isnotnull', 'contains', 'startswith', 'gt', 'gte', 'lt', 'lte']),
+  numeric: new Set(['eq', 'neq', 'isnull', 'isnotnull', 'gt', 'gte', 'lt', 'lte']),
+  timestamp: new Set(['eq', 'neq', 'isnull', 'isnotnull', 'gt', 'gte', 'lt', 'lte']),
+  boolean: new Set(['eq', 'neq', 'isnull', 'isnotnull']),
+  uuid: new Set(['eq', 'neq', 'isnull', 'isnotnull']),
+};
+
+const COMPARATORS: Partial<Record<ColumnOperator, string>> = {
+  eq: '=',
+  neq: '<>',
+  gt: '>',
+  gte: '>=',
+  lt: '<',
+  lte: '<=',
+};
+
+export function renderColumnCondition(
+  quotedColumn: string,
+  type: ColumnType,
+  operator: ColumnOperator,
+  value: unknown,
+  params: ParamBuilder,
+): string {
+  if (!ALLOWED[type].has(operator)) {
+    throw new ColumnQueryError(
+      `Operator "${operator}" is not supported for ${type} column`,
+      'UNSUPPORTED_OPERATOR',
+    );
+  }
+  if (NULLARY.has(operator)) {
+    if (value !== undefined) {
+      throw new ColumnQueryError(`Operator "${operator}" must not carry a value`, 'INVALID_VALUE');
+    }
+    return operator === 'isnull' ? `${quotedColumn} is null` : `${quotedColumn} is not null`;
+  }
+  if (value === undefined) {
+    throw new ColumnQueryError(`Operator "${operator}" requires a value`, 'INVALID_VALUE');
+  }
+  if (operator === 'contains') {
+    return `${quotedColumn} ilike '%' || ${params.add(value)} || '%'`;
+  }
+  if (operator === 'startswith') {
+    return `${quotedColumn} ilike ${params.add(value)} || '%'`;
+  }
+  return `${quotedColumn} ${COMPARATORS[operator]} ${params.add(value)}`;
+}

--- a/packages/sql-filter/src/column/operators.ts
+++ b/packages/sql-filter/src/column/operators.ts
@@ -61,5 +61,11 @@ export function renderColumnCondition(
   if (operator === 'startswith') {
     return `${quotedColumn} ilike ${params.add(value)} || '%'`;
   }
-  return `${quotedColumn} ${COMPARATORS[operator]} ${params.add(value)}`;
+  const comparator = COMPARATORS[operator];
+  if (comparator === undefined) {
+    // Unreachable for the current operator set (nullary/contains/startswith are handled above),
+    // but guards against silently emitting `undefined` if the operator union grows.
+    throw new ColumnQueryError(`Operator "${operator}" is not a comparison operator`, 'UNSUPPORTED_OPERATOR');
+  }
+  return `${quotedColumn} ${comparator} ${params.add(value)}`;
 }

--- a/packages/sql-filter/src/column/order-by.spec.ts
+++ b/packages/sql-filter/src/column/order-by.spec.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { ColumnQueryError } from '../errors';
+import { buildColumnOrderBy } from './order-by';
+import type { ColumnConfig } from './config';
+
+const config: ColumnConfig = {
+  name: { column: 'name', type: 'text' },
+  createdAt: { column: 'created_at', type: 'timestamp' },
+};
+
+describe('buildColumnOrderBy', () => {
+  it('renders multiple sort keys with direction and nulls', () => {
+    const r = buildColumnOrderBy(config, [
+      { column: 'createdAt', direction: 'desc' },
+      { column: 'name', direction: 'asc', nulls: 'last' },
+    ]);
+    expect(r.orderBy).toBe('"created_at" desc, "name" asc nulls last');
+    expect(r.values).toEqual([]);
+  });
+
+  it('defaults direction to asc', () => {
+    expect(buildColumnOrderBy(config, [{ column: 'name' }]).orderBy).toBe('"name" asc');
+  });
+
+  it('rejects an unknown column and an invalid direction/nulls', () => {
+    expect(() => buildColumnOrderBy(config, [{ column: 'evil' }])).toThrow(ColumnQueryError);
+    expect(() =>
+      buildColumnOrderBy(config, [{ column: 'name', direction: 'sideways' as never }]),
+    ).toThrow(ColumnQueryError);
+    expect(() => buildColumnOrderBy(config, [{ column: 'name', nulls: 'middle' as never }])).toThrow(
+      ColumnQueryError,
+    );
+  });
+});

--- a/packages/sql-filter/src/column/order-by.ts
+++ b/packages/sql-filter/src/column/order-by.ts
@@ -1,0 +1,34 @@
+import { ColumnQueryError } from '../errors';
+import type { ColumnConfig } from './config';
+import { quoteIdent } from './ident';
+
+export type ColumnSortSpec = {
+  column: string;
+  direction?: 'asc' | 'desc';
+  nulls?: 'first' | 'last';
+};
+
+export function buildColumnOrderBy(
+  config: ColumnConfig,
+  sorts: ColumnSortSpec[],
+): { orderBy: string; values: unknown[] } {
+  const parts = sorts.map((spec) => {
+    const def = config[spec.column];
+    if (!def) {
+      throw new ColumnQueryError(`Unknown column: ${JSON.stringify(spec.column)}`, 'UNKNOWN_COLUMN');
+    }
+    const direction = spec.direction ?? 'asc';
+    if (direction !== 'asc' && direction !== 'desc') {
+      throw new ColumnQueryError(`Invalid sort direction: ${JSON.stringify(direction)}`, 'INVALID_SORT');
+    }
+    let sql = `${quoteIdent(def.column)} ${direction}`;
+    if (spec.nulls !== undefined) {
+      if (spec.nulls !== 'first' && spec.nulls !== 'last') {
+        throw new ColumnQueryError(`Invalid sort nulls: ${JSON.stringify(spec.nulls)}`, 'INVALID_SORT');
+      }
+      sql += ` nulls ${spec.nulls}`;
+    }
+    return sql;
+  });
+  return { orderBy: parts.join(', '), values: [] };
+}

--- a/packages/sql-filter/src/engine.spec.ts
+++ b/packages/sql-filter/src/engine.spec.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { ParamBuilder } from './param-builder';
+import { buildFilterGroup } from './engine';
+import type { FilterGroup } from './types';
+
+type FakeLeaf = { token: string };
+const renderFake = (leaf: FakeLeaf, p: ParamBuilder) => `${leaf.token}=${p.add(leaf.token)}`;
+const g = (group: FilterGroup<FakeLeaf>) => {
+  const p = new ParamBuilder();
+  return { sql: buildFilterGroup(group, renderFake, p), values: p.values };
+};
+
+describe('buildFilterGroup', () => {
+  it('joins leaves with the group logic', () => {
+    expect(g({ logic: 'and', filters: [{ token: 'a' }, { token: 'b' }] }).sql).toBe('a=$1 and b=$2');
+    expect(g({ logic: 'or', filters: [{ token: 'a' }, { token: 'b' }] }).sql).toBe('a=$1 or b=$2');
+  });
+
+  it('negates not/nor', () => {
+    expect(g({ logic: 'not', filters: [{ token: 'a' }, { token: 'b' }] }).sql).toBe('not (a=$1 and b=$2)');
+    expect(g({ logic: 'nor', filters: [{ token: 'a' }, { token: 'b' }] }).sql).toBe('not (a=$1 or b=$2)');
+  });
+
+  it('applies empty-group identity', () => {
+    expect(g({ logic: 'and', filters: [] }).sql).toBe('true');
+    expect(g({ logic: 'or', filters: [] }).sql).toBe('false');
+    expect(g({ logic: 'not', filters: [] }).sql).toBe('false');
+    expect(g({ logic: 'nor', filters: [] }).sql).toBe('true');
+  });
+
+  it('wraps nested groups in parentheses', () => {
+    const r = g({
+      logic: 'and',
+      filters: [{ token: 'a' }, { logic: 'or', filters: [{ token: 'b' }, { token: 'c' }] }],
+    });
+    expect(r.sql).toBe('a=$1 and (b=$2 or c=$3)');
+    expect(r.values).toEqual(['a', 'b', 'c']);
+  });
+
+  it('continues placeholder numbering from the ParamBuilder offset', () => {
+    const p = new ParamBuilder(5);
+    const sql = buildFilterGroup({ logic: 'and', filters: [{ token: 'a' }] }, renderFake, p);
+    expect(sql).toBe('a=$6');
+  });
+});

--- a/packages/sql-filter/src/engine.spec.ts
+++ b/packages/sql-filter/src/engine.spec.ts
@@ -42,4 +42,18 @@ describe('buildFilterGroup', () => {
     const sql = buildFilterGroup({ logic: 'and', filters: [{ token: 'a' }] }, renderFake, p);
     expect(sql).toBe('a=$6');
   });
+
+  it('treats a leaf carrying logic/filters-like fields as a leaf, not a group', () => {
+    type TrickyLeaf = { token: string; logic?: string; filters?: unknown[] };
+    const renderTricky = (leaf: TrickyLeaf, p: ParamBuilder) => `${leaf.token}=${p.add(leaf.token)}`;
+    const p = new ParamBuilder();
+    // `logic: 'xor'` is NOT a valid LogicalOperator -> must be treated as a leaf
+    const sql = buildFilterGroup<TrickyLeaf>(
+      { logic: 'and', filters: [{ token: 'a', logic: 'xor', filters: [] }] },
+      renderTricky,
+      p,
+    );
+    expect(sql).toBe('a=$1');
+    expect(p.values).toEqual(['a']);
+  });
 });

--- a/packages/sql-filter/src/engine.ts
+++ b/packages/sql-filter/src/engine.ts
@@ -1,0 +1,49 @@
+import { ParamBuilder } from './param-builder';
+import type { FilterGroup, LogicalOperator } from './types';
+
+const EMPTY_GROUP_IDENTITY: Record<LogicalOperator, string> = {
+  and: 'true',
+  or: 'false',
+  not: 'false', // not(AND of nothing) = not(true)
+  nor: 'true', // not(OR of nothing) = not(false)
+};
+
+function isFilterGroup<L>(node: L | FilterGroup<L>): node is FilterGroup<L> {
+  return (
+    typeof node === 'object' &&
+    node !== null &&
+    'logic' in node &&
+    'filters' in node &&
+    Array.isArray((node as { filters: unknown }).filters)
+  );
+}
+
+function joinLogic(parts: string[], logic: LogicalOperator): string {
+  if (parts.length === 0) return EMPTY_GROUP_IDENTITY[logic];
+  const joined = parts.join(logic === 'or' || logic === 'nor' ? ' or ' : ' and ');
+  return logic === 'not' || logic === 'nor' ? `not (${joined})` : joined;
+}
+
+function wrap(sql: string): string {
+  return sql.length > 0 ? `(${sql})` : '';
+}
+
+/**
+ * Render a nested filter group to a parameterized SQL boolean expression.
+ * Leaf rendering is delegated to `renderLeaf`, making the engine independent of
+ * what a leaf is (column condition, jsonb condition, etc.).
+ */
+export function buildFilterGroup<L>(
+  group: FilterGroup<L>,
+  renderLeaf: (leaf: L, params: ParamBuilder) => string,
+  params: ParamBuilder,
+): string {
+  const parts = group.filters
+    .map((node) =>
+      isFilterGroup(node)
+        ? wrap(buildFilterGroup(node, renderLeaf, params))
+        : renderLeaf(node, params),
+    )
+    .filter((sql) => sql.length > 0);
+  return joinLogic(parts, group.logic);
+}

--- a/packages/sql-filter/src/engine.ts
+++ b/packages/sql-filter/src/engine.ts
@@ -8,11 +8,14 @@ const EMPTY_GROUP_IDENTITY: Record<LogicalOperator, string> = {
   nor: 'true', // not(OR of nothing) = not(false)
 };
 
+const LOGICS = new Set<LogicalOperator>(['and', 'or', 'nor', 'not']);
+
 function isFilterGroup<L>(node: L | FilterGroup<L>): node is FilterGroup<L> {
   return (
     typeof node === 'object' &&
     node !== null &&
     'logic' in node &&
+    LOGICS.has((node as { logic: unknown }).logic as LogicalOperator) &&
     'filters' in node &&
     Array.isArray((node as { filters: unknown }).filters)
   );

--- a/packages/sql-filter/src/errors.spec.ts
+++ b/packages/sql-filter/src/errors.spec.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import { ColumnQueryError } from './errors';
+
+describe('ColumnQueryError', () => {
+  it('is an Error carrying a typed code and name', () => {
+    const err = new ColumnQueryError('nope', 'UNKNOWN_COLUMN');
+    expect(err).toBeInstanceOf(Error);
+    expect(err.code).toBe('UNKNOWN_COLUMN');
+    expect(err.name).toBe('ColumnQueryError');
+    expect(err.message).toBe('nope');
+  });
+});

--- a/packages/sql-filter/src/errors.ts
+++ b/packages/sql-filter/src/errors.ts
@@ -1,0 +1,16 @@
+export type ColumnQueryErrorCode =
+  | 'UNKNOWN_COLUMN'
+  | 'UNSUPPORTED_OPERATOR'
+  | 'INVALID_VALUE'
+  | 'INVALID_SORT'
+  | 'INVALID_PARAM_OFFSET';
+
+export class ColumnQueryError extends Error {
+  constructor(
+    message: string,
+    readonly code: ColumnQueryErrorCode,
+  ) {
+    super(message);
+    this.name = 'ColumnQueryError';
+  }
+}

--- a/packages/sql-filter/src/index.ts
+++ b/packages/sql-filter/src/index.ts
@@ -1,1 +1,5 @@
+export * from './types';
 export * from './param-builder';
+export * from './errors';
+export * from './engine';
+export * from './column';

--- a/packages/sql-filter/src/index.ts
+++ b/packages/sql-filter/src/index.ts
@@ -1,0 +1,1 @@
+export * from './param-builder';

--- a/packages/sql-filter/src/param-builder.spec.ts
+++ b/packages/sql-filter/src/param-builder.spec.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { ParamBuilder } from './param-builder';
+
+describe('ParamBuilder', () => {
+  it('emits sequential placeholders and collects values', () => {
+    const p = new ParamBuilder();
+    expect(p.add('a')).toBe('$1');
+    expect(p.add('b')).toBe('$2');
+    expect(p.values).toEqual(['a', 'b']);
+  });
+
+  it('honors a starting offset', () => {
+    const p = new ParamBuilder(2);
+    expect(p.add('x')).toBe('$3');
+    expect(p.values).toEqual(['x']);
+  });
+});

--- a/packages/sql-filter/src/param-builder.ts
+++ b/packages/sql-filter/src/param-builder.ts
@@ -1,0 +1,14 @@
+export class ParamBuilder {
+  private _values: unknown[] = [];
+
+  constructor(private readonly offset = 0) {}
+
+  add(value: unknown): string {
+    this._values.push(value);
+    return `$${this.offset + this._values.length}`;
+  }
+
+  get values(): unknown[] {
+    return [...this._values];
+  }
+}

--- a/packages/sql-filter/src/types.ts
+++ b/packages/sql-filter/src/types.ts
@@ -1,0 +1,6 @@
+export type LogicalOperator = 'and' | 'or' | 'nor' | 'not';
+
+export type FilterGroup<L> = {
+  logic: LogicalOperator;
+  filters: Array<L | FilterGroup<L>>;
+};

--- a/packages/sql-filter/tsconfig.build.json
+++ b/packages/sql-filter/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", "dist", "test", "*.config.*"]
+}

--- a/packages/sql-filter/tsconfig.json
+++ b/packages/sql-filter/tsconfig.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "target": "ES2023",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "importHelpers": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "declarationDir": "types",
+    "emitDeclarationOnly": false,
+    "outDir": "dist",
+    "sourceMap": true,
+    "paths": {
+      "@/*": ["./src/*"]
+    },
+    "resolveJsonModule": true,
+    "removeComments": true,
+    "newLine": "lf",
+    "noUnusedLocals": true,
+    "noFallthroughCasesInSwitch": true,
+    "isolatedModules": true,
+    "forceConsistentCasingInFileNames": true,
+    "lib": ["ESNext"]
+  },
+  "exclude": ["node_modules", "dist*", "test", "types", "**/*.spec.ts", "**/*.test.ts", "**/*.e2e.spec.ts", "**/*.e2e.test.ts", "*.config.*"]
+}

--- a/packages/sql-filter/tsdown.config.ts
+++ b/packages/sql-filter/tsdown.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  outDir: 'dist',
+  format: ['esm', 'cjs'],
+  tsconfig: 'tsconfig.build.json',
+  target: 'es2023',
+  platform: 'neutral',
+  treeshake: true,
+  sourcemap: true,
+  clean: true,
+  dts: true,
+});

--- a/packages/sql-filter/vitest.config.mts
+++ b/packages/sql-filter/vitest.config.mts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+  resolve: { alias: { '@': path.resolve(__dirname, 'src') } },
+  test: {
+    include: ['src/**/*.test.(ts|js)', 'src/**/*.spec.(ts|js)'],
+    globals: true,
+    reporters: ['verbose'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1445,6 +1445,39 @@ importers:
         specifier: ^3.2.3
         version: 3.2.4(@types/node@25.9.1)(@vitest/ui@3.2.4)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0))(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
 
+  packages/sql-filter:
+    devDependencies:
+      '@eslint/js':
+        specifier: ^9.20.0
+        version: 9.39.1
+      eslint:
+        specifier: ^9.20.1
+        version: 9.39.1(jiti@2.7.0)
+      eslint-config-prettier:
+        specifier: ^10.0.1
+        version: 10.0.1(eslint@9.39.1(jiti@2.7.0))
+      npm-run-all:
+        specifier: ^4.1.5
+        version: 4.1.5
+      prettier:
+        specifier: ^3.5.1
+        version: 3.5.3
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.1.2
+      tsdown:
+        specifier: 0.17.0-beta.6
+        version: 0.17.0-beta.6(typescript@5.8.3)
+      typescript:
+        specifier: ^5.7.3
+        version: 5.8.3
+      typescript-eslint:
+        specifier: ^8.24.0
+        version: 8.61.0(eslint@9.39.1(jiti@2.7.0))(typescript@5.8.3)
+      vitest:
+        specifier: ^3.2.3
+        version: 3.2.4(@types/node@25.9.3)(@vitest/ui@3.2.4)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0))(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
+
   packages/tpl-toolkit:
     dependencies:
       tslib:
@@ -11877,6 +11910,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/eslint-plugin@8.61.0(@typescript-eslint/parser@8.61.0(eslint@9.39.1(jiti@2.7.0))(typescript@5.8.3))(eslint@9.39.1(jiti@2.7.0))(typescript@5.8.3)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      '@typescript-eslint/parser': 8.61.0(eslint@9.39.1(jiti@2.7.0))(typescript@5.8.3)
+      '@typescript-eslint/scope-manager': 8.61.0
+      '@typescript-eslint/type-utils': 8.61.0(eslint@9.39.1(jiti@2.7.0))(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.61.0(eslint@9.39.1(jiti@2.7.0))(typescript@5.8.3)
+      '@typescript-eslint/visitor-keys': 8.61.0
+      eslint: 9.39.1(jiti@2.7.0)
+      ignore: 7.0.5
+      natural-compare: 1.4.0
+      ts-api-utils: 2.5.0(typescript@5.8.3)
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/eslint-plugin@8.61.0(@typescript-eslint/parser@8.61.0(eslint@9.39.1(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.1(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
@@ -11917,6 +11966,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/parser@8.61.0(eslint@9.39.1(jiti@2.7.0))(typescript@5.8.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.61.0
+      '@typescript-eslint/types': 8.61.0
+      '@typescript-eslint/typescript-estree': 8.61.0(typescript@5.8.3)
+      '@typescript-eslint/visitor-keys': 8.61.0
+      debug: 4.4.3(supports-color@5.5.0)
+      eslint: 9.39.1(jiti@2.7.0)
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/parser@8.61.0(eslint@9.39.1(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.61.0
@@ -11947,6 +12008,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/project-service@8.61.0(typescript@5.8.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.61.0(typescript@5.8.3)
+      '@typescript-eslint/types': 8.61.0
+      debug: 4.4.3(supports-color@5.5.0)
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/project-service@8.61.0(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.61.0(typescript@6.0.3)
@@ -11974,6 +12044,10 @@ snapshots:
     dependencies:
       typescript: 5.7.3
 
+  '@typescript-eslint/tsconfig-utils@8.61.0(typescript@5.8.3)':
+    dependencies:
+      typescript: 5.8.3
+
   '@typescript-eslint/tsconfig-utils@8.61.0(typescript@6.0.3)':
     dependencies:
       typescript: 6.0.3
@@ -11999,6 +12073,18 @@ snapshots:
       eslint: 9.39.1(jiti@2.7.0)
       ts-api-utils: 2.5.0(typescript@5.7.3)
       typescript: 5.7.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/type-utils@8.61.0(eslint@9.39.1(jiti@2.7.0))(typescript@5.8.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.61.0
+      '@typescript-eslint/typescript-estree': 8.61.0(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.61.0(eslint@9.39.1(jiti@2.7.0))(typescript@5.8.3)
+      debug: 4.4.3(supports-color@5.5.0)
+      eslint: 9.39.1(jiti@2.7.0)
+      ts-api-utils: 2.5.0(typescript@5.8.3)
+      typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
@@ -12048,6 +12134,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/typescript-estree@8.61.0(typescript@5.8.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.61.0(typescript@5.8.3)
+      '@typescript-eslint/tsconfig-utils': 8.61.0(typescript@5.8.3)
+      '@typescript-eslint/types': 8.61.0
+      '@typescript-eslint/visitor-keys': 8.61.0
+      debug: 4.4.3(supports-color@5.5.0)
+      minimatch: 10.2.4
+      semver: 7.7.3
+      tinyglobby: 0.2.15
+      ts-api-utils: 2.5.0(typescript@5.8.3)
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/typescript-estree@8.61.0(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/project-service': 8.61.0(typescript@6.0.3)
@@ -12082,6 +12183,17 @@ snapshots:
       '@typescript-eslint/typescript-estree': 8.61.0(typescript@5.7.3)
       eslint: 9.39.1(jiti@2.7.0)
       typescript: 5.7.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.7.0))(typescript@5.8.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.1(jiti@2.7.0))
+      '@typescript-eslint/scope-manager': 8.61.0
+      '@typescript-eslint/types': 8.61.0
+      '@typescript-eslint/typescript-estree': 8.61.0(typescript@5.8.3)
+      eslint: 9.39.1(jiti@2.7.0)
+      typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
@@ -15971,6 +16083,10 @@ snapshots:
     dependencies:
       typescript: 5.7.3
 
+  ts-api-utils@2.5.0(typescript@5.8.3):
+    dependencies:
+      typescript: 5.8.3
+
   ts-api-utils@2.5.0(typescript@6.0.3):
     dependencies:
       typescript: 6.0.3
@@ -16226,6 +16342,17 @@ snapshots:
       '@typescript-eslint/utils': 8.61.0(eslint@9.39.1(jiti@2.7.0))(typescript@5.7.3)
       eslint: 9.39.1(jiti@2.7.0)
       typescript: 5.7.3
+    transitivePeerDependencies:
+      - supports-color
+
+  typescript-eslint@8.61.0(eslint@9.39.1(jiti@2.7.0))(typescript@5.8.3):
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 8.61.0(@typescript-eslint/parser@8.61.0(eslint@9.39.1(jiti@2.7.0))(typescript@5.8.3))(eslint@9.39.1(jiti@2.7.0))(typescript@5.8.3)
+      '@typescript-eslint/parser': 8.61.0(eslint@9.39.1(jiti@2.7.0))(typescript@5.8.3)
+      '@typescript-eslint/typescript-estree': 8.61.0(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.61.0(eslint@9.39.1(jiti@2.7.0))(typescript@5.8.3)
+      eslint: 9.39.1(jiti@2.7.0)
+      typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
## Summary

New public package **`@rfjs/sql-filter`**: a generic boolean filter-group → SQL builder, modeled on `@rfjs/jsonb-query`'s engine but with a **pluggable leaf renderer**. The reusable machinery (`and/or/nor/not`, nesting, empty-group identity, param offsetting) is factored out from any leaf specifics; a built-in **column leaf** is the headline use.

This is sub-project 1 of the datasets filter+sort+pagination work. Sub-project 2 (datasets consuming `@rfjs/sql-filter` + `@rfjs/jsonb-query` for a unified column+jsonb tree) lands separately and injects a jsonb leaf via the exported engine.

### API
- **Generic core:** `buildFilterGroup<L>(group, renderLeaf, params)`, `ParamBuilder`, `FilterGroup<L>`, `LogicalOperator`, `ColumnQueryError` (+ `ColumnQueryErrorCode`).
- **Built-in column leaf:** `buildColumnQuery(config, group, { paramOffset? })`, `buildColumnOrderBy(config, sorts)`, `makeColumnLeafRenderer(config)`, `ColumnConfig`/`ColumnType`/`ColumnCondition`/`ColumnOperator`/`ColumnSortSpec`.
- v1 operators: `eq neq isnull isnotnull` (all types), `contains startswith` (text), `gt gte lt lte` (numeric/timestamp/text). Per-type applicability enforced; enhancements (`in`, `endswith`, ranges, case-insensitive) deferred.

### Security
SQL-injection safe by construction: every user value flows through `ParamBuilder` as a positional `$N`; SQL identifiers come **only** from the developer-declared `ColumnConfig` (quoted via `quoteIdent`); the request-controlled `column` is used solely as a config lookup key (unknown → `UNKNOWN_COLUMN`). `contains`/`startswith` concatenate only the literal `%` in-SQL around a bound param.

## Design / plan
- Spec: `docs/superpowers/specs/2026-06-15-sql-filter-design.md`
- Plan: `docs/superpowers/plans/2026-06-15-sql-filter.md`

## Test Plan
- [x] Unit: 23 tests (param-builder, errors, engine incl. empty-group/negation/nesting/offset/leaf-vs-group discriminator, operators per type, build, order-by, quoteIdent) — pass
- [x] Build + typecheck (esm+cjs+dts) — clean
- [x] Pure package — no `dependencies` block
- [x] Public surface verified: `renderColumnCondition`/`quoteIdent` are internal (absent from `dist/index.d.ts`); engine + `ParamBuilder` exported for custom-leaf consumers

## Notes / follow-ups (non-blocking)
- Public/ISC, version 0.0.0; npm publish deferred to the changeset flow.
- Vestigial `clean:types` script (copied from jsonb-query; tsdown emits dts to `dist/`) — harmless, can drop later.
- Deferred (per spec): enhancement operators; datasets integration (sub-project 2); optionally refactoring `@rfjs/jsonb-query` to reuse this engine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)