### PR TITLE
a11y(web): radio-item semantics for tool single-select dropdowns

### DIFF
--- a/apps/web/src/components/tools/jsonb-query-generator.tsx
+++ b/apps/web/src/components/tools/jsonb-query-generator.tsx
@@ -5,11 +5,12 @@ import { CopyButton } from "@rfjs/web-ui/components/copy-button";
 import {
   DropdownMenu,
   DropdownMenuContent,
-  DropdownMenuItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
   DropdownMenuTrigger,
 } from "@rfjs/web-ui/components/dropdown-menu";
 import { Panel } from "@rfjs/web-ui/components/panel";
-import { Check, ChevronDown } from "lucide-react";
+import { ChevronDown } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useState } from "react";
 
@@ -54,12 +55,16 @@ export function JsonbQueryGenerator() {
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="start">
-                {JSONB_DIALECTS.map((d) => (
-                  <DropdownMenuItem key={d} onSelect={() => setDialect(d)}>
-                    <Check className={d === dialect ? "size-4 opacity-100" : "size-4 opacity-0"} />
-                    {d}
-                  </DropdownMenuItem>
-                ))}
+                <DropdownMenuRadioGroup
+                  value={dialect}
+                  onValueChange={(next) => setDialect(next as JsonbDialect)}
+                >
+                  {JSONB_DIALECTS.map((d) => (
+                    <DropdownMenuRadioItem key={d} value={d}>
+                      {d}
+                    </DropdownMenuRadioItem>
+                  ))}
+                </DropdownMenuRadioGroup>
               </DropdownMenuContent>
             </DropdownMenu>
             <label className="flex flex-col gap-1 text-xs text-muted-foreground">

--- a/apps/web/src/components/tools/type-converter.tsx
+++ b/apps/web/src/components/tools/type-converter.tsx
@@ -6,11 +6,12 @@ import { CopyButton } from "@rfjs/web-ui/components/copy-button";
 import {
   DropdownMenu,
   DropdownMenuContent,
-  DropdownMenuItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
   DropdownMenuTrigger,
 } from "@rfjs/web-ui/components/dropdown-menu";
 import { Panel } from "@rfjs/web-ui/components/panel";
-import { Check, ChevronDown } from "lucide-react";
+import { ChevronDown } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useState } from "react";
 
@@ -44,12 +45,16 @@ export function TypeConverter() {
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="start">
-                {CONVERT_TYPES.map((ty) => (
-                  <DropdownMenuItem key={ty} onSelect={() => setType(ty)}>
-                    <Check className={ty === type ? "size-4 opacity-100" : "size-4 opacity-0"} />
-                    {t(`types.${ty}`)}
-                  </DropdownMenuItem>
-                ))}
+                <DropdownMenuRadioGroup
+                  value={type}
+                  onValueChange={(next) => setType(next as DataType)}
+                >
+                  {CONVERT_TYPES.map((ty) => (
+                    <DropdownMenuRadioItem key={ty} value={ty}>
+                      {t(`types.${ty}`)}
+                    </DropdownMenuRadioItem>
+                  ))}
+                </DropdownMenuRadioGroup>
               </DropdownMenuContent>
             </DropdownMenu>
           </div>

--- a/packages/web-ui/src/components/dropdown-menu.spec.tsx
+++ b/packages/web-ui/src/components/dropdown-menu.spec.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from './dropdown-menu';
+
+function Fixture({ value }: { value: string }) {
+  return (
+    <DropdownMenu defaultOpen>
+      <DropdownMenuTrigger>open</DropdownMenuTrigger>
+      <DropdownMenuContent>
+        <DropdownMenuRadioGroup value={value}>
+          <DropdownMenuRadioItem value="legacy">legacy</DropdownMenuRadioItem>
+          <DropdownMenuRadioItem value="jsonpath">jsonpath</DropdownMenuRadioItem>
+        </DropdownMenuRadioGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+describe('DropdownMenuRadioItem', () => {
+  it('exposes each option as a menuitemradio', () => {
+    render(<Fixture value="legacy" />);
+    expect(screen.getAllByRole('menuitemradio')).toHaveLength(2);
+  });
+
+  it('marks only the selected option aria-checked', () => {
+    render(<Fixture value="jsonpath" />);
+    const items = screen.getAllByRole('menuitemradio');
+    const checked = items.filter((el) => el.getAttribute('aria-checked') === 'true');
+    expect(checked).toHaveLength(1);
+    expect(checked[0]?.textContent).toContain('jsonpath');
+  });
+});

--- a/packages/web-ui/src/components/dropdown-menu.tsx
+++ b/packages/web-ui/src/components/dropdown-menu.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Check } from 'lucide-react';
 import * as React from 'react';
 import { DropdownMenu as DropdownMenuPrimitive } from 'radix-ui';
 
@@ -51,4 +52,41 @@ function DropdownMenuItem({
   );
 }
 
-export { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger };
+function DropdownMenuRadioGroup(
+  props: React.ComponentProps<typeof DropdownMenuPrimitive.RadioGroup>,
+) {
+  return <DropdownMenuPrimitive.RadioGroup data-slot="dropdown-menu-radio-group" {...props} />;
+}
+
+function DropdownMenuRadioItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioItem>) {
+  return (
+    <DropdownMenuPrimitive.RadioItem
+      data-slot="dropdown-menu-radio-item"
+      className={cn(
+        'relative flex cursor-pointer items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-none transition-colors select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+        className,
+      )}
+      {...props}
+    >
+      <span className="absolute left-2 flex size-4 items-center justify-center">
+        <DropdownMenuPrimitive.ItemIndicator>
+          <Check className="size-4" />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.RadioItem>
+  );
+}
+
+export {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+};


### PR DESCRIPTION
## Summary

Two tool dropdowns — `type-converter` (target type) and `jsonb-query-generator` (dialect) — were single-select menus that marked the active option with a visual-only `opacity-0` Check. The underlying `DropdownMenuItem` carried no `aria-checked`/`role`, so screen-reader users could not tell which option was selected.

- **`@rfjs/web-ui`** (private): add `DropdownMenuRadioGroup` / `DropdownMenuRadioItem`. Radix renders `role="menuitemradio"` + `aria-checked` automatically and shows the Check via `ItemIndicator` (selected-only), replacing the manual opacity toggle.
- **`apps/web`**: migrate both tool dropdowns to the radio primitives; drop the hand-rolled `opacity-0` Check.

Scope note: the originally-tracked follow-ups turned out done already — the orphan `playground*` i18n keys were removed in #156, and the locale switcher is already an accessible `aria-pressed` button group. The real `opacity-0`-Check a11y gap had migrated to these two tool dropdowns, which this PR fixes.

`@rfjs/web-ui` is private, so no changeset is needed.

## Test Plan

- [x] `@rfjs/web-ui`: lint + `tsc --noEmit` clean; vitest 12/12 (incl. 2 new specs asserting `role=menuitemradio` and single `aria-checked`)
- [x] `apps/web`: lint + `tsc --noEmit` clean
- [x] `apps/web`: `next build` succeeds; 51 static pages prerender (incl. `/tools/type-converter`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)