### PR TITLE
chore(dev): make `pnpm dev -F <pkg>` scope to one app

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,13 +25,16 @@ All root-level commands delegate to Turborepo. Run from repo root unless noted.
 pnpm install              # install dependencies (use --frozen-lockfile in CI)
 pnpm build                # build all apps and packages
 pnpm build:packages       # build only @rfjs/* packages
-pnpm dev                  # start all dev servers
+pnpm dev                  # start the app dev servers (apps/*); see note below
+pnpm dev -F web           # start only one app/package's dev server
 pnpm test                 # run all tests
 pnpm lint                 # lint all packages
 pnpm typecheck            # type check all packages
 pnpm format               # prettier write
 pnpm commit               # commitizen (conventional commits)
 ```
+
+`pnpm dev` runs `scripts/dev.mjs`: with no filter it scopes to the app dev servers (`--filter=./apps/*`) so the 15 library watchers don't all start at once (that trips the inotify watch limit); pass `-F`/`--filter` and it steps aside so turbo scopes to exactly what you asked (`pnpm dev -F web` → only `web`). All run with `--concurrency=22`. `pnpm dev:all` still starts every package's watcher.
 
 ### Per-package commands
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "build": "turbo build",
     "build:packages": "turbo run build --filter='@rfjs/*'",
-    "dev": "turbo dev --filter=./apps/*",
+    "dev": "node scripts/dev.mjs",
     "dev:all": "turbo dev --concurrency=22",
     "test": "turbo test",
     "lint": "turbo lint",

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+// Root `dev` wrapper.
+//
+// Bare `pnpm dev` should start only the app dev servers (apps/*) — running every
+// package's watcher at once trips the inotify watch limit and is rarely wanted.
+// But a hard-coded `turbo dev --filter=./apps/*` cannot be narrowed: turbo merges
+// multiple `--filter` flags as a UNION, and pnpm appends post-script args, so
+// `pnpm dev -F web` would expand to `--filter=./apps/* -F web` = all apps again.
+//
+// So: default to the apps filter only when the caller passed no filter of their
+// own. With an explicit -F/--filter we step aside and let turbo scope it.
+//   pnpm dev            -> turbo dev --concurrency=22 --filter=./apps/*
+//   pnpm dev -F web     -> turbo dev --concurrency=22 -F web
+import { spawn } from "node:child_process";
+
+const passthrough = process.argv.slice(2);
+const hasFilter = passthrough.some(
+  (arg) =>
+    arg === "-F" ||
+    arg === "--filter" ||
+    arg.startsWith("-F") ||
+    arg.startsWith("--filter="),
+);
+
+const scope = hasFilter ? [] : ["--filter=./apps/*"];
+const args = ["dev", "--concurrency=22", ...scope, ...passthrough];
+
+const child = spawn("turbo", args, { stdio: "inherit" });
+child.on("exit", (code, signal) => {
+  if (signal) process.kill(process.pid, signal);
+  else process.exit(code ?? 0);
+});


### PR DESCRIPTION
## Summary

`pnpm dev` hard-coded `turbo dev --filter=./apps/*`, which could not be narrowed. Turbo unions multiple `--filter` flags and pnpm appends post-script args, so `pnpm dev -F web` expanded to `turbo dev --filter=./apps/* -F web` and still ran **all four apps** instead of just `web`.

Replace the static script with `scripts/dev.mjs`:

- **No filter** → applies the apps scope (`--filter=./apps/*`) so the 15 library watchers don't all start at once (that trips the inotify watch limit — the reason #155 scoped `dev` to apps).
- **Explicit `-F`/`--filter`** → steps aside and lets turbo scope it: `pnpm dev -F web` → only `web`.
- Always runs with `--concurrency=22`. `pnpm dev:all` still watches every package.

No behavior change to bare `pnpm dev` (still the 4 app servers); this only makes targeted single-app dev work via the natural `pnpm dev -F <pkg>` form.

## Test Plan

- [x] `pnpm dev` → `Packages in scope: api, orm-app, web, workbench` (4)
- [x] `pnpm dev -F web` → `Packages in scope: web` (1)
- [x] `pnpm dev --filter=api` → `Packages in scope: api` (1)
- [x] `scripts/dev.mjs` passes Prettier

🤖 Generated with [Claude Code](https://claude.com/claude-code)