### PR TITLE
feat(web): group sidebar tools by @rfjs package

### DIFF
--- a/apps/web/src/components/layout/app-sidebar.tsx
+++ b/apps/web/src/components/layout/app-sidebar.tsx
@@ -4,18 +4,19 @@ import { Seam } from "@rfjs/web-ui/components/seam";
 import { useTranslations } from "next-intl";
 
 import { Link, usePathname } from "@/i18n/navigation";
-import { sidebarPackages, sidebarTools } from "@/lib/nav";
+import { sidebarToolGroups } from "@/lib/nav";
 import { toolHref } from "@/lib/tool-href";
 
 export function AppSidebar() {
   const t = useTranslations("Tools");
   const tNav = useTranslations("Pages");
   const pathname = usePathname();
-  const packages = sidebarPackages();
-  const tools = sidebarTools();
+  const groups = sidebarToolGroups();
 
-  const linkClass =
+  const toolLinkClass =
     "flex items-center gap-2 rounded-sm px-2 py-1.5 text-sm transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-intake aria-[current=page]:text-signal";
+  const headerLinkClass =
+    "rounded-sm px-2 py-1.5 font-mono text-xs uppercase tracking-wide text-muted-foreground transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-intake aria-[current=page]:text-signal";
   const seam = (active: boolean) => (
     <span className="h-4 w-px">
       {active ? <Seam state="current" operation="" orientation="vertical" /> : null}
@@ -23,36 +24,36 @@ export function AppSidebar() {
   );
 
   return (
-    <nav aria-label={tNav("packagesTitle")} className="flex flex-col gap-5 p-4">
-      <div className="flex flex-col gap-1">
-        <span className="px-2 font-mono text-xs uppercase tracking-wide text-muted-foreground">
-          {tNav("packagesTitle")}
-        </span>
-        {packages.map((pkg) => {
-          const active = pathname === pkg.href;
-          return (
-            <Link key={pkg.name} href={pkg.href} aria-current={active ? "page" : undefined} className={linkClass}>
-              {seam(active)}
+    <nav aria-label={tNav("toolsTitle")} className="flex flex-col gap-5 p-4">
+      {groups.map(({ pkg, tools }) => {
+        const pkgActive = pathname === pkg.href;
+        return (
+          <div key={pkg.name} className="flex flex-col gap-1">
+            <Link
+              href={pkg.href}
+              aria-current={pkgActive ? "page" : undefined}
+              className={headerLinkClass}
+            >
               {pkg.name.replace("@rfjs/", "")}
             </Link>
-          );
-        })}
-      </div>
-      <div className="flex flex-col gap-1">
-        <span className="px-2 font-mono text-xs uppercase tracking-wide text-muted-foreground">
-          {tNav("toolsTitle")}
-        </span>
-        {tools.map((tool) => {
-          const href = toolHref(tool);
-          const active = pathname === href;
-          return (
-            <Link key={tool.id} href={href} aria-current={active ? "page" : undefined} className={linkClass}>
-              {seam(active)}
-              {t(`${tool.id}.title`)}
-            </Link>
-          );
-        })}
-      </div>
+            {tools.map((tool) => {
+              const href = toolHref(tool);
+              const active = pathname === href;
+              return (
+                <Link
+                  key={tool.id}
+                  href={href}
+                  aria-current={active ? "page" : undefined}
+                  className={toolLinkClass}
+                >
+                  {seam(active)}
+                  {t(`${tool.id}.title`)}
+                </Link>
+              );
+            })}
+          </div>
+        );
+      })}
     </nav>
   );
 }

--- a/apps/web/src/lib/nav.spec.ts
+++ b/apps/web/src/lib/nav.spec.ts
@@ -1,16 +1,49 @@
+import { packageRegistry, toolRegistry } from "@rfjs/web-core";
 import { describe, expect, it } from "vitest";
 
-import { sidebarPackages, sidebarTools } from "./nav";
+import { sidebarToolGroups } from "./nav";
 
-describe("sidebar nav", () => {
-  it("lists every package", () => {
-    expect(sidebarPackages().length).toBeGreaterThanOrEqual(10);
+describe("sidebarToolGroups", () => {
+  it("emits groups in packageRegistry order, only packages that have web tools", () => {
+    const webPrimaries = new Set(
+      toolRegistry.filter((t) => t.surface === "web").map((t) => t.relatedPackages?.[0]),
+    );
+    const expected = packageRegistry.map((p) => p.name).filter((name) => webPrimaries.has(name));
+
+    expect(sidebarToolGroups().map((g) => g.pkg.name)).toEqual(expected);
+    // a lib-only package with no web tool must not appear
+    expect(sidebarToolGroups().some((g) => g.pkg.name === "@rfjs/pg-toolkit")).toBe(false);
   });
 
-  it("lists only web-surface quick tools (workbench apps excluded)", () => {
-    const tools = sidebarTools();
-    expect(tools.length).toBeGreaterThan(0);
-    expect(tools.every((t) => t.surface === "web")).toBe(true);
-    expect(tools.some((t) => t.surface === "workbench")).toBe(false);
+  it("places every web tool under exactly one group (no orphans, no dupes)", () => {
+    const webIds = toolRegistry
+      .filter((t) => t.surface === "web")
+      .map((t) => t.id)
+      .sort();
+    const groupedIds = sidebarToolGroups()
+      .flatMap((g) => g.tools.map((t) => t.id))
+      .sort();
+
+    expect(groupedIds).toEqual(webIds);
+  });
+
+  it("places a multi-package tool under its primary package only", () => {
+    const groups = sidebarToolGroups();
+    const jsonb = groups.find((g) => g.pkg.name === "@rfjs/jsonb-query");
+    const dataFilter = groups.find((g) => g.pkg.name === "@rfjs/data-filter");
+
+    expect(jsonb?.tools.map((t) => t.id)).toContain("query-builder");
+    expect(dataFilter?.tools.map((t) => t.id) ?? []).not.toContain("query-builder");
+  });
+
+  it("keeps tools within a group in toolRegistry order", () => {
+    const jsonb = sidebarToolGroups().find((g) => g.pkg.name === "@rfjs/jsonb-query");
+    expect(jsonb?.tools.map((t) => t.id)).toEqual(["jsonb-query-generator", "query-builder"]);
+  });
+
+  it("excludes workbench-surface tools", () => {
+    const ids = sidebarToolGroups().flatMap((g) => g.tools.map((t) => t.id));
+    expect(ids).not.toContain("data-filter-builder");
+    expect(ids).not.toContain("object-transformer");
   });
 });

--- a/apps/web/src/lib/nav.ts
+++ b/apps/web/src/lib/nav.ts
@@ -1,11 +1,21 @@
 import { packageRegistry, toolRegistry, type PackageDefinition, type ToolDefinition } from "@rfjs/web-core";
 
-// Flat sidebar sections (the old package→tool nesting + `claimed` dedupe is gone;
-// a tool's package association is shown as a badge on the tools index instead).
-export function sidebarPackages(): PackageDefinition[] {
-  return packageRegistry;
-}
+export type SidebarToolGroup = {
+  pkg: PackageDefinition;
+  tools: ToolDefinition[];
+};
 
-export function sidebarTools(): ToolDefinition[] {
-  return toolRegistry.filter((tool) => tool.surface === "web");
+// Sidebar tree: each @rfjs package that has at least one web tool becomes a
+// group, keyed by the tool's primary package (relatedPackages[0]). Group order
+// follows packageRegistry (curated); tool order within a group follows
+// toolRegistry. Packages with no web tool are omitted (reachable via /packages).
+export function sidebarToolGroups(): SidebarToolGroup[] {
+  const webTools = toolRegistry.filter((tool) => tool.surface === "web");
+
+  return packageRegistry
+    .map((pkg) => ({
+      pkg,
+      tools: webTools.filter((tool) => tool.relatedPackages?.[0] === pkg.name),
+    }))
+    .filter((group) => group.tools.length > 0);
 }

--- a/docs/superpowers/plans/2026-06-16-web-sidebar-package-groups.md
+++ b/docs/superpowers/plans/2026-06-16-web-sidebar-package-groups.md
@@ -1,0 +1,343 @@
+# Web Sidebar Package Grouping Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reshape the `apps/web` left sidebar from two flat lists (Packages + Tools) into a single tree grouped by `@rfjs/*` package, where each package with at least one web tool is a group header linking to its package page, with its tools nested underneath.
+
+**Architecture:** Pure data-shaping lives in `apps/web/src/lib/nav.ts` (`sidebarToolGroups()`), which folds `toolRegistry` into `{ pkg, tools }[]` keyed by each tool's primary package (`relatedPackages[0]`), in `packageRegistry` order, emitting only packages that have web tools. The `AppSidebar` component renders that shape; it holds no grouping logic. The grouping data (`relatedPackages`) already exists in `@rfjs/web-core` — this is a presentation change, not a data-model change.
+
+**Tech Stack:** Next.js (App Router) + next-intl, TypeScript, Vitest, `@rfjs/web-core` registry, `@rfjs/web-ui` (Seam component).
+
+---
+
+## Reference — current state
+
+- Sidebar component: `apps/web/src/components/layout/app-sidebar.tsx` — renders a `Packages` section (`sidebarPackages()` → whole `packageRegistry`) and a flat `Tools` section (`sidebarTools()` → web tools).
+- Data source: `apps/web/src/lib/nav.ts` exports `sidebarPackages()` and `sidebarTools()`. **These two functions are used ONLY by the sidebar component and `nav.spec.ts`** — after this change they are dead and get replaced by `sidebarToolGroups()`.
+- Registry types (from `@rfjs/web-core`): `ToolDefinition` has `id`, `surface: 'web' | 'workbench'`, `relatedPackages?: string[]`. `PackageDefinition` has `name`, `href`, `status`.
+- i18n: section labels come from `useTranslations("Pages")` → `Pages.toolsTitle` / `Pages.packagesTitle`. Tool titles come from `useTranslations("Tools")` → `Tools.<id>.title` (deep-merged from tool feature folders). **No new i18n keys are needed.**
+- `toolHref(tool)` (`apps/web/src/lib/tool-href.ts`) returns `/tools/<id>` for web tools.
+
+Expected groups from the current registry (group order = registry order):
+
+| Group (package) | web tools |
+| --- | --- |
+| data-filter | data-filter-tester |
+| data-transform | type-converter |
+| jsonb-query | jsonb-query-generator, query-builder |
+| jwt | jwt-decoder |
+| mongo-query | mongo-query-generator |
+| object-utils | object-flatten |
+
+Excluded (no web tool): `data-label`, `pg-toolkit`, `retry`, `tpl-toolkit`. Excluded (workbench surface): `data-filter-builder`, `object-transformer`.
+
+No changeset is required — `apps/web` is a private app, not a published package.
+
+---
+
+## Task 1: Set up the worktree
+
+**Files:** none (git/worktree operations only).
+
+- [ ] **Step 1: Remove the stale, already-merged worktree**
+
+The `feat+web-feature-folders` worktree/branch shipped in PR #169 and is merged into `main`.
+
+Run:
+```bash
+cd /home/royfw/_/code/royfw/rfjs
+git worktree remove .claude/worktrees/feat+web-feature-folders
+git branch -d worktree-feat+web-feature-folders
+```
+Expected: worktree removed; `Deleted branch worktree-feat+web-feature-folders`. If `git branch -d` reports "not fully merged" (it should be merged), stop and investigate rather than force-deleting.
+
+- [ ] **Step 2: Confirm `main` has the spec and this plan committed**
+
+Run:
+```bash
+git -C /home/royfw/_/code/royfw/rfjs log --oneline -3
+git -C /home/royfw/_/code/royfw/rfjs status --short
+```
+Expected: recent commits include the design spec and this plan; working tree clean.
+
+- [ ] **Step 3: Create the feature worktree from main**
+
+Run:
+```bash
+git -C /home/royfw/_/code/royfw/rfjs worktree add -b feat/web-sidebar-package-groups \
+  .claude/worktrees/feat+web-sidebar-package-groups main
+```
+Expected: new worktree at `.claude/worktrees/feat+web-sidebar-package-groups` on branch `feat/web-sidebar-package-groups`.
+
+- [ ] **Step 4: Install deps in the worktree (pnpm workspace)**
+
+Run:
+```bash
+cd /home/royfw/_/code/royfw/rfjs/.claude/worktrees/feat+web-sidebar-package-groups
+pnpm install
+```
+Expected: install completes (lockfile already satisfied → fast).
+
+> **All remaining tasks run inside the worktree** at `.claude/worktrees/feat+web-sidebar-package-groups`. Paths below are relative to that worktree root.
+
+---
+
+## Task 2: Add `sidebarToolGroups()` (TDD)
+
+**Files:**
+- Modify: `apps/web/src/lib/nav.ts`
+- Test: `apps/web/src/lib/nav.spec.ts` (replace existing contents)
+
+- [ ] **Step 1: Replace `nav.spec.ts` with tests for the new function**
+
+Write `apps/web/src/lib/nav.spec.ts` (full file — the old `sidebarPackages`/`sidebarTools` tests are dropped because those functions are being removed):
+
+```ts
+import { packageRegistry, toolRegistry } from "@rfjs/web-core";
+import { describe, expect, it } from "vitest";
+
+import { sidebarToolGroups } from "./nav";
+
+describe("sidebarToolGroups", () => {
+  it("emits groups in packageRegistry order, only packages that have web tools", () => {
+    const webPrimaries = new Set(
+      toolRegistry.filter((t) => t.surface === "web").map((t) => t.relatedPackages?.[0]),
+    );
+    const expected = packageRegistry.map((p) => p.name).filter((name) => webPrimaries.has(name));
+
+    expect(sidebarToolGroups().map((g) => g.pkg.name)).toEqual(expected);
+    // a lib-only package with no web tool must not appear
+    expect(sidebarToolGroups().some((g) => g.pkg.name === "@rfjs/pg-toolkit")).toBe(false);
+  });
+
+  it("places every web tool under exactly one group (no orphans, no dupes)", () => {
+    const webIds = toolRegistry
+      .filter((t) => t.surface === "web")
+      .map((t) => t.id)
+      .sort();
+    const groupedIds = sidebarToolGroups()
+      .flatMap((g) => g.tools.map((t) => t.id))
+      .sort();
+
+    expect(groupedIds).toEqual(webIds);
+  });
+
+  it("places a multi-package tool under its primary package only", () => {
+    const groups = sidebarToolGroups();
+    const jsonb = groups.find((g) => g.pkg.name === "@rfjs/jsonb-query");
+    const dataFilter = groups.find((g) => g.pkg.name === "@rfjs/data-filter");
+
+    expect(jsonb?.tools.map((t) => t.id)).toContain("query-builder");
+    expect(dataFilter?.tools.map((t) => t.id) ?? []).not.toContain("query-builder");
+  });
+
+  it("keeps tools within a group in toolRegistry order", () => {
+    const jsonb = sidebarToolGroups().find((g) => g.pkg.name === "@rfjs/jsonb-query");
+    expect(jsonb?.tools.map((t) => t.id)).toEqual(["jsonb-query-generator", "query-builder"]);
+  });
+
+  it("excludes workbench-surface tools", () => {
+    const ids = sidebarToolGroups().flatMap((g) => g.tools.map((t) => t.id));
+    expect(ids).not.toContain("data-filter-builder");
+    expect(ids).not.toContain("object-transformer");
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run:
+```bash
+pnpm -F web vitest:run nav.spec.ts
+```
+Expected: FAIL — `sidebarToolGroups` is not exported from `./nav` (import/type error or "is not a function").
+
+- [ ] **Step 3: Replace `nav.ts` with the new shaping function**
+
+Write `apps/web/src/lib/nav.ts` (full file — removes the now-dead `sidebarPackages`/`sidebarTools`):
+
+```ts
+import { packageRegistry, toolRegistry, type PackageDefinition, type ToolDefinition } from "@rfjs/web-core";
+
+export type SidebarToolGroup = {
+  pkg: PackageDefinition;
+  tools: ToolDefinition[];
+};
+
+// Sidebar tree: each @rfjs package that has at least one web tool becomes a
+// group, keyed by the tool's primary package (relatedPackages[0]). Group order
+// follows packageRegistry (curated); tool order within a group follows
+// toolRegistry. Packages with no web tool are omitted (reachable via /packages).
+export function sidebarToolGroups(): SidebarToolGroup[] {
+  const webTools = toolRegistry.filter((tool) => tool.surface === "web");
+
+  return packageRegistry
+    .map((pkg) => ({
+      pkg,
+      tools: webTools.filter((tool) => tool.relatedPackages?.[0] === pkg.name),
+    }))
+    .filter((group) => group.tools.length > 0);
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run:
+```bash
+pnpm -F web vitest:run nav.spec.ts
+```
+Expected: PASS — all 5 tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/lib/nav.ts apps/web/src/lib/nav.spec.ts
+git commit -m "feat(web): group sidebar tools by primary @rfjs package"
+```
+
+---
+
+## Task 3: Render the package tree in `AppSidebar`
+
+**Files:**
+- Modify: `apps/web/src/components/layout/app-sidebar.tsx` (full rewrite of the component body)
+
+- [ ] **Step 1: Rewrite the sidebar component**
+
+Write `apps/web/src/components/layout/app-sidebar.tsx` (full file):
+
+```tsx
+"use client";
+
+import { Seam } from "@rfjs/web-ui/components/seam";
+import { useTranslations } from "next-intl";
+
+import { Link, usePathname } from "@/i18n/navigation";
+import { sidebarToolGroups } from "@/lib/nav";
+import { toolHref } from "@/lib/tool-href";
+
+export function AppSidebar() {
+  const t = useTranslations("Tools");
+  const tNav = useTranslations("Pages");
+  const pathname = usePathname();
+  const groups = sidebarToolGroups();
+
+  const toolLinkClass =
+    "flex items-center gap-2 rounded-sm px-2 py-1.5 text-sm transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-intake aria-[current=page]:text-signal";
+  const headerLinkClass =
+    "rounded-sm px-2 py-1.5 font-mono text-xs uppercase tracking-wide text-muted-foreground transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-intake aria-[current=page]:text-signal";
+  const seam = (active: boolean) => (
+    <span className="h-4 w-px">
+      {active ? <Seam state="current" operation="" orientation="vertical" /> : null}
+    </span>
+  );
+
+  return (
+    <nav aria-label={tNav("toolsTitle")} className="flex flex-col gap-5 p-4">
+      {groups.map(({ pkg, tools }) => {
+        const pkgActive = pathname === pkg.href;
+        return (
+          <div key={pkg.name} className="flex flex-col gap-1">
+            <Link
+              href={pkg.href}
+              aria-current={pkgActive ? "page" : undefined}
+              className={headerLinkClass}
+            >
+              {pkg.name.replace("@rfjs/", "")}
+            </Link>
+            {tools.map((tool) => {
+              const href = toolHref(tool);
+              const active = pathname === href;
+              return (
+                <Link
+                  key={tool.id}
+                  href={href}
+                  aria-current={active ? "page" : undefined}
+                  className={toolLinkClass}
+                >
+                  {seam(active)}
+                  {t(`${tool.id}.title`)}
+                </Link>
+              );
+            })}
+          </div>
+        );
+      })}
+    </nav>
+  );
+}
+```
+
+Notes for the implementer:
+- The package name becomes a clickable group header (`/packages/<slug>`); web tools are internal `/tools/<id>` links via `toolHref`.
+- Section labels `Pages.packagesTitle` / the old flat `Tools` heading are gone; one `aria-label` (`Pages.toolsTitle`) names the whole nav. No new i18n keys.
+- Active highlight (`aria-current` + `Seam`) is preserved for both header and tool links.
+
+- [ ] **Step 2: Typecheck**
+
+Run:
+```bash
+pnpm -F web check-types
+```
+Expected: PASS, no errors. (Catches any prop/type mismatch in the component.)
+
+- [ ] **Step 3: Lint**
+
+Run:
+```bash
+pnpm -F web lint
+```
+Expected: PASS, no warnings (eslint runs with `--max-warnings 0`). Confirms no unused imports (`sidebarPackages`/`sidebarTools` are no longer referenced anywhere).
+
+- [ ] **Step 4: Build**
+
+Run:
+```bash
+pnpm -F web build
+```
+Expected: Next.js build succeeds.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/layout/app-sidebar.tsx
+git commit -m "feat(web): render sidebar as @rfjs package tree"
+```
+
+---
+
+## Task 4: Full verification
+
+**Files:** none.
+
+- [ ] **Step 1: Run the web test suite**
+
+Run:
+```bash
+pnpm -F web vitest:run
+```
+Expected: all tests pass (including `nav.spec.ts` and unchanged tool specs).
+
+- [ ] **Step 2: Manual smoke check (optional but recommended)**
+
+Run:
+```bash
+pnpm -F web dev
+```
+Then open `http://localhost:3000`, confirm the sidebar shows 6 package groups in registry order, `jsonb-query` lists both `JSONB Query Generator` and `Query Builder`, clicking a package header navigates to `/packages/<slug>`, and the active tool/package highlights correctly. Stop the dev server when done.
+
+- [ ] **Step 3: Verify the diff scope**
+
+Run:
+```bash
+git diff --stat main...HEAD
+```
+Expected: only `apps/web/src/lib/nav.ts`, `apps/web/src/lib/nav.spec.ts`, `apps/web/src/components/layout/app-sidebar.tsx` changed (plus the spec/plan docs already on main).
+
+---
+
+## Self-Review (completed during plan authoring)
+
+- **Spec coverage:** data shaping in `lib/nav.ts` (Task 2) ✓; package-tree render (Task 3) ✓; no new i18n keys (Task 3 note) ✓; only-packages-with-web-tools + registry order + primary-package + no-orphans tests (Task 2) ✓; folder structure unchanged (only 3 files) ✓; worktree cleanup + create (Task 1) ✓.
+- **Placeholder scan:** none — every code/test step has full content.
+- **Type consistency:** `SidebarToolGroup { pkg, tools }` defined in Task 2, consumed with the same `pkg`/`tools` destructuring in Task 3; `sidebarToolGroups` named identically throughout.

--- a/docs/superpowers/specs/2026-06-16-web-sidebar-package-groups-design.md
+++ b/docs/superpowers/specs/2026-06-16-web-sidebar-package-groups-design.md
@@ -1,0 +1,128 @@
+# apps/web 側欄依 @rfjs package 分組 — 設計文件
+
+- 日期：2026-06-16
+- 範圍：`apps/web` 左側導覽列
+- 狀態：設計定案，待寫實作計畫
+
+## 目標
+
+把 `apps/web` 左側欄目前的「兩條平鋪清單（Packages + Tools）」改成**單一 package 樹**：以 `@rfjs/*` package 作為分類軸，每個 package 是一個群組標題，底下掛該 package 對應的 web 工具。
+
+## 背景：目前狀態
+
+側欄 `apps/web/src/components/layout/app-sidebar.tsx` 渲染兩個獨立區段：
+
+- **Packages**：`sidebarPackages()` 回傳整個 `packageRegistry`，每個 package 連到 `/packages/:slug`。
+- **Tools**：`sidebarTools()` 回傳 `toolRegistry` 中 `surface === 'web'` 的工具，平鋪、無分組。
+
+資料來源在 `apps/web/src/lib/nav.ts`，型別與資料來自 `@rfjs/web-core` 的 `packageRegistry` / `toolRegistry`。
+
+關鍵：分組所需資料**已存在**，不需改資料模型。
+
+- 每個 `ToolDefinition` 已有 `relatedPackages: string[]`（例：`query-builder → ['@rfjs/jsonb-query', '@rfjs/data-filter']`）。
+- 每個 `PackageDefinition` 已有 `href`、`status`。
+
+因此這是**呈現層**的改動，不是資料模型改動。
+
+## 已定案的設計決策
+
+1. **側欄形狀**：融合成 package 樹。原本獨立的 Packages / Tools 兩區消失，合成一棵以 package 為鍵的樹。
+2. **多 package 工具歸屬**：以 `relatedPackages[0]`（主 package）為準，工具只掛在主群組下，不重複出現。`query-builder` 歸在 `jsonb-query`。
+3. **收合**：不做收合，全部展開（目前工具數量少，收合屬過度設計）。
+4. **沒有 web 工具的 package**：不顯示在側欄（純 lib 的入口交給 `/packages` 頁）。
+5. **範圍**：只動左側欄。home 頁、`/packages` 頁這次不動。
+6. **分組邏輯位置**：放在 `lib/nav.ts`（既有的側欄資料來源），元件只負責渲染。
+
+## 架構
+
+### 1. 資料塑形 — `apps/web/src/lib/nav.ts`
+
+新增純函式 `sidebarToolGroups()`：
+
+```ts
+export type SidebarToolGroup = {
+  pkg: PackageDefinition;
+  tools: ToolDefinition[];
+};
+
+export function sidebarToolGroups(): SidebarToolGroup[];
+```
+
+規則：
+
+- 取 `toolRegistry` 過濾 `surface === 'web'`。
+- 依每個工具的 `relatedPackages[0]`（主 package 名稱）分組。
+- 群組順序沿用 `packageRegistry` 既有順序（人工策展過的順序），只輸出「至少有一個 web 工具」的 package。
+- 群組內工具順序沿用 `toolRegistry` 順序。
+- 每組用主 package 名稱從 `packageRegistry` 反查 `PackageDefinition`（取得 `href`、`status`）。
+
+孤兒處理：每個 web 工具的主 package 都必須能在 `packageRegistry` 反查到。若反查不到，視為設定錯誤（由測試把關，見下），而非靜默丟棄該工具。
+
+既有的 `sidebarPackages()` / `sidebarTools()`：若仍有其他消費者就保留；側欄改成只吃 `sidebarToolGroups()`。實作時確認是否還有別處引用，沒有引用的就一併移除。
+
+#### 預期輸出（依目前 registry）
+
+| 群組（package） | web 工具 |
+| --- | --- |
+| data-filter | data-filter-tester |
+| data-transform | type-converter |
+| jsonb-query | jsonb-query-generator, query-builder |
+| jwt | jwt-decoder |
+| mongo-query | mongo-query-generator |
+| object-utils | object-flatten |
+
+不出現：`data-label`、`pg-toolkit`、`retry`、`tpl-toolkit`（無 web 工具）。
+
+### 2. 側欄渲染 — `apps/web/src/components/layout/app-sidebar.tsx`
+
+從「Packages 區 + 平鋪 Tools 區」改為單一 package 樹：
+
+- 頂部保留一個區段標題，沿用既有 i18n key `Pages.toolsTitle`。
+- **群組標題** = package 名（去掉 `@rfjs/` 前綴），標題本身連到 `pkg.href`（`/packages/:slug`），與目前 package 連結呈現方式一致。
+- **子項** = 該群組的工具，標題用既有 `t('Tools.${tool.id}.title')`，連到 `toolHref(tool)`。
+- 全部展開，不收合。
+- 保留現有的 active 高亮（`Seam`）機制；package 標題與工具子項都要能反映 `aria-current`。
+- `nav` 的 `aria-label` 沿用合理的既有 key（例如 `Pages.toolsTitle`）。
+
+### 3. i18n — `messages/{en,zh-TW}.json`
+
+不需新增 key：
+
+- 區段標題沿用 `Pages.toolsTitle`。
+- 群組標題用 package 名稱（不翻譯，與現況相同）。
+- 工具標題沿用既有 deep-merge 的 `Tools` namespace（各工具 feature folder 提供，不動）。
+- 側欄不再使用 `Pages.packagesTitle` 當區段標題；該 key 仍被 `/packages` 頁等其他地方使用，故保留。
+
+## 測試
+
+針對 `sidebarToolGroups()` 寫單元測試（唯一具邏輯的部分）：
+
+- 分組正確：每個 web 工具落在其 `relatedPackages[0]` 對應的群組。
+- 群組順序＝`packageRegistry` 順序。
+- 群組內工具順序＝`toolRegistry` 順序。
+- 只輸出有 web 工具的 package（`data-label` / `pg-toolkit` / `retry` / `tpl-toolkit` 不出現）。
+- 多 package 工具（`query-builder`）只出現在主 package（`jsonb-query`）下，不在 `data-filter` 重複。
+- 無孤兒：每個 web 工具的主 package 都能在 `packageRegistry` 反查到（若有人新增工具忘了對應 package，此測試讓 CI 失敗，而非工具默默從側欄消失）。
+
+元件本身靠 `typecheck` + `build` 把關。
+
+## 資料夾架構
+
+**不需要調整。** feature-folder 結構維持原樣。本次只動三個既有檔案：
+
+- `apps/web/src/lib/nav.ts`
+- `apps/web/src/components/layout/app-sidebar.tsx`
+- （若需要）`apps/web/src/messages/{en,zh-TW}.json` — 預期不需改，因不新增 key
+
+## 非目標（YAGNI）
+
+- 群組收合/展開狀態。
+- home 頁、`/packages` 頁的同步分組（可列為後續）。
+- 工具在多個 package 群組下重複顯示。
+- 任何資料模型 / registry schema 改動。
+
+## Worktree 計畫
+
+- 命令訊息與 PR 用英文；本設計文件用繁中。
+- 清掉已合併的舊 worktree `feat+web-feature-folders`（branch 已隨 PR #169 進 main）。
+- 開新 worktree：branch `feat/web-sidebar-package-groups`，路徑 `.claude/worktrees/feat+web-sidebar-package-groups`。


### PR DESCRIPTION
## Summary
- Reshape the `apps/web` left sidebar from two flat lists (Packages + Tools) into a single tree grouped by `@rfjs/*` package. Each package that has at least one web tool becomes a clickable group header (links to `/packages/<slug>`) with its tools nested underneath.
- Add `sidebarToolGroups()` to `apps/web/src/lib/nav.ts` — a pure function that folds the web-surface tools into `{ pkg, tools }[]` keyed by each tool's primary package (`relatedPackages[0]`), in `packageRegistry` order, omitting packages with no web tools. Replaces the now-unused `sidebarPackages()`/`sidebarTools()`.
- Grouping logic lives in `lib/nav.ts`; `AppSidebar` only renders. Multi-package tools (e.g. `query-builder`) appear under their primary package only. No new i18n keys; active highlight (`aria-current` + `Seam`) preserved.

## Design / Plan
- Spec: `docs/superpowers/specs/2026-06-16-web-sidebar-package-groups-design.md`
- Plan: `docs/superpowers/plans/2026-06-16-web-sidebar-package-groups.md`

## Test Plan
- [x] `pnpm -F web vitest:run` — 99/99 pass (incl. 5 new `nav.spec.ts` tests: registry-order grouping, no-orphans/dupes, primary-package placement, intra-group order, workbench exclusion)
- [x] `pnpm -F web check-types` / `pnpm -F web lint` / `pnpm -F web build` pass
- [ ] Visual check: sidebar shows 6 package groups in registry order; `jsonb-query` lists both JSONB Query Generator and Query Builder; clicking a package header navigates to its detail page

## Follow-up (non-blocking)
- Harden the "every web tool has a primary package" invariant at the `@rfjs/web-core` schema level (a `.refine()` on `toolDefinitionSchema`) so a mis-registered tool fails at the registry test rather than only at the sidebar nav test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)