### PR TITLE
feat(web-core): require a primary package on web-surface tools

### DIFF
--- a/packages/web-core/src/registry/registry.spec.ts
+++ b/packages/web-core/src/registry/registry.spec.ts
@@ -26,6 +26,30 @@ describe('toolRegistry', () => {
   });
 });
 
+describe('toolDefinitionSchema web-surface guard', () => {
+  const base = { id: 'x', category: 'inspect', status: 'planned' } as const;
+
+  it('rejects a web tool with no relatedPackages', () => {
+    expect(() => toolDefinitionSchema.parse({ ...base, surface: 'web' })).toThrow();
+  });
+
+  it('rejects a web tool with an empty relatedPackages array', () => {
+    expect(() =>
+      toolDefinitionSchema.parse({ ...base, surface: 'web', relatedPackages: [] }),
+    ).toThrow();
+  });
+
+  it('allows a web tool that declares a primary package', () => {
+    expect(() =>
+      toolDefinitionSchema.parse({ ...base, surface: 'web', relatedPackages: ['@rfjs/jwt'] }),
+    ).not.toThrow();
+  });
+
+  it('allows a workbench tool with no relatedPackages', () => {
+    expect(() => toolDefinitionSchema.parse({ ...base, surface: 'workbench' })).not.toThrow();
+  });
+});
+
 describe('tool surfaces', () => {
   it('every tool declares a surface', () => {
     for (const tool of toolRegistry) {

--- a/packages/web-core/src/registry/schemas.ts
+++ b/packages/web-core/src/registry/schemas.ts
@@ -13,14 +13,21 @@ export const registryStatusSchema = z.enum(['ready', 'preview', 'planned']);
 
 export const toolSurfaceSchema = z.enum(['web', 'workbench']);
 
-export const toolDefinitionSchema = z.object({
-  id: z.string().min(1),
-  category: toolCategorySchema,
-  surface: toolSurfaceSchema,
-  status: registryStatusSchema,
-  relatedPackages: z.array(z.string().startsWith('@rfjs/')).optional(),
-  tags: z.array(z.string()).optional(),
-});
+export const toolDefinitionSchema = z
+  .object({
+    id: z.string().min(1),
+    category: toolCategorySchema,
+    surface: toolSurfaceSchema,
+    status: registryStatusSchema,
+    relatedPackages: z.array(z.string().startsWith('@rfjs/')).optional(),
+    tags: z.array(z.string()).optional(),
+  })
+  // A web-surface tool drives the sidebar's package tree via its primary package
+  // (relatedPackages[0]); without one it would be silently dropped from the nav.
+  .refine((tool) => tool.surface !== 'web' || (tool.relatedPackages?.length ?? 0) > 0, {
+    error: 'web-surface tools must declare at least one relatedPackages entry',
+    path: ['relatedPackages'],
+  });
 
 export const packageDefinitionSchema = z.object({
   name: z.string().startsWith('@rfjs/'),


### PR DESCRIPTION
## Summary
- Add a `.refine()` to `toolDefinitionSchema` (`@rfjs/web-core`) requiring every `web`-surface tool to declare at least one `relatedPackages` entry. `workbench` tools are unaffected.
- Closes the follow-up from #170: the sidebar package tree keys each web tool by its primary package (`relatedPackages[0]`). Previously a web tool registered without one would be silently dropped from the nav, caught only by `apps/web`'s `nav` test. Now it fails registry validation at the source.

## Test Plan
- [x] `pnpm -F @rfjs/web-core vitest:run` — 12/12 pass (4 new guard tests: rejects web tool with no / empty `relatedPackages`, allows web tool with a primary package, allows workbench tool without one)
- [x] `pnpm -F @rfjs/web-core check-types` / `lint` pass
- [x] `pnpm -F web check-types` passes — `ToolDefinition` inferred type unchanged by the refine

🤖 Generated with [Claude Code](https://claude.com/claude-code)