### PR TITLE
feat(web/query-builder): pg-filter engine + column/jsonb field-kind + 3-column UI

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@rfjs/data-filter": "workspace:*",
+    "@rfjs/pg-filter": "workspace:*",
     "@rfjs/data-transform": "workspace:*",
     "@rfjs/jsonb-query": "workspace:*",
     "@rfjs/jwt": "workspace:*",

--- a/apps/web/src/tools/query-builder/logic/colors.spec.ts
+++ b/apps/web/src/tools/query-builder/logic/colors.spec.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from "vitest";
+import { logicColor, dataTypeColor } from "./colors";
+
+describe("colors", () => {
+  it("returns a stable token class per logic operator", () => {
+    expect(logicColor("and")).toBe(logicColor("and"));
+    expect(logicColor("and")).not.toBe(logicColor("or"));
+    expect(logicColor("and")).toMatch(/^text-/);
+  });
+
+  it("returns a token class per dataType and a fallback", () => {
+    expect(dataTypeColor("string")).toMatch(/^text-/);
+    expect(dataTypeColor("unknown")).toMatch(/^text-/);
+  });
+});

--- a/apps/web/src/tools/query-builder/logic/colors.ts
+++ b/apps/web/src/tools/query-builder/logic/colors.ts
@@ -1,0 +1,25 @@
+import type { LogicOp } from "./types";
+
+const LOGIC: Record<LogicOp, string> = {
+  and: "text-signal",
+  or: "text-intake",
+  nor: "text-yield",
+  not: "text-fault",
+};
+
+const DATATYPE: Record<string, string> = {
+  string: "text-signal",
+  numeric: "text-intake",
+  date: "text-yield",
+  boolean: "text-fault",
+  object: "text-muted-foreground",
+  array: "text-muted-foreground",
+};
+
+export function logicColor(op: LogicOp): string {
+  return LOGIC[op];
+}
+
+export function dataTypeColor(dataType: string): string {
+  return DATATYPE[dataType] ?? "text-muted-foreground";
+}

--- a/apps/web/src/tools/query-builder/logic/engines/data-filter.spec.ts
+++ b/apps/web/src/tools/query-builder/logic/engines/data-filter.spec.ts
@@ -34,7 +34,7 @@ describe("dataFilterEngine.compile", () => {
       kind: "group", id: "g", logic: "and",
       children: [{ kind: "condition", id: "c", field: "age", dataType: "numeric", operator: "gt", value: 18 }],
     };
-    const out = dataFilterEngine.compile(treeToFilterGroup(tree));
+    const out = dataFilterEngine.compile(treeToFilterGroup(tree), { fields: [] });
     expect(out).toEqual({
       ok: true,
       primary: JSON.stringify({ logic: "and", filters: [{ field: "age", dataType: "numeric", operator: "gt", value: 18 }] }, null, 2),

--- a/apps/web/src/tools/query-builder/logic/engines/index.spec.ts
+++ b/apps/web/src/tools/query-builder/logic/engines/index.spec.ts
@@ -3,12 +3,13 @@ import { describe, expect, it } from "vitest";
 import { ENGINE_IDS, getEngine } from "./index";
 
 describe("engine registry", () => {
-  it("lists both engine ids, jsonb first", () => {
-    expect(ENGINE_IDS).toEqual(["jsonb", "data-filter"]);
+  it("lists all engine ids, jsonb first", () => {
+    expect(ENGINE_IDS).toEqual(["jsonb", "data-filter", "pg-filter"]);
   });
 
   it("resolves an engine by id", () => {
     expect(getEngine("jsonb").id).toBe("jsonb");
     expect(getEngine("data-filter").id).toBe("data-filter");
+    expect(getEngine("pg-filter").id).toBe("pg-filter");
   });
 });

--- a/apps/web/src/tools/query-builder/logic/engines/index.ts
+++ b/apps/web/src/tools/query-builder/logic/engines/index.ts
@@ -1,17 +1,26 @@
 import { dataFilterEngine } from "./data-filter";
 import { jsonbEngine } from "./jsonb";
+import { pgFilterEngine } from "./pg-filter";
 import type { Engine, EngineId } from "./types";
 
-// Extension point for a mongo engine: add mongoEngine and register it here.
 const ENGINES: Record<EngineId, Engine> = {
   jsonb: jsonbEngine,
   "data-filter": dataFilterEngine,
+  "pg-filter": pgFilterEngine,
 };
 
-export const ENGINE_IDS: EngineId[] = ["jsonb", "data-filter"];
+export const ENGINE_IDS: EngineId[] = ["jsonb", "data-filter", "pg-filter"];
 
 export function getEngine(id: EngineId): Engine {
   return ENGINES[id];
 }
 
-export type { Engine, EngineId, OperatorSpec, OperatorArity, EngineOutput } from "./types";
+export type {
+  Engine,
+  EngineId,
+  OperatorSpec,
+  OperatorArity,
+  EngineOutput,
+  CompileContext,
+  CompileField,
+} from "./types";

--- a/apps/web/src/tools/query-builder/logic/engines/jsonb.spec.ts
+++ b/apps/web/src/tools/query-builder/logic/engines/jsonb.spec.ts
@@ -43,7 +43,7 @@ describe("jsonbEngine.compile", () => {
   };
 
   it("produces a parameterized where + values", () => {
-    const out = jsonbEngine.compile(treeToFilterGroup(tree));
+    const out = jsonbEngine.compile(treeToFilterGroup(tree), { fields: [] });
     expect(out).toEqual({
       ok: true,
       primary: '(("data" #>> $1)::numeric > $2)',
@@ -52,7 +52,7 @@ describe("jsonbEngine.compile", () => {
   });
 
   it("reports a build failure as an error result", () => {
-    const out = jsonbEngine.compile({ logic: "and", filters: [{ field: "x" } as never] });
+    const out = jsonbEngine.compile({ logic: "and", filters: [{ field: "x" } as never] }, { fields: [] });
     expect(out.ok).toBe(false);
   });
 });

--- a/apps/web/src/tools/query-builder/logic/engines/pg-filter.spec.ts
+++ b/apps/web/src/tools/query-builder/logic/engines/pg-filter.spec.ts
@@ -67,4 +67,58 @@ describe("pgFilterEngine.compile", () => {
     const out = pgFilterEngine.compile(group, ctx([{ path: "n", kind: "column", dataType: "numeric" }]));
     expect(out.ok).toBe(false);
   });
+
+  it("renders a nested group mixing column + jsonb with contiguous params", () => {
+    const group = {
+      logic: "and",
+      filters: [
+        { field: "name", dataType: "string", operator: "eq", value: "a" },
+        {
+          logic: "or",
+          filters: [
+            { field: "score", dataType: "numeric", operator: "gt", value: 1 },
+            { field: "age", dataType: "numeric", operator: "lt", value: 9 },
+          ],
+        },
+      ],
+    };
+    const out = pgFilterEngine.compile(
+      group,
+      ctx([
+        { path: "name", kind: "column", dataType: "string" },
+        { path: "score", kind: "jsonb", dataType: "numeric" },
+        { path: "age", kind: "column", dataType: "numeric" },
+      ]),
+    );
+    expect(out.ok).toBe(true);
+    if (out.ok) {
+      expect(out.primary).toContain("name");
+      expect(out.primary).toContain("data");
+      expect(out.primary).toContain("age");
+      expect(out.primary).toContain("$1");
+      expect(out.primary).toContain("$2");
+      expect(out.primary).toContain("$3");
+    }
+  });
+
+  it("passes an elemmatch jsonb leaf (nested filters) through to buildPgFilter", () => {
+    const group = {
+      logic: "and",
+      filters: [
+        {
+          field: "tags",
+          dataType: "array",
+          elementType: "object",
+          operator: "elemmatch",
+          filters: {
+            logic: "and",
+            filters: [{ field: "k", dataType: "string", operator: "eq", value: "v" }],
+          },
+        },
+      ],
+    };
+    const out = pgFilterEngine.compile(group, ctx([{ path: "tags", kind: "jsonb", dataType: "array", elementType: "object" }]));
+    expect(out.ok).toBe(true);
+    if (out.ok) expect(out.primary).toContain("data");
+  });
 });

--- a/apps/web/src/tools/query-builder/logic/engines/pg-filter.spec.ts
+++ b/apps/web/src/tools/query-builder/logic/engines/pg-filter.spec.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import { pgFilterEngine } from "./pg-filter";
+import type { CompileContext } from "./types";
+
+const ctx = (fields: CompileContext["fields"]): CompileContext => ({ fields });
+
+describe("pgFilterEngine.operators", () => {
+  it("returns column operators for column-kind fields", () => {
+    const ops = pgFilterEngine.operators("string", undefined, "column").map((o) => o.op);
+    expect(ops).toContain("contains");
+    expect(ops).toContain("startswith");
+    expect(ops).toContain("eq");
+    expect(ops).not.toContain("icontains");
+  });
+
+  it("returns jsonb operators for jsonb-kind fields", () => {
+    const ops = pgFilterEngine.operators("string", undefined, "jsonb").map((o) => o.op);
+    expect(ops).toContain("icontains");
+  });
+});
+
+describe("pgFilterEngine.compile", () => {
+  it("renders a pure column condition", () => {
+    const group = { logic: "and", filters: [{ field: "name", dataType: "string", operator: "contains", value: "ab" }] };
+    const out = pgFilterEngine.compile(group, ctx([{ path: "name", kind: "column", dataType: "string" }]));
+    expect(out.ok).toBe(true);
+    if (out.ok) {
+      expect(out.primary).toContain("name");
+      expect(out.primary).toContain("$1");
+      expect(out.secondary).toContain("ab");
+    }
+  });
+
+  it("renders a pure jsonb condition against the data column", () => {
+    const group = { logic: "and", filters: [{ field: "score", dataType: "numeric", operator: "gt", value: 80 }] };
+    const out = pgFilterEngine.compile(group, ctx([{ path: "score", kind: "jsonb", dataType: "numeric" }]));
+    expect(out.ok).toBe(true);
+    if (out.ok) expect(out.primary).toContain("data");
+  });
+
+  it("mixes column + jsonb leaves with contiguous params", () => {
+    const group = {
+      logic: "and",
+      filters: [
+        { field: "name", dataType: "string", operator: "eq", value: "x" },
+        { field: "score", dataType: "numeric", operator: "gt", value: 5 },
+      ],
+    };
+    const out = pgFilterEngine.compile(
+      group,
+      ctx([
+        { path: "name", kind: "column", dataType: "string" },
+        { path: "score", kind: "jsonb", dataType: "numeric" },
+      ]),
+    );
+    expect(out.ok).toBe(true);
+    if (out.ok) {
+      expect(out.primary).toContain("name");
+      expect(out.primary).toContain("data");
+      expect(out.primary).toContain("$1");
+      expect(out.primary).toContain("$2");
+    }
+  });
+
+  it("returns ok:false when a column gets an unsupported operator", () => {
+    const group = { logic: "and", filters: [{ field: "n", dataType: "numeric", operator: "contains", value: "x" }] };
+    const out = pgFilterEngine.compile(group, ctx([{ path: "n", kind: "column", dataType: "numeric" }]));
+    expect(out.ok).toBe(false);
+  });
+});

--- a/apps/web/src/tools/query-builder/logic/engines/pg-filter.ts
+++ b/apps/web/src/tools/query-builder/logic/engines/pg-filter.ts
@@ -1,0 +1,76 @@
+import { buildPgFilter, type PgFilterConfig, type PgFilterGroup, type PgLeaf } from "@rfjs/pg-filter";
+
+import type { FilterConditionLike, FilterGroupLike } from "../compile";
+import { mapColumnType } from "../field-kind";
+import type { FieldKind } from "../types";
+import { arityOf } from "./arity";
+import { jsonbEngine } from "./jsonb";
+import type { CompileContext, Engine, OperatorSpec } from "./types";
+
+const NULL_OPS = ["isnull", "isnotnull"];
+const COLUMN_TEXT_OPS = ["eq", "neq", "contains", "startswith", "gt", "gte", "lt", "lte", ...NULL_OPS];
+const COLUMN_NUMERIC_OPS = ["eq", "neq", "gt", "gte", "lt", "lte", ...NULL_OPS]; // numeric + date(timestamp)
+const COLUMN_BOOL_OPS = ["eq", "neq", ...NULL_OPS];
+
+function columnOps(dataType: string): string[] {
+  if (dataType === "string") return COLUMN_TEXT_OPS;
+  if (dataType === "boolean") return COLUMN_BOOL_OPS;
+  return COLUMN_NUMERIC_OPS; // numeric, date
+}
+
+function toSpecs(ops: string[]): OperatorSpec[] {
+  return [...new Set(ops)].map((op) => ({ op, arity: arityOf(op) }));
+}
+
+function toPgLeaf(c: FilterConditionLike, kindByPath: Map<string, FieldKind>): PgLeaf {
+  const kind = kindByPath.get(c.field) ?? "jsonb";
+  if (kind === "column") {
+    return { target: "column", column: c.field, operator: c.operator, value: c.value } as PgLeaf;
+  }
+  const leaf = {
+    target: "jsonb",
+    field: c.field,
+    dataType: c.dataType,
+    operator: c.operator,
+    ...(c.value !== undefined ? { value: c.value } : {}),
+    ...(c.elementType ? { elementType: c.elementType } : {}),
+    ...(c.filters ? { filters: c.filters } : {}),
+  };
+  return leaf as unknown as PgLeaf;
+}
+
+function toPgGroup(group: FilterGroupLike, kindByPath: Map<string, FieldKind>): PgFilterGroup {
+  return {
+    logic: group.logic as PgFilterGroup["logic"],
+    filters: group.filters.map((node) =>
+      "logic" in node
+        ? toPgGroup(node as FilterGroupLike, kindByPath)
+        : toPgLeaf(node as FilterConditionLike, kindByPath),
+    ),
+  };
+}
+
+export const pgFilterEngine: Engine = {
+  id: "pg-filter",
+  label: "pg-filter (column + jsonb)",
+  operators(dataType, elementType, kind) {
+    if (kind === "column") return toSpecs(columnOps(dataType));
+    return jsonbEngine.operators(dataType, elementType);
+  },
+  compile(group, ctx: CompileContext) {
+    try {
+      const kindByPath = new Map(ctx.fields.map((f) => [f.path, f.kind]));
+      const columns = ctx.fields
+        .filter((f) => f.kind === "column")
+        .reduce<PgFilterConfig["columns"]>((acc, f) => {
+          acc[f.path] = { column: f.path, type: mapColumnType(f.dataType) };
+          return acc;
+        }, {});
+      const config: PgFilterConfig = { columns, jsonb: { column: "data", dialect: "legacy" } };
+      const { where, values } = buildPgFilter(config, { filter: toPgGroup(group, kindByPath) });
+      return { ok: true, primary: where, secondary: JSON.stringify(values, null, 2) };
+    } catch (err) {
+      return { ok: false, error: err instanceof Error ? err.message : "queryFailed" };
+    }
+  },
+};

--- a/apps/web/src/tools/query-builder/logic/engines/pg-filter.ts
+++ b/apps/web/src/tools/query-builder/logic/engines/pg-filter.ts
@@ -2,10 +2,9 @@ import { buildPgFilter, type PgFilterConfig, type PgFilterGroup, type PgLeaf } f
 
 import type { FilterConditionLike, FilterGroupLike } from "../compile";
 import { mapColumnType } from "../field-kind";
-import type { FieldKind } from "../types";
 import { arityOf } from "./arity";
 import { jsonbEngine } from "./jsonb";
-import type { CompileContext, Engine, OperatorSpec } from "./types";
+import type { CompileContext, CompileField, Engine, OperatorSpec } from "./types";
 
 const NULL_OPS = ["isnull", "isnotnull"];
 const COLUMN_TEXT_OPS = ["eq", "neq", "contains", "startswith", "gt", "gte", "lt", "lte", ...NULL_OPS];
@@ -22,30 +21,31 @@ function toSpecs(ops: string[]): OperatorSpec[] {
   return [...new Set(ops)].map((op) => ({ op, arity: arityOf(op) }));
 }
 
-function toPgLeaf(c: FilterConditionLike, kindByPath: Map<string, FieldKind>): PgLeaf {
-  const kind = kindByPath.get(c.field) ?? "jsonb";
+function toPgLeaf(c: FilterConditionLike, byPath: Map<string, CompileField>): PgLeaf {
+  const f = byPath.get(c.field);
+  const kind = f?.kind ?? "jsonb";
   if (kind === "column") {
     return { target: "column", column: c.field, operator: c.operator, value: c.value } as PgLeaf;
   }
   const leaf = {
     target: "jsonb",
     field: c.field,
-    dataType: c.dataType,
+    dataType: f?.dataType ?? c.dataType,
     operator: c.operator,
     ...(c.value !== undefined ? { value: c.value } : {}),
-    ...(c.elementType ? { elementType: c.elementType } : {}),
+    ...((f?.elementType ?? c.elementType) ? { elementType: f?.elementType ?? c.elementType } : {}),
     ...(c.filters ? { filters: c.filters } : {}),
   };
   return leaf as unknown as PgLeaf;
 }
 
-function toPgGroup(group: FilterGroupLike, kindByPath: Map<string, FieldKind>): PgFilterGroup {
+function toPgGroup(group: FilterGroupLike, byPath: Map<string, CompileField>): PgFilterGroup {
   return {
     logic: group.logic as PgFilterGroup["logic"],
     filters: group.filters.map((node) =>
       "logic" in node
-        ? toPgGroup(node as FilterGroupLike, kindByPath)
-        : toPgLeaf(node as FilterConditionLike, kindByPath),
+        ? toPgGroup(node as FilterGroupLike, byPath)
+        : toPgLeaf(node as FilterConditionLike, byPath),
     ),
   };
 }
@@ -59,7 +59,7 @@ export const pgFilterEngine: Engine = {
   },
   compile(group, ctx: CompileContext) {
     try {
-      const kindByPath = new Map(ctx.fields.map((f) => [f.path, f.kind]));
+      const byPath = new Map(ctx.fields.map((f) => [f.path, f]));
       const columns = ctx.fields
         .filter((f) => f.kind === "column")
         .reduce<PgFilterConfig["columns"]>((acc, f) => {
@@ -67,7 +67,7 @@ export const pgFilterEngine: Engine = {
           return acc;
         }, {});
       const config: PgFilterConfig = { columns, jsonb: { column: "data", dialect: "legacy" } };
-      const { where, values } = buildPgFilter(config, { filter: toPgGroup(group, kindByPath) });
+      const { where, values } = buildPgFilter(config, { filter: toPgGroup(group, byPath) });
       return { ok: true, primary: where, secondary: JSON.stringify(values, null, 2) };
     } catch (err) {
       return { ok: false, error: err instanceof Error ? err.message : "queryFailed" };

--- a/apps/web/src/tools/query-builder/logic/engines/types.ts
+++ b/apps/web/src/tools/query-builder/logic/engines/types.ts
@@ -1,4 +1,5 @@
 import type { FilterGroupLike } from "../compile";
+import type { ElementType, FieldKind, FieldType } from "../types";
 
 export type OperatorArity = "none" | "one" | "two" | "list";
 
@@ -9,6 +10,17 @@ export interface OperatorSpec {
 
 export type EngineId = "jsonb" | "data-filter";
 
+export interface CompileField {
+  path: string;
+  kind: FieldKind;
+  dataType: FieldType;
+  elementType?: ElementType;
+}
+
+export interface CompileContext {
+  fields: CompileField[];
+}
+
 export type EngineOutput =
   | { ok: true; primary: string; secondary?: string }
   | { ok: false; error: string };
@@ -16,6 +28,6 @@ export type EngineOutput =
 export interface Engine {
   id: EngineId;
   label: string;
-  operators(dataType: string, elementType?: string): OperatorSpec[];
-  compile(group: FilterGroupLike): EngineOutput;
+  operators(dataType: string, elementType?: string, kind?: FieldKind): OperatorSpec[];
+  compile(group: FilterGroupLike, ctx: CompileContext): EngineOutput;
 }

--- a/apps/web/src/tools/query-builder/logic/engines/types.ts
+++ b/apps/web/src/tools/query-builder/logic/engines/types.ts
@@ -8,7 +8,7 @@ export interface OperatorSpec {
   arity: OperatorArity;
 }
 
-export type EngineId = "jsonb" | "data-filter";
+export type EngineId = "jsonb" | "data-filter" | "pg-filter";
 
 export interface CompileField {
   path: string;

--- a/apps/web/src/tools/query-builder/logic/field-create.spec.ts
+++ b/apps/web/src/tools/query-builder/logic/field-create.spec.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { addInferredField } from "./field-create";
+import type { FieldSchema } from "./types";
+
+const base: FieldSchema[] = [{ path: "name", dataType: "string", include: true, kind: "jsonb" }];
+
+describe("addInferredField", () => {
+  it("appends a new jsonb string field when the path is unknown", () => {
+    const next = addInferredField(base, "newKey");
+    expect(next).toHaveLength(2);
+    expect(next[1]).toEqual({ path: "newKey", dataType: "string", include: true, kind: "jsonb" });
+  });
+
+  it("returns the same array when the path already exists", () => {
+    const next = addInferredField(base, "name");
+    expect(next).toBe(base);
+  });
+
+  it("ignores empty paths", () => {
+    expect(addInferredField(base, "")).toBe(base);
+  });
+});

--- a/apps/web/src/tools/query-builder/logic/field-create.ts
+++ b/apps/web/src/tools/query-builder/logic/field-create.ts
@@ -1,0 +1,7 @@
+import type { FieldSchema } from "./types";
+
+// Append a new field (default jsonb string) when the user types a key not in the schema.
+export function addInferredField(schema: FieldSchema[], path: string): FieldSchema[] {
+  if (!path || schema.some((f) => f.path === path)) return schema;
+  return [...schema, { path, dataType: "string", include: true, kind: "jsonb" }];
+}

--- a/apps/web/src/tools/query-builder/logic/field-kind.spec.ts
+++ b/apps/web/src/tools/query-builder/logic/field-kind.spec.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { canBeColumn, mapColumnType } from "./field-kind";
+
+describe("field-kind", () => {
+  it("maps scalar dataTypes to SQL column types", () => {
+    expect(mapColumnType("string")).toBe("text");
+    expect(mapColumnType("numeric")).toBe("numeric");
+    expect(mapColumnType("date")).toBe("timestamp");
+    expect(mapColumnType("boolean")).toBe("boolean");
+  });
+
+  it("allows only scalar dataTypes as columns", () => {
+    expect(canBeColumn("string")).toBe(true);
+    expect(canBeColumn("numeric")).toBe(true);
+    expect(canBeColumn("date")).toBe(true);
+    expect(canBeColumn("boolean")).toBe(true);
+    expect(canBeColumn("object")).toBe(false);
+    expect(canBeColumn("array")).toBe(false);
+  });
+
+  it("throws when mapping a non-column dataType", () => {
+    expect(() => mapColumnType("object")).toThrow();
+    expect(() => mapColumnType("array")).toThrow();
+  });
+});

--- a/apps/web/src/tools/query-builder/logic/field-kind.ts
+++ b/apps/web/src/tools/query-builder/logic/field-kind.ts
@@ -1,0 +1,24 @@
+import type { PgFilterConfig } from "@rfjs/pg-filter";
+
+import type { FieldType } from "./types";
+
+// Derive the SQL column type union from pg-filter's config shape (avoids a direct
+// @rfjs/sql-filter import; stays in sync with the package).
+export type SqlColumnType = PgFilterConfig["columns"][string]["type"];
+
+const COLUMN_TYPE_BY_DATATYPE: Partial<Record<FieldType, SqlColumnType>> = {
+  string: "text",
+  numeric: "numeric",
+  date: "timestamp",
+  boolean: "boolean",
+};
+
+export function canBeColumn(dataType: FieldType): boolean {
+  return dataType in COLUMN_TYPE_BY_DATATYPE;
+}
+
+export function mapColumnType(dataType: FieldType): SqlColumnType {
+  const t = COLUMN_TYPE_BY_DATATYPE[dataType];
+  if (!t) throw new Error(`dataType "${dataType}" cannot be a SQL column`);
+  return t;
+}

--- a/apps/web/src/tools/query-builder/logic/schema-infer.spec.ts
+++ b/apps/web/src/tools/query-builder/logic/schema-infer.spec.ts
@@ -6,40 +6,40 @@ describe("inferSchema", () => {
   it("infers scalar types from the first non-null value", () => {
     const s = inferSchema([{ name: "a", age: 30, active: true }]);
     expect(s).toEqual([
-      { path: "name", dataType: "string", include: true },
-      { path: "age", dataType: "numeric", include: true },
-      { path: "active", dataType: "boolean", include: true },
+      { path: "name", dataType: "string", include: true, kind: "jsonb" },
+      { path: "age", dataType: "numeric", include: true, kind: "jsonb" },
+      { path: "active", dataType: "boolean", include: true, kind: "jsonb" },
     ]);
   });
 
   it("detects ISO date strings as date", () => {
     expect(inferSchema([{ created: "2020-01-15" }])).toEqual([
-      { path: "created", dataType: "date", include: true },
+      { path: "created", dataType: "date", include: true, kind: "jsonb" },
     ]);
   });
 
   it("emits both the object field and its leaf paths", () => {
     expect(inferSchema([{ address: { city: "TP" } }])).toEqual([
-      { path: "address", dataType: "object", include: true },
-      { path: "address.city", dataType: "string", include: true },
+      { path: "address", dataType: "object", include: true, kind: "jsonb" },
+      { path: "address.city", dataType: "string", include: true, kind: "jsonb" },
     ]);
   });
 
   it("infers arrays of scalars with elementType", () => {
     expect(inferSchema([{ tags: ["a", "b"] }])).toEqual([
-      { path: "tags", dataType: "array", elementType: "string", include: true },
+      { path: "tags", dataType: "array", elementType: "string", include: true, kind: "jsonb" },
     ]);
   });
 
   it("infers arrays of objects as elementType object", () => {
     expect(inferSchema([{ items: [{ sku: "x" }] }])).toEqual([
-      { path: "items", dataType: "array", elementType: "object", include: true },
+      { path: "items", dataType: "array", elementType: "object", include: true, kind: "jsonb" },
     ]);
   });
 
   it("falls back to string on conflicting types across rows", () => {
     expect(inferSchema([{ v: 1 }, { v: "x" }])).toEqual([
-      { path: "v", dataType: "string", include: true },
+      { path: "v", dataType: "string", include: true, kind: "jsonb" },
     ]);
   });
 
@@ -51,19 +51,19 @@ describe("inferSchema", () => {
   // Fix A: ISO date regex must be anchored
   it("does not classify a date-prefixed string with trailing text as date", () => {
     expect(inferSchema([{ note: "2020-01-15 follow up" }])).toEqual([
-      { path: "note", dataType: "string", include: true },
+      { path: "note", dataType: "string", include: true, kind: "jsonb" },
     ]);
   });
 
   it("classifies YYYY-MM-DDThh:mm as date", () => {
     expect(inferSchema([{ ts: "2020-01-15T10:30" }])).toEqual([
-      { path: "ts", dataType: "date", include: true },
+      { path: "ts", dataType: "date", include: true, kind: "jsonb" },
     ]);
   });
 
   // Fix B: orphaned dotted paths under a non-object parent must be dropped
   it("does not emit leaf paths when an object field conflicts with a scalar in another row", () => {
     const s = inferSchema([{ a: { b: 1 } }, { a: "x" }]);
-    expect(s).toEqual([{ path: "a", dataType: "string", include: true }]);
+    expect(s).toEqual([{ path: "a", dataType: "string", include: true, kind: "jsonb" }]);
   });
 });

--- a/apps/web/src/tools/query-builder/logic/schema-infer.ts
+++ b/apps/web/src/tools/query-builder/logic/schema-infer.ts
@@ -68,5 +68,6 @@ export function inferSchema(rows: unknown): FieldSchema[] {
     dataType: t.dataType,
     ...(t.elementType ? { elementType: t.elementType } : {}),
     include: true,
+    kind: "jsonb" as const,
   }));
 }

--- a/apps/web/src/tools/query-builder/logic/types.ts
+++ b/apps/web/src/tools/query-builder/logic/types.ts
@@ -1,4 +1,5 @@
 export type LogicOp = "and" | "or" | "nor" | "not";
+export type FieldKind = "column" | "jsonb";
 export type ScalarType = "string" | "numeric" | "date" | "boolean";
 export type FieldType = ScalarType | "object" | "array";
 export type ElementType = ScalarType | "object";
@@ -28,4 +29,5 @@ export interface FieldSchema {
   dataType: FieldType;
   elementType?: ElementType;
   include: boolean;
+  kind: FieldKind; // whether this field is queried as a typed SQL column or via JSONB
 }

--- a/apps/web/src/tools/query-builder/messages.ts
+++ b/apps/web/src/tools/query-builder/messages.ts
@@ -5,7 +5,7 @@ export const messages: LocaleMessages = {
     Tools: {
       "query-builder": {
         title: "Query Builder",
-        description: "Build nested JSONB queries visually and preview live matches.",
+        description: "Build nested filters over real columns and JSONB, and preview the generated SQL (jsonb / data-filter / pg-filter).",
       },
     },
     ToolUI: {
@@ -19,7 +19,7 @@ export const messages: LocaleMessages = {
   },
   "zh-TW": {
     Tools: {
-      "query-builder": { title: "查詢建構器", description: "視覺化建構巢狀 JSONB 查詢，並即時預覽命中結果。" },
+      "query-builder": { title: "查詢建構器", description: "在真實欄位與 JSONB 上建構巢狀過濾，並預覽產生的 SQL（jsonb / data-filter / pg-filter）。" },
     },
     ToolUI: {
       notPreviewable: "此 operator 無法在瀏覽器預覽",

--- a/apps/web/src/tools/query-builder/messages.ts
+++ b/apps/web/src/tools/query-builder/messages.ts
@@ -12,6 +12,9 @@ export const messages: LocaleMessages = {
       notPreviewable: "This operator can't be previewed in the browser",
       builder: "Builder",
       elemMatchPlaceholder: "elemmatch (nested match — single-level in this slice)",
+      kindColumn: "column",
+      kindJsonb: "jsonb",
+      topLevelToColumns: "Top-level scalars → columns",
     },
   },
   "zh-TW": {
@@ -22,6 +25,9 @@ export const messages: LocaleMessages = {
       notPreviewable: "此 operator 無法在瀏覽器預覽",
       builder: "Builder",
       elemMatchPlaceholder: "elemmatch（巢狀比對，本切片暫以單層條件呈現）",
+      kindColumn: "欄位",
+      kindJsonb: "jsonb",
+      topLevelToColumns: "頂層 scalar 設為欄位",
     },
   },
 };

--- a/apps/web/src/tools/query-builder/ui/builder-tree.tsx
+++ b/apps/web/src/tools/query-builder/ui/builder-tree.tsx
@@ -8,6 +8,7 @@ import { getEngine, type EngineId } from "@/tools/query-builder/logic/engines";
 import { addCondition, addGroup, removeNode, setLogic, updateNode } from "@/tools/query-builder/logic/tree-ops";
 import type { BuilderCondition, BuilderGroup, FieldSchema, LogicOp } from "@/tools/query-builder/logic/types";
 
+import { FieldCombobox } from "./field-combobox";
 import { ValueEditor } from "./value-editor";
 
 const LOGIC_LABELS: Record<LogicOp, string> = {
@@ -25,6 +26,7 @@ export function GroupNode({
   schema,
   onChange,
   onRemove,
+  onCreateField,
   depth = 0,
 }: {
   group: BuilderGroup;
@@ -32,6 +34,7 @@ export function GroupNode({
   schema: FieldSchema[];
   onChange: (next: BuilderGroup) => void;
   onRemove?: () => void;
+  onCreateField: (path: string) => void;
   depth?: number;
 }) {
   return (
@@ -72,6 +75,7 @@ export function GroupNode({
                 onChange({ ...group, children: group.children.map((c) => (c.id === child.id ? nextChild : c)) })
               }
               onRemove={() => onChange(removeNode(group, child.id))}
+              onCreateField={onCreateField}
             />
           ) : (
             <ConditionRow
@@ -81,6 +85,7 @@ export function GroupNode({
               schema={schema}
               onChange={(patch) => onChange(updateNode(group, child.id, patch))}
               onRemove={() => onChange(removeNode(group, child.id))}
+              onCreateField={onCreateField}
             />
           ),
         )}
@@ -95,45 +100,42 @@ function ConditionRow({
   schema,
   onChange,
   onRemove,
+  onCreateField,
 }: {
   condition: BuilderCondition;
   engineId: EngineId;
   schema: FieldSchema[];
   onChange: (patch: Omit<Partial<BuilderCondition>, "kind" | "id">) => void;
   onRemove: () => void;
+  onCreateField: (path: string) => void;
 }) {
   const t = useTranslations("ToolUI");
   const fields = schema.filter((f) => f.include);
   const engine = getEngine(engineId);
-  const ops = engine.operators(condition.dataType, condition.elementType);
+  const fieldKind = schema.find((s) => s.path === condition.field)?.kind;
+  const ops = engine.operators(condition.dataType, condition.elementType, fieldKind);
   const arity = ops.find((o) => o.op === condition.operator)?.arity ?? "one";
 
   function onField(path: string) {
     const f = schema.find((s) => s.path === path);
-    if (!f) return;
-    const nextOps = engine.operators(f.dataType, f.elementType);
-    onChange({
-      field: f.path,
-      dataType: f.dataType,
-      elementType: f.elementType,
-      operator: nextOps[0]?.op ?? "",
-      value: "",
-    });
+    const dataType = f?.dataType ?? "string";
+    const elementType = f?.elementType;
+    const kind = f?.kind ?? "jsonb";
+    const nextOps = engine.operators(dataType, elementType, kind);
+    onChange({ field: path, dataType, elementType, operator: nextOps[0]?.op ?? "", value: "" });
   }
 
   return (
     <div className="flex flex-wrap items-center gap-2">
-      <select
-        aria-label="field"
+      <FieldCombobox
+        ariaLabel="field"
         value={condition.field}
-        onChange={(e) => onField(e.target.value)}
-        className="rounded-sm border bg-transparent px-2 py-1 text-sm"
-      >
-        <option value="">—</option>
-        {fields.map((f) => (
-          <option key={f.path} value={f.path}>{f.path}</option>
-        ))}
-      </select>
+        options={fields.map((f) => f.path)}
+        onCommit={(path) => {
+          if (path && !schema.some((s) => s.path === path)) onCreateField(path);
+          onField(path);
+        }}
+      />
       <select
         aria-label="operator"
         value={condition.operator}

--- a/apps/web/src/tools/query-builder/ui/builder-tree.tsx
+++ b/apps/web/src/tools/query-builder/ui/builder-tree.tsx
@@ -5,6 +5,7 @@ import { X } from "lucide-react";
 import { useTranslations } from "next-intl";
 
 import { getEngine, type EngineId } from "@/tools/query-builder/logic/engines";
+import { logicColor, dataTypeColor } from "@/tools/query-builder/logic/colors";
 import { addCondition, addGroup, removeNode, setLogic, updateNode } from "@/tools/query-builder/logic/tree-ops";
 import type { BuilderCondition, BuilderGroup, FieldSchema, LogicOp } from "@/tools/query-builder/logic/types";
 
@@ -44,7 +45,7 @@ export function GroupNode({
           aria-label="logic"
           value={group.logic}
           onChange={(e) => onChange(setLogic(group, group.id, e.target.value as LogicOp))}
-          className="rounded-sm border bg-transparent px-2 py-1 text-sm"
+          className={`rounded-sm border bg-transparent px-2 py-1 text-sm ${logicColor(group.logic)}`}
         >
           {(Object.keys(LOGIC_LABELS) as LogicOp[]).map((l) => (
             <option key={l} value={l}>{LOGIC_LABELS[l]}</option>
@@ -136,6 +137,11 @@ function ConditionRow({
           onField(path);
         }}
       />
+      {condition.field ? (
+        <span className={`font-mono text-[10px] ${dataTypeColor(condition.dataType)}`}>
+          {condition.dataType}
+        </span>
+      ) : null}
       <select
         aria-label="operator"
         value={condition.operator}

--- a/apps/web/src/tools/query-builder/ui/builder-tree.tsx
+++ b/apps/web/src/tools/query-builder/ui/builder-tree.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useEffect } from "react";
+
 import { Button } from "@rfjs/web-ui/components/button";
 import { X } from "lucide-react";
 import { useTranslations } from "next-intl";
@@ -113,9 +115,30 @@ function ConditionRow({
   const t = useTranslations("ToolUI");
   const fields = schema.filter((f) => f.include);
   const engine = getEngine(engineId);
-  const fieldKind = schema.find((s) => s.path === condition.field)?.kind;
-  const ops = engine.operators(condition.dataType, condition.elementType, fieldKind);
+  const field = schema.find((s) => s.path === condition.field);
+  const dataType = field?.dataType ?? condition.dataType;
+  const elementType = field?.elementType ?? condition.elementType;
+  const fieldKind = field?.kind;
+  const ops = engine.operators(dataType, elementType, fieldKind);
   const arity = ops.find((o) => o.op === condition.operator)?.arity ?? "one";
+  const operatorValid = ops.some((o) => o.op === condition.operator);
+
+  // Keep the condition's snapshot reconciled with the schema field and selected
+  // engine: sync dataType/elementType and reset an operator that is no longer
+  // valid for the current matrix (prevents silently-wrong or erroring SQL).
+  useEffect(() => {
+    const patch: Omit<Partial<BuilderCondition>, "kind" | "id"> = {};
+    if (field) {
+      if (field.dataType !== condition.dataType) patch.dataType = field.dataType;
+      if (field.elementType !== condition.elementType) patch.elementType = field.elementType;
+    }
+    if (condition.operator && !operatorValid) {
+      patch.operator = ops[0]?.op ?? "";
+      patch.value = "";
+    }
+    if (Object.keys(patch).length > 0) onChange(patch);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [engineId, field?.dataType, field?.elementType, field?.kind, operatorValid]);
 
   function onField(path: string) {
     const f = schema.find((s) => s.path === path);
@@ -138,9 +161,7 @@ function ConditionRow({
         }}
       />
       {condition.field ? (
-        <span className={`font-mono text-[10px] ${dataTypeColor(condition.dataType)}`}>
-          {condition.dataType}
-        </span>
+        <span className={`font-mono text-[10px] ${dataTypeColor(dataType)}`}>{dataType}</span>
       ) : null}
       <select
         aria-label="operator"
@@ -156,7 +177,7 @@ function ConditionRow({
         <span className="text-xs text-muted-foreground">{t("elemMatchPlaceholder")}</span>
       ) : (
         <ValueEditor
-          dataType={condition.dataType === "array" ? (condition.elementType ?? "string") : condition.dataType}
+          dataType={dataType === "array" ? (elementType ?? "string") : dataType}
           arity={arity}
           value={condition.value}
           onChange={(v) => onChange({ value: v })}

--- a/apps/web/src/tools/query-builder/ui/field-combobox.tsx
+++ b/apps/web/src/tools/query-builder/ui/field-combobox.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+let nextId = 0;
+
+export function FieldCombobox({
+  value,
+  options,
+  ariaLabel,
+  onCommit,
+}: {
+  value: string;
+  options: string[];
+  ariaLabel: string;
+  onCommit: (path: string) => void;
+}) {
+  const listId = `fields-${(nextId += 1)}`;
+  return (
+    <>
+      <input
+        aria-label={ariaLabel}
+        list={listId}
+        defaultValue={value}
+        onBlur={(e) => onCommit(e.target.value.trim())}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") (e.target as HTMLInputElement).blur();
+        }}
+        className="min-w-0 flex-1 rounded-sm border bg-transparent px-2 py-1 text-sm"
+      />
+      <datalist id={listId}>
+        {options.map((o) => (
+          <option key={o} value={o} />
+        ))}
+      </datalist>
+    </>
+  );
+}

--- a/apps/web/src/tools/query-builder/ui/field-combobox.tsx
+++ b/apps/web/src/tools/query-builder/ui/field-combobox.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-let nextId = 0;
+import { useId } from "react";
 
 export function FieldCombobox({
   value,
@@ -13,7 +13,7 @@ export function FieldCombobox({
   ariaLabel: string;
   onCommit: (path: string) => void;
 }) {
-  const listId = `fields-${(nextId += 1)}`;
+  const listId = `fields-${useId()}`;
   return (
     <>
       <input

--- a/apps/web/src/tools/query-builder/ui/index.tsx
+++ b/apps/web/src/tools/query-builder/ui/index.tsx
@@ -44,7 +44,15 @@ export function QueryBuilder() {
   }
 
   const rows = useMemo(() => parseRows(sampleText), [sampleText]);
-  const output = useMemo(() => getEngine(engineId).compile(treeToFilterGroup(tree)), [engineId, tree]);
+  const output = useMemo(
+    () =>
+      getEngine(engineId).compile(treeToFilterGroup(tree), {
+        fields: schema
+          .filter((f) => f.include)
+          .map((f) => ({ path: f.path, kind: f.kind, dataType: f.dataType, elementType: f.elementType })),
+      }),
+    [engineId, tree, schema],
+  );
   const live = useMemo(() => runLiveMatch(rows, tree), [rows, tree]);
 
   return (

--- a/apps/web/src/tools/query-builder/ui/index.tsx
+++ b/apps/web/src/tools/query-builder/ui/index.tsx
@@ -80,7 +80,7 @@ export function QueryBuilder() {
                 </Button>
               ))}
             </div>
-            <GroupNode group={tree} engineId={engineId} schema={schema} onChange={setTree} />
+            <GroupNode group={tree} engineId={engineId} schema={schema} onChange={setTree} onCreateField={() => {}} />
           </Panel>
         </div>
       }

--- a/apps/web/src/tools/query-builder/ui/index.tsx
+++ b/apps/web/src/tools/query-builder/ui/index.tsx
@@ -7,15 +7,16 @@ import { useMemo, useState } from "react";
 
 import { treeToFilterGroup } from "@/tools/query-builder/logic/compile";
 import { ENGINE_IDS, getEngine, type EngineId } from "@/tools/query-builder/logic/engines";
+import { addInferredField } from "@/tools/query-builder/logic/field-create";
 import { runLiveMatch } from "@/tools/query-builder/logic/live-match";
 import { inferSchema } from "@/tools/query-builder/logic/schema-infer";
 import { emptyGroup } from "@/tools/query-builder/logic/tree-ops";
 import type { BuilderGroup, FieldSchema } from "@/tools/query-builder/logic/types";
 
-import { ToolShell } from "@/tools/_shared/tool-shell";
 import { GroupNode } from "./builder-tree";
 import { PreviewPanel } from "./preview-panel";
 import { SchemaPanel } from "./schema-panel";
+import { ThreePane } from "./three-pane";
 
 const SAMPLE = JSON.stringify(
   [
@@ -33,7 +34,7 @@ export function QueryBuilder() {
   const [sampleText, setSampleText] = useState(SAMPLE);
   const [schema, setSchema] = useState<FieldSchema[]>(() => safeInfer(SAMPLE).schema);
   const [error, setError] = useState<string | null>(() => safeInfer(SAMPLE).error);
-  const [engineId, setEngineId] = useState<EngineId>("jsonb");
+  const [engineId, setEngineId] = useState<EngineId>("pg-filter");
   const [tree, setTree] = useState<BuilderGroup>(() => emptyGroup(id));
 
   function onSample(text: string) {
@@ -56,35 +57,44 @@ export function QueryBuilder() {
   const live = useMemo(() => runLiveMatch(rows, tree), [rows, tree]);
 
   return (
-    <ToolShell
-      operation="buildJsonbQuery() · matchQuery()"
-      input={
-        <div className="flex flex-col gap-3">
-          <SchemaPanel
-            sampleText={sampleText}
+    <ThreePane
+      source={
+        <SchemaPanel
+          sampleText={sampleText}
+          schema={schema}
+          error={error}
+          onSampleChange={onSample}
+          onSchemaChange={setSchema}
+        />
+      }
+      builder={
+        <Panel title={t("builder")}>
+          <GroupNode
+            group={tree}
+            engineId={engineId}
             schema={schema}
-            error={error}
-            onSampleChange={onSample}
-            onSchemaChange={setSchema}
+            onChange={setTree}
+            onCreateField={(path) => setSchema((s) => addInferredField(s, path))}
           />
-          <Panel title={t("builder")}>
-            <div className="mb-3 flex gap-2">
-              {ENGINE_IDS.map((eid) => (
-                <Button
-                  key={eid}
-                  size="sm"
-                  variant={eid === engineId ? "default" : "outline"}
-                  onClick={() => setEngineId(eid)}
-                >
-                  {getEngine(eid).label}
-                </Button>
-              ))}
-            </div>
-            <GroupNode group={tree} engineId={engineId} schema={schema} onChange={setTree} onCreateField={() => {}} />
-          </Panel>
+        </Panel>
+      }
+      output={
+        <div className="flex flex-col gap-3">
+          <div className="flex flex-wrap gap-2">
+            {ENGINE_IDS.map((eid) => (
+              <Button
+                key={eid}
+                size="sm"
+                variant={eid === engineId ? "default" : "outline"}
+                onClick={() => setEngineId(eid)}
+              >
+                {getEngine(eid).label}
+              </Button>
+            ))}
+          </div>
+          <PreviewPanel output={output} live={live} />
         </div>
       }
-      output={<PreviewPanel output={output} live={live} />}
     />
   );
 }

--- a/apps/web/src/tools/query-builder/ui/index.tsx
+++ b/apps/web/src/tools/query-builder/ui/index.tsx
@@ -48,9 +48,12 @@ export function QueryBuilder() {
   const output = useMemo(
     () =>
       getEngine(engineId).compile(treeToFilterGroup(tree), {
-        fields: schema
-          .filter((f) => f.include)
-          .map((f) => ({ path: f.path, kind: f.kind, dataType: f.dataType, elementType: f.elementType })),
+        fields: schema.map((f) => ({
+          path: f.path,
+          kind: f.kind,
+          dataType: f.dataType,
+          elementType: f.elementType,
+        })),
       }),
     [engineId, tree, schema],
   );

--- a/apps/web/src/tools/query-builder/ui/schema-panel.tsx
+++ b/apps/web/src/tools/query-builder/ui/schema-panel.tsx
@@ -3,7 +3,8 @@
 import { Panel } from "@rfjs/web-ui/components/panel";
 import { useTranslations } from "next-intl";
 
-import type { FieldSchema, FieldType } from "@/tools/query-builder/logic/types";
+import { canBeColumn } from "@/tools/query-builder/logic/field-kind";
+import type { FieldKind, FieldSchema, FieldType } from "@/tools/query-builder/logic/types";
 
 const TYPES: FieldType[] = ["string", "numeric", "date", "boolean", "object", "array"];
 
@@ -51,16 +52,42 @@ export function SchemaPanel({
               <select
                 aria-label={`type ${f.path}`}
                 value={f.dataType}
-                onChange={(e) => patch(f.path, { dataType: e.target.value as FieldType })}
+                onChange={(e) => {
+                  const dataType = e.target.value as FieldType;
+                  patch(f.path, canBeColumn(dataType) ? { dataType } : { dataType, kind: "jsonb" });
+                }}
                 className="rounded-sm border bg-transparent px-1 py-0.5 text-xs"
               >
                 {TYPES.map((tp) => (
                   <option key={tp} value={tp}>{tp}</option>
                 ))}
               </select>
+              <select
+                aria-label={`kind ${f.path}`}
+                value={canBeColumn(f.dataType) ? f.kind : "jsonb"}
+                disabled={!canBeColumn(f.dataType)}
+                onChange={(e) => patch(f.path, { kind: e.target.value as FieldKind })}
+                className="rounded-sm border bg-transparent px-1 py-0.5 text-xs disabled:opacity-50"
+              >
+                <option value="jsonb">{t("kindJsonb")}</option>
+                <option value="column">{t("kindColumn")}</option>
+              </select>
             </div>
           ))}
         </div>
+        <button
+          type="button"
+          onClick={() =>
+            onSchemaChange(
+              schema.map((f) =>
+                !f.path.includes(".") && canBeColumn(f.dataType) ? { ...f, kind: "column" } : f,
+              ),
+            )
+          }
+          className="self-start rounded-sm border border-border bg-transparent px-2 py-1 text-xs"
+        >
+          {t("topLevelToColumns")}
+        </button>
       </div>
     </Panel>
   );

--- a/apps/web/src/tools/query-builder/ui/three-pane.tsx
+++ b/apps/web/src/tools/query-builder/ui/three-pane.tsx
@@ -1,0 +1,19 @@
+import type { ReactNode } from "react";
+
+export function ThreePane({
+  source,
+  builder,
+  output,
+}: {
+  source: ReactNode;
+  builder: ReactNode;
+  output: ReactNode;
+}) {
+  return (
+    <div className="grid grid-cols-1 gap-3 lg:grid-cols-3">
+      <div className="flex flex-col gap-3">{source}</div>
+      <div className="flex flex-col gap-3">{builder}</div>
+      <div className="flex flex-col gap-3">{output}</div>
+    </div>
+  );
+}

--- a/docs/superpowers/plans/2026-06-16-query-builder-pg-filter.md
+++ b/docs/superpowers/plans/2026-06-16-query-builder-pg-filter.md
@@ -1,0 +1,998 @@
+# query-builder pg-filter engine + field-kind + 3-column UI — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `pg-filter` engine to the apps/web query-builder that previews unified column+jsonb PostgreSQL SQL, introduce a per-field column/jsonb "kind" model, and redesign the tool as a full-width 3-column colored UI.
+
+**Architecture:** Phase A is pure logic (model + engine-registry interface + the pg-filter engine), fully TDD. Phase B rebuilds the tool's UI once into the 3-column layout (left data source + schema, middle colored tree, right engine output) — folding in the B1 wiring so UI files aren't edited twice. The existing `jsonb`/`data-filter` engines need no changes (their narrower functions satisfy the widened `Engine` interface structurally).
+
+**Tech Stack:** Next.js (apps/web), React 19, `@rfjs/pg-filter` (+ transitively `@rfjs/sql-filter`, `@rfjs/jsonb-query`), `@rfjs/web-ui` (Tailwind tokens), next-intl, Vitest.
+
+**Spec:** `docs/superpowers/specs/2026-06-16-query-builder-pg-filter-design.md`
+**Decisions locked:** D1 default kind `jsonb` + one-click "top-level scalars → column"; D2 dialect `legacy`; D3 no sort/pagination in builder (WHERE preview only); D4 `lg` 3-column else stacked.
+
+All paths are under `apps/web/src/tools/query-builder/` unless noted. Run tests with `pnpm -F web vitest:run <pattern>`. Commit subjects lowercase (commitlint); never `--no-verify`. Commit messages in English.
+
+---
+
+## File Structure
+
+**Phase A — logic**
+- `logic/types.ts` (modify) — add `FieldKind`; `FieldSchema.kind`.
+- `logic/schema-infer.ts` (modify) — inferred fields default `kind: 'jsonb'`.
+- `logic/field-kind.ts` (create, + spec) — `canBeColumn`, `mapColumnType`, `SqlColumnType`.
+- `logic/engines/types.ts` (modify) — `EngineId += 'pg-filter'`; `CompileField`/`CompileContext`; `operators(...,kind?)`; `compile(group, ctx)`.
+- `logic/engines/pg-filter.ts` (create, + spec) — the engine.
+- `logic/engines/index.ts` (modify) — register pg-filter.
+- `apps/web/package.json` (modify) — add `@rfjs/pg-filter`.
+
+**Phase B — UI (3-column)**
+- `ui/index.tsx` (rewrite) — 3-column layout, build `CompileContext`, thread create-field.
+- `ui/three-pane.tsx` (create) — full-width 3-column container.
+- `ui/schema-panel.tsx` (modify) — per-field kind control + "top-level scalars → column" button.
+- `logic/field-create.ts` (create, + spec) — pure `addInferredField` helper for the creatable combobox.
+- `ui/field-combobox.tsx` (create) — input + datalist creatable field picker.
+- `logic/colors.ts` (create, + spec) — token-class mapping for logic/dataType/operator.
+- `ui/builder-tree.tsx` (modify) — pass field `kind` to `operators`; use combobox; apply colors.
+- `messages.ts` (modify) — new i18n keys (en + zh-TW).
+
+---
+
+## Phase A — Logic
+
+### Task 1: field-kind model + helper
+
+**Files:**
+- Modify: `logic/types.ts`
+- Modify: `logic/schema-infer.ts`
+- Modify: `logic/schema-infer.spec.ts`
+- Create: `logic/field-kind.ts`
+- Test: `logic/field-kind.spec.ts`
+
+- [ ] **Step 1: Write the failing test** `logic/field-kind.spec.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { canBeColumn, mapColumnType } from "./field-kind";
+
+describe("field-kind", () => {
+  it("maps scalar dataTypes to SQL column types", () => {
+    expect(mapColumnType("string")).toBe("text");
+    expect(mapColumnType("numeric")).toBe("numeric");
+    expect(mapColumnType("date")).toBe("timestamp");
+    expect(mapColumnType("boolean")).toBe("boolean");
+  });
+
+  it("allows only scalar dataTypes as columns", () => {
+    expect(canBeColumn("string")).toBe(true);
+    expect(canBeColumn("numeric")).toBe(true);
+    expect(canBeColumn("date")).toBe(true);
+    expect(canBeColumn("boolean")).toBe(true);
+    expect(canBeColumn("object")).toBe(false);
+    expect(canBeColumn("array")).toBe(false);
+  });
+
+  it("throws when mapping a non-column dataType", () => {
+    expect(() => mapColumnType("object")).toThrow();
+    expect(() => mapColumnType("array")).toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Run, expect FAIL**
+
+Run: `pnpm -F web vitest:run field-kind`
+Expected: FAIL (`./field-kind` not found).
+
+- [ ] **Step 3: Create `logic/field-kind.ts`**
+
+```ts
+import type { PgFilterConfig } from "@rfjs/pg-filter";
+
+import type { FieldType } from "./types";
+
+// Derive the SQL column type union from pg-filter's config shape (avoids a direct
+// @rfjs/sql-filter import; stays in sync with the package).
+export type SqlColumnType = PgFilterConfig["columns"][string]["type"];
+
+const COLUMN_TYPE_BY_DATATYPE: Partial<Record<FieldType, SqlColumnType>> = {
+  string: "text",
+  numeric: "numeric",
+  date: "timestamp",
+  boolean: "boolean",
+};
+
+export function canBeColumn(dataType: FieldType): boolean {
+  return dataType in COLUMN_TYPE_BY_DATATYPE;
+}
+
+export function mapColumnType(dataType: FieldType): SqlColumnType {
+  const t = COLUMN_TYPE_BY_DATATYPE[dataType];
+  if (!t) throw new Error(`dataType "${dataType}" cannot be a SQL column`);
+  return t;
+}
+```
+
+- [ ] **Step 4: Add `FieldKind` + `FieldSchema.kind` to `logic/types.ts`**
+
+Add the type and field (rest of the file unchanged):
+```ts
+export type FieldKind = "column" | "jsonb";
+```
+And in `FieldSchema`, add `kind`:
+```ts
+export interface FieldSchema {
+  path: string;
+  dataType: FieldType;
+  elementType?: ElementType;
+  include: boolean;
+  kind: FieldKind; // 'column' = real SQL column, 'jsonb' = path inside the jsonb blob
+}
+```
+
+- [ ] **Step 5: Default inferred fields to `jsonb` in `logic/schema-infer.ts`**
+
+In `inferSchema`, the final `.map(...)` returns the FieldSchema objects — add `kind: "jsonb"`:
+```ts
+  return [...acc.entries()].map(([path, t]) => ({
+    path,
+    dataType: t.dataType,
+    ...(t.elementType ? { elementType: t.elementType } : {}),
+    include: true,
+    kind: "jsonb" as const,
+  }));
+```
+
+- [ ] **Step 6: Update `logic/schema-infer.spec.ts`**
+
+The existing assertions compare returned `FieldSchema[]`. Add `kind: "jsonb"` to each expected object. (Open the file; for every expected field object that asserts `include: true`, add `kind: "jsonb"`. If it uses `toEqual` on full arrays, add the key to each element; if it uses `toMatchObject`/`toContainEqual`, add `kind` to those matchers.)
+
+- [ ] **Step 7: Run, expect PASS**
+
+Run: `pnpm -F web vitest:run field-kind schema-infer`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/web/src/tools/query-builder/logic/types.ts apps/web/src/tools/query-builder/logic/schema-infer.ts apps/web/src/tools/query-builder/logic/schema-infer.spec.ts apps/web/src/tools/query-builder/logic/field-kind.ts apps/web/src/tools/query-builder/logic/field-kind.spec.ts
+git commit -m "feat(web/query-builder): field-kind model (column vs jsonb) + type mapping"
+```
+
+---
+
+### Task 2: widen the Engine interface (CompileContext + operator kind)
+
+**Files:**
+- Modify: `logic/engines/types.ts`
+- Modify: `ui/index.tsx` (the single `compile` caller — minimal change; full rewrite in Phase B)
+
+> Note: the existing `jsonbEngine` / `dataFilterEngine` need NO changes — a `compile(group)` function is assignable to the widened `compile(group, ctx)` type, and `operators(dataType, elementType)` is assignable to `operators(dataType, elementType?, kind?)`. Do NOT add `'pg-filter'` to `EngineId` here (it would make `ENGINES: Record<EngineId, Engine>` in index.ts non-exhaustive until Task 3).
+
+- [ ] **Step 1: Widen `logic/engines/types.ts`**
+
+Add imports + types; widen `Engine`:
+```ts
+import type { FilterGroupLike } from "../compile";
+import type { ElementType, FieldKind, FieldType } from "../types";
+
+export type OperatorArity = "none" | "one" | "two" | "list";
+
+export interface OperatorSpec {
+  op: string;
+  arity: OperatorArity;
+}
+
+export type EngineId = "jsonb" | "data-filter";
+
+export interface CompileField {
+  path: string;
+  kind: FieldKind;
+  dataType: FieldType;
+  elementType?: ElementType;
+}
+
+export interface CompileContext {
+  fields: CompileField[];
+}
+
+export type EngineOutput =
+  | { ok: true; primary: string; secondary?: string }
+  | { ok: false; error: string };
+
+export interface Engine {
+  id: EngineId;
+  label: string;
+  operators(dataType: string, elementType?: string, kind?: FieldKind): OperatorSpec[];
+  compile(group: FilterGroupLike, ctx: CompileContext): EngineOutput;
+}
+```
+
+- [ ] **Step 2: Update the `compile` caller in `ui/index.tsx`**
+
+Replace the `output` memo so it passes a `CompileContext` built from the included schema fields:
+```ts
+  const output = useMemo(
+    () =>
+      getEngine(engineId).compile(treeToFilterGroup(tree), {
+        fields: schema
+          .filter((f) => f.include)
+          .map((f) => ({ path: f.path, kind: f.kind, dataType: f.dataType, elementType: f.elementType })),
+      }),
+    [engineId, tree, schema],
+  );
+```
+
+- [ ] **Step 3: Verify typecheck + existing engine tests still pass**
+
+Run: `pnpm -F web vitest:run engines && pnpm -F web typecheck`
+Expected: PASS (jsonb/data-filter unchanged and still satisfy `Engine`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/tools/query-builder/logic/engines/types.ts apps/web/src/tools/query-builder/ui/index.tsx
+git commit -m "feat(web/query-builder): widen Engine interface with CompileContext + operator kind"
+```
+
+---
+
+### Task 3: pg-filter engine
+
+**Files:**
+- Modify: `apps/web/package.json` (add dep)
+- Create: `logic/engines/pg-filter.ts`
+- Test: `logic/engines/pg-filter.spec.ts`
+- Modify: `logic/engines/types.ts` (add `'pg-filter'` to `EngineId`)
+- Modify: `logic/engines/index.ts` (register)
+
+- [ ] **Step 1: Add the dependency**
+
+In `apps/web/package.json` `dependencies`, add (keep the list alphabetical-ish near the other `@rfjs/*`):
+```json
+    "@rfjs/pg-filter": "workspace:*",
+```
+Run: `pnpm install`
+Expected: links `@rfjs/pg-filter`.
+
+- [ ] **Step 2: Write the failing test** `logic/engines/pg-filter.spec.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { pgFilterEngine } from "./pg-filter";
+import type { CompileContext } from "./types";
+
+const ctx = (fields: CompileContext["fields"]): CompileContext => ({ fields });
+
+describe("pgFilterEngine.operators", () => {
+  it("returns column operators for column-kind fields", () => {
+    const ops = pgFilterEngine.operators("string", undefined, "column").map((o) => o.op);
+    expect(ops).toContain("contains");
+    expect(ops).toContain("startswith");
+    expect(ops).toContain("eq");
+    expect(ops).not.toContain("icontains"); // jsonb-only, not a column op
+  });
+
+  it("returns jsonb operators for jsonb-kind fields", () => {
+    const ops = pgFilterEngine.operators("string", undefined, "jsonb").map((o) => o.op);
+    expect(ops).toContain("icontains"); // jsonb engine has this
+  });
+});
+
+describe("pgFilterEngine.compile", () => {
+  it("renders a pure column condition", () => {
+    const group = { logic: "and", filters: [{ field: "name", dataType: "string", operator: "contains", value: "ab" }] };
+    const out = pgFilterEngine.compile(group, ctx([{ path: "name", kind: "column", dataType: "string" }]));
+    expect(out.ok).toBe(true);
+    if (out.ok) {
+      expect(out.primary).toContain("name");
+      expect(out.primary).toContain("$1");
+      expect(out.secondary).toContain("ab");
+    }
+  });
+
+  it("renders a pure jsonb condition against the data column", () => {
+    const group = { logic: "and", filters: [{ field: "score", dataType: "numeric", operator: "gt", value: 80 }] };
+    const out = pgFilterEngine.compile(group, ctx([{ path: "score", kind: "jsonb", dataType: "numeric" }]));
+    expect(out.ok).toBe(true);
+    if (out.ok) expect(out.primary).toContain("data");
+  });
+
+  it("mixes column + jsonb leaves with contiguous params", () => {
+    const group = {
+      logic: "and",
+      filters: [
+        { field: "name", dataType: "string", operator: "eq", value: "x" },
+        { field: "score", dataType: "numeric", operator: "gt", value: 5 },
+      ],
+    };
+    const out = pgFilterEngine.compile(
+      group,
+      ctx([
+        { path: "name", kind: "column", dataType: "string" },
+        { path: "score", kind: "jsonb", dataType: "numeric" },
+      ]),
+    );
+    expect(out.ok).toBe(true);
+    if (out.ok) {
+      expect(out.primary).toContain("name");
+      expect(out.primary).toContain("data");
+      expect(out.primary).toContain("$1");
+      expect(out.primary).toContain("$2");
+    }
+  });
+
+  it("returns ok:false when a column gets an unsupported operator", () => {
+    const group = { logic: "and", filters: [{ field: "n", dataType: "numeric", operator: "contains", value: "x" }] };
+    const out = pgFilterEngine.compile(group, ctx([{ path: "n", kind: "column", dataType: "numeric" }]));
+    expect(out.ok).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 3: Run, expect FAIL**
+
+Run: `pnpm -F web vitest:run pg-filter`
+Expected: FAIL (`./pg-filter` not found).
+
+- [ ] **Step 4: Create `logic/engines/pg-filter.ts`**
+
+```ts
+import { buildPgFilter, type PgFilterConfig, type PgFilterGroup, type PgLeaf } from "@rfjs/pg-filter";
+
+import type { FilterConditionLike, FilterGroupLike } from "../compile";
+import { mapColumnType } from "../field-kind";
+import type { FieldKind } from "../types";
+import { arityOf } from "./arity";
+import { jsonbEngine } from "./jsonb";
+import type { CompileContext, Engine, OperatorSpec } from "./types";
+
+const NULL_OPS = ["isnull", "isnotnull"];
+const COLUMN_TEXT_OPS = ["eq", "neq", "contains", "startswith", "gt", "gte", "lt", "lte", ...NULL_OPS];
+const COLUMN_NUMERIC_OPS = ["eq", "neq", "gt", "gte", "lt", "lte", ...NULL_OPS]; // numeric + date(timestamp)
+const COLUMN_BOOL_OPS = ["eq", "neq", ...NULL_OPS];
+
+function columnOps(dataType: string): string[] {
+  if (dataType === "string") return COLUMN_TEXT_OPS;
+  if (dataType === "boolean") return COLUMN_BOOL_OPS;
+  return COLUMN_NUMERIC_OPS; // numeric, date
+}
+
+function toSpecs(ops: string[]): OperatorSpec[] {
+  return [...new Set(ops)].map((op) => ({ op, arity: arityOf(op) }));
+}
+
+function toPgLeaf(c: FilterConditionLike, kindByPath: Map<string, FieldKind>): PgLeaf {
+  const kind = kindByPath.get(c.field) ?? "jsonb";
+  if (kind === "column") {
+    return { target: "column", column: c.field, operator: c.operator, value: c.value } as PgLeaf;
+  }
+  const leaf = {
+    target: "jsonb",
+    field: c.field,
+    dataType: c.dataType,
+    operator: c.operator,
+    ...(c.value !== undefined ? { value: c.value } : {}),
+    ...(c.elementType ? { elementType: c.elementType } : {}),
+    ...(c.filters ? { filters: c.filters } : {}),
+  };
+  return leaf as unknown as PgLeaf;
+}
+
+function toPgGroup(group: FilterGroupLike, kindByPath: Map<string, FieldKind>): PgFilterGroup {
+  return {
+    logic: group.logic as PgFilterGroup["logic"],
+    filters: group.filters.map((node) =>
+      "logic" in node
+        ? toPgGroup(node as FilterGroupLike, kindByPath)
+        : toPgLeaf(node as FilterConditionLike, kindByPath),
+    ),
+  };
+}
+
+export const pgFilterEngine: Engine = {
+  id: "pg-filter",
+  label: "pg-filter (column + jsonb)",
+  operators(dataType, elementType, kind) {
+    if (kind === "column") return toSpecs(columnOps(dataType));
+    return jsonbEngine.operators(dataType, elementType); // jsonb fields reuse the jsonb matrix
+  },
+  compile(group, ctx: CompileContext) {
+    try {
+      const kindByPath = new Map(ctx.fields.map((f) => [f.path, f.kind]));
+      const columns = ctx.fields
+        .filter((f) => f.kind === "column")
+        .reduce<PgFilterConfig["columns"]>((acc, f) => {
+          acc[f.path] = { column: f.path, type: mapColumnType(f.dataType) };
+          return acc;
+        }, {});
+      const config: PgFilterConfig = { columns, jsonb: { column: "data", dialect: "legacy" } };
+      const { where, values } = buildPgFilter(config, { filter: toPgGroup(group, kindByPath) });
+      return { ok: true, primary: where, secondary: JSON.stringify(values, null, 2) };
+    } catch (err) {
+      return { ok: false, error: err instanceof Error ? err.message : "queryFailed" };
+    }
+  },
+};
+```
+
+- [ ] **Step 5: Add `'pg-filter'` to `EngineId` in `logic/engines/types.ts`**
+
+```ts
+export type EngineId = "jsonb" | "data-filter" | "pg-filter";
+```
+
+- [ ] **Step 6: Register in `logic/engines/index.ts`**
+
+```ts
+import { dataFilterEngine } from "./data-filter";
+import { jsonbEngine } from "./jsonb";
+import { pgFilterEngine } from "./pg-filter";
+import type { Engine, EngineId } from "./types";
+
+const ENGINES: Record<EngineId, Engine> = {
+  jsonb: jsonbEngine,
+  "data-filter": dataFilterEngine,
+  "pg-filter": pgFilterEngine,
+};
+
+export const ENGINE_IDS: EngineId[] = ["jsonb", "data-filter", "pg-filter"];
+
+export function getEngine(id: EngineId): Engine {
+  return ENGINES[id];
+}
+
+export type {
+  Engine,
+  EngineId,
+  OperatorSpec,
+  OperatorArity,
+  EngineOutput,
+  CompileContext,
+  CompileField,
+} from "./types";
+```
+
+- [ ] **Step 7: Run, expect PASS + typecheck**
+
+Run: `pnpm -F web vitest:run pg-filter engines && pnpm -F web typecheck`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/web/package.json pnpm-lock.yaml apps/web/src/tools/query-builder/logic/engines
+git commit -m "feat(web/query-builder): pg-filter engine for unified column+jsonb SQL preview"
+```
+
+---
+
+## Phase B — 3-column UI
+
+### Task 4: schema-panel — per-field kind control + one-click columns
+
+**Files:**
+- Modify: `ui/schema-panel.tsx`
+- Modify: `messages.ts`
+
+- [ ] **Step 1: Add i18n keys** in `messages.ts` under `ToolUI` for BOTH `en` and `zh-TW`:
+
+en:
+```ts
+      kindColumn: "column",
+      kindJsonb: "jsonb",
+      topLevelToColumns: "Top-level scalars → columns",
+```
+zh-TW:
+```ts
+      kindColumn: "欄位",
+      kindJsonb: "jsonb",
+      topLevelToColumns: "頂層 scalar 設為欄位",
+```
+
+- [ ] **Step 2: Add the kind control + button to `ui/schema-panel.tsx`**
+
+Import the helper at the top:
+```ts
+import { canBeColumn } from "@/tools/query-builder/logic/field-kind";
+import type { FieldKind } from "@/tools/query-builder/logic/types";
+```
+
+Inside the field row (after the type `<select>`), add a kind toggle that is forced to `jsonb` and disabled when the dataType can't be a column:
+```tsx
+              <select
+                aria-label={`kind ${f.path}`}
+                value={canBeColumn(f.dataType) ? f.kind : "jsonb"}
+                disabled={!canBeColumn(f.dataType)}
+                onChange={(e) => patch(f.path, { kind: e.target.value as FieldKind })}
+                className="rounded-sm border bg-transparent px-1 py-0.5 text-xs disabled:opacity-50"
+              >
+                <option value="jsonb">{t("kindJsonb")}</option>
+                <option value="column">{t("kindColumn")}</option>
+              </select>
+```
+
+When the dataType select changes to object/array, also reset kind to jsonb. In the existing `patch` call for the type select, change it to also clear kind when needed:
+```tsx
+                onChange={(e) => {
+                  const dataType = e.target.value as FieldType;
+                  patch(f.path, canBeColumn(dataType) ? { dataType } : { dataType, kind: "jsonb" });
+                }}
+```
+
+Add a one-click button above or below the field list (inside the Panel, after the field list `</div>`):
+```tsx
+        <button
+          type="button"
+          onClick={() =>
+            onSchemaChange(
+              schema.map((f) =>
+                !f.path.includes(".") && canBeColumn(f.dataType) ? { ...f, kind: "column" } : f,
+              ),
+            )
+          }
+          className="self-start rounded-sm border border-border bg-transparent px-2 py-1 text-xs"
+        >
+          {t("topLevelToColumns")}
+        </button>
+```
+
+- [ ] **Step 3: Verify typecheck + build**
+
+Run: `pnpm -F web typecheck`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/tools/query-builder/ui/schema-panel.tsx apps/web/src/tools/query-builder/messages.ts
+git commit -m "feat(web/query-builder): per-field column/jsonb kind control"
+```
+
+---
+
+### Task 5: creatable field combobox
+
+**Files:**
+- Create: `logic/field-create.ts`
+- Test: `logic/field-create.spec.ts`
+- Create: `ui/field-combobox.tsx`
+- Modify: `ui/builder-tree.tsx` (use the combobox; pass field kind to `operators`)
+
+- [ ] **Step 1: Write the failing test** `logic/field-create.spec.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { addInferredField } from "./field-create";
+import type { FieldSchema } from "./types";
+
+const base: FieldSchema[] = [{ path: "name", dataType: "string", include: true, kind: "jsonb" }];
+
+describe("addInferredField", () => {
+  it("appends a new jsonb string field when the path is unknown", () => {
+    const next = addInferredField(base, "newKey");
+    expect(next).toHaveLength(2);
+    expect(next[1]).toEqual({ path: "newKey", dataType: "string", include: true, kind: "jsonb" });
+  });
+
+  it("returns the same array when the path already exists", () => {
+    const next = addInferredField(base, "name");
+    expect(next).toBe(base);
+  });
+
+  it("ignores empty paths", () => {
+    expect(addInferredField(base, "")).toBe(base);
+  });
+});
+```
+
+- [ ] **Step 2: Run, expect FAIL**
+
+Run: `pnpm -F web vitest:run field-create`
+Expected: FAIL.
+
+- [ ] **Step 3: Create `logic/field-create.ts`**
+
+```ts
+import type { FieldSchema } from "./types";
+
+// Append a new field (default jsonb string) when the user types a key not in the schema.
+export function addInferredField(schema: FieldSchema[], path: string): FieldSchema[] {
+  if (!path || schema.some((f) => f.path === path)) return schema;
+  return [...schema, { path, dataType: "string", include: true, kind: "jsonb" }];
+}
+```
+
+- [ ] **Step 4: Run, expect PASS**
+
+Run: `pnpm -F web vitest:run field-create`
+Expected: PASS.
+
+- [ ] **Step 5: Create `ui/field-combobox.tsx`** (input + datalist; free text allowed = creatable):
+
+```tsx
+"use client";
+
+let nextId = 0;
+
+export function FieldCombobox({
+  value,
+  options,
+  ariaLabel,
+  onCommit,
+}: {
+  value: string;
+  options: string[];
+  ariaLabel: string;
+  onCommit: (path: string) => void;
+}) {
+  const listId = `fields-${(nextId += 1)}`;
+  return (
+    <>
+      <input
+        aria-label={ariaLabel}
+        list={listId}
+        defaultValue={value}
+        onBlur={(e) => onCommit(e.target.value.trim())}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") (e.target as HTMLInputElement).blur();
+        }}
+        className="min-w-0 flex-1 rounded-sm border bg-transparent px-2 py-1 text-sm"
+      />
+      <datalist id={listId}>
+        {options.map((o) => (
+          <option key={o} value={o} />
+        ))}
+      </datalist>
+    </>
+  );
+}
+```
+
+- [ ] **Step 6: Use the combobox + pass kind to `operators` in `ui/builder-tree.tsx`**
+
+`GroupNode` and `ConditionRow` need an `onCreateField(path: string)` callback threaded from the top. Add `onCreateField: (path: string) => void` to both component prop types and pass it through the recursion (alongside `schema`).
+
+In `ConditionRow`, look up the selected field's kind and pass it to `operators`, and replace the field `<select>` with the combobox:
+```tsx
+  const fieldKind = schema.find((s) => s.path === condition.field)?.kind;
+  const ops = engine.operators(condition.dataType, condition.elementType, fieldKind);
+```
+Replace the field `<select>...</select>` block with:
+```tsx
+      <FieldCombobox
+        ariaLabel="field"
+        value={condition.field}
+        options={fields.map((f) => f.path)}
+        onCommit={(path) => {
+          if (path && !schema.some((s) => s.path === path)) onCreateField(path);
+          onField(path);
+        }}
+      />
+```
+Keep the existing `onField` logic, but make it resilient when the field isn't in the schema yet (combobox just created it; the schema prop updates next render). Update `onField` to default to a jsonb string field when not found, and pass kind into the ops lookup:
+```tsx
+  function onField(path: string) {
+    const f = schema.find((s) => s.path === path);
+    const dataType = f?.dataType ?? "string";
+    const elementType = f?.elementType;
+    const kind = f?.kind ?? "jsonb";
+    const nextOps = engine.operators(dataType, elementType, kind);
+    onChange({ field: path, dataType, elementType, operator: nextOps[0]?.op ?? "", value: "" });
+  }
+```
+Add the import:
+```ts
+import { FieldCombobox } from "./field-combobox";
+```
+
+- [ ] **Step 7: Verify typecheck + tests**
+
+Run: `pnpm -F web vitest:run field-create && pnpm -F web typecheck`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/web/src/tools/query-builder/logic/field-create.ts apps/web/src/tools/query-builder/logic/field-create.spec.ts apps/web/src/tools/query-builder/ui/field-combobox.tsx apps/web/src/tools/query-builder/ui/builder-tree.tsx
+git commit -m "feat(web/query-builder): creatable field combobox + kind-aware operators"
+```
+
+---
+
+### Task 6: colored nodes
+
+**Files:**
+- Create: `logic/colors.ts`
+- Test: `logic/colors.spec.ts`
+- Modify: `ui/builder-tree.tsx` (apply color classes)
+
+- [ ] **Step 1: Write the failing test** `logic/colors.spec.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { logicColor, dataTypeColor } from "./colors";
+
+describe("colors", () => {
+  it("returns a stable token class per logic operator", () => {
+    expect(logicColor("and")).toBe(logicColor("and"));
+    expect(logicColor("and")).not.toBe(logicColor("or"));
+    expect(logicColor("and")).toMatch(/^text-/);
+  });
+
+  it("returns a token class per dataType and a fallback", () => {
+    expect(dataTypeColor("string")).toMatch(/^text-/);
+    expect(dataTypeColor("unknown")).toMatch(/^text-/);
+  });
+});
+```
+
+- [ ] **Step 2: Run, expect FAIL**
+
+Run: `pnpm -F web vitest:run colors`
+Expected: FAIL.
+
+- [ ] **Step 3: Create `logic/colors.ts`** (web-ui Tailwind semantic tokens only — no hex):
+
+```ts
+import type { LogicOp } from "./types";
+
+const LOGIC: Record<LogicOp, string> = {
+  and: "text-signal",
+  or: "text-accent",
+  nor: "text-fault",
+  not: "text-warning",
+};
+
+const DATATYPE: Record<string, string> = {
+  string: "text-signal",
+  numeric: "text-accent",
+  date: "text-accent",
+  boolean: "text-warning",
+  object: "text-muted-foreground",
+  array: "text-muted-foreground",
+};
+
+export function logicColor(op: LogicOp): string {
+  return LOGIC[op];
+}
+
+export function dataTypeColor(dataType: string): string {
+  return DATATYPE[dataType] ?? "text-muted-foreground";
+}
+```
+> If a token (e.g. `text-accent`/`text-warning`) is not defined in `@rfjs/web-ui`, substitute an existing one (check `packages/web-ui`); the test only requires distinct `text-*` classes, so keep them distinct and token-based.
+
+- [ ] **Step 4: Apply colors in `ui/builder-tree.tsx`**
+
+- Logic `<select>`: add the color class, e.g. `className={`rounded-sm border bg-transparent px-2 py-1 text-sm ${logicColor(group.logic)}`}`.
+- ConditionRow: wrap/append the dataType color on the operator `<select>` or a small dataType badge: e.g. show `condition.dataType` in a span with `className={`font-mono text-[10px] ${dataTypeColor(condition.dataType)}`}`.
+- Add import: `import { logicColor, dataTypeColor } from "@/tools/query-builder/logic/colors";`
+
+- [ ] **Step 5: Run, expect PASS + typecheck**
+
+Run: `pnpm -F web vitest:run colors && pnpm -F web typecheck`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/tools/query-builder/logic/colors.ts apps/web/src/tools/query-builder/logic/colors.spec.ts apps/web/src/tools/query-builder/ui/builder-tree.tsx
+git commit -m "feat(web/query-builder): token-based coloring for logic and dataType"
+```
+
+---
+
+### Task 7: three-pane layout
+
+**Files:**
+- Create: `ui/three-pane.tsx`
+- Rewrite: `ui/index.tsx`
+
+- [ ] **Step 1: Create `ui/three-pane.tsx`** (full-width 3-column at `lg`, stacked below — D4):
+
+```tsx
+import type { ReactNode } from "react";
+
+export function ThreePane({
+  source,
+  builder,
+  output,
+}: {
+  source: ReactNode;
+  builder: ReactNode;
+  output: ReactNode;
+}) {
+  return (
+    <div className="grid grid-cols-1 gap-3 lg:grid-cols-3">
+      <div className="flex flex-col gap-3">{source}</div>
+      <div className="flex flex-col gap-3">{builder}</div>
+      <div className="flex flex-col gap-3">{output}</div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Rewrite `ui/index.tsx`** to use ThreePane, move the engine selector to the output column, build `CompileContext`, and thread `onCreateField`:
+
+```tsx
+"use client";
+
+import { Button } from "@rfjs/web-ui/components/button";
+import { Panel } from "@rfjs/web-ui/components/panel";
+import { useTranslations } from "next-intl";
+import { useMemo, useState } from "react";
+
+import { treeToFilterGroup } from "@/tools/query-builder/logic/compile";
+import { ENGINE_IDS, getEngine, type EngineId } from "@/tools/query-builder/logic/engines";
+import { addInferredField } from "@/tools/query-builder/logic/field-create";
+import { runLiveMatch } from "@/tools/query-builder/logic/live-match";
+import { inferSchema } from "@/tools/query-builder/logic/schema-infer";
+import { emptyGroup } from "@/tools/query-builder/logic/tree-ops";
+import type { BuilderGroup, FieldSchema } from "@/tools/query-builder/logic/types";
+
+import { GroupNode } from "./builder-tree";
+import { PreviewPanel } from "./preview-panel";
+import { SchemaPanel } from "./schema-panel";
+import { ThreePane } from "./three-pane";
+
+const SAMPLE = JSON.stringify(
+  [
+    { name: "Ada", age: 36, active: true, tags: ["ml", "math"] },
+    { name: "Bo", age: 12, active: false, tags: ["games"] },
+  ],
+  null,
+  2,
+);
+
+const id = () => crypto.randomUUID();
+
+export function QueryBuilder() {
+  const t = useTranslations("ToolUI");
+  const [sampleText, setSampleText] = useState(SAMPLE);
+  const [schema, setSchema] = useState<FieldSchema[]>(() => safeInfer(SAMPLE).schema);
+  const [error, setError] = useState<string | null>(() => safeInfer(SAMPLE).error);
+  const [engineId, setEngineId] = useState<EngineId>("pg-filter");
+  const [tree, setTree] = useState<BuilderGroup>(() => emptyGroup(id));
+
+  function onSample(text: string) {
+    setSampleText(text);
+    const { schema: next, error: err } = safeInfer(text);
+    setError(err);
+    if (!err) setSchema(next);
+  }
+
+  const rows = useMemo(() => parseRows(sampleText), [sampleText]);
+  const output = useMemo(
+    () =>
+      getEngine(engineId).compile(treeToFilterGroup(tree), {
+        fields: schema
+          .filter((f) => f.include)
+          .map((f) => ({ path: f.path, kind: f.kind, dataType: f.dataType, elementType: f.elementType })),
+      }),
+    [engineId, tree, schema],
+  );
+  const live = useMemo(() => runLiveMatch(rows, tree), [rows, tree]);
+
+  return (
+    <ThreePane
+      source={
+        <SchemaPanel
+          sampleText={sampleText}
+          schema={schema}
+          error={error}
+          onSampleChange={onSample}
+          onSchemaChange={setSchema}
+        />
+      }
+      builder={
+        <Panel title={t("builder")}>
+          <GroupNode
+            group={tree}
+            engineId={engineId}
+            schema={schema}
+            onChange={setTree}
+            onCreateField={(path) => setSchema((s) => addInferredField(s, path))}
+          />
+        </Panel>
+      }
+      output={
+        <div className="flex flex-col gap-3">
+          <div className="flex flex-wrap gap-2">
+            {ENGINE_IDS.map((eid) => (
+              <Button
+                key={eid}
+                size="sm"
+                variant={eid === engineId ? "default" : "outline"}
+                onClick={() => setEngineId(eid)}
+              >
+                {getEngine(eid).label}
+              </Button>
+            ))}
+          </div>
+          <PreviewPanel output={output} live={live} />
+        </div>
+      }
+    />
+  );
+}
+
+function parseRows(text: string): unknown[] {
+  try {
+    const data: unknown = JSON.parse(text);
+    return Array.isArray(data) ? data : [];
+  } catch {
+    return [];
+  }
+}
+
+function safeInfer(text: string): { schema: FieldSchema[]; error: string | null } {
+  try {
+    return { schema: inferSchema(JSON.parse(text)), error: null };
+  } catch {
+    return { schema: [], error: "invalidJson" };
+  }
+}
+```
+
+> Note: `GroupNode` must accept and forward `onCreateField` (added in Task 5). If Task 5 only added it to `ConditionRow`, also add `onCreateField` to `GroupNode`'s props and pass it down both recursion branches.
+
+- [ ] **Step 3: Verify typecheck + build (SSG)**
+
+Run: `pnpm -F web typecheck && pnpm -F web build`
+Expected: typecheck clean; Next build + SSG prerender succeed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/tools/query-builder/ui/three-pane.tsx apps/web/src/tools/query-builder/ui/index.tsx apps/web/src/tools/query-builder/ui/builder-tree.tsx
+git commit -m "feat(web/query-builder): full-width three-pane layout"
+```
+
+---
+
+### Task 8: tool description i18n + full verification
+
+**Files:**
+- Modify: `messages.ts`
+
+- [ ] **Step 1: Update the tool description** in `messages.ts` to mention column+jsonb + SQL preview (both locales):
+
+en `Tools["query-builder"].description`:
+```
+"Build nested filters over real columns and JSONB, and preview the generated SQL (jsonb / data-filter / pg-filter)."
+```
+zh-TW:
+```
+"在真實欄位與 JSONB 上建構巢狀過濾，並預覽產生的 SQL（jsonb / data-filter / pg-filter）。"
+```
+
+- [ ] **Step 2: Full verification**
+
+Run: `pnpm -F web vitest:run && pnpm -F web typecheck && pnpm -F web build`
+Expected: all query-builder unit tests pass; typecheck clean; build + SSG succeed.
+
+- [ ] **Step 3: Manual smoke (optional but recommended)**
+
+Run: `pnpm -F web dev`, open the query-builder tool, mark `name` as column, add `name contains "A"` + a jsonb `age > 10`, select the pg-filter engine, confirm the SQL preview shows a mixed WHERE with `$1/$2` and the params list.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/tools/query-builder/messages.ts
+git commit -m "docs(web/query-builder): update tool description for pg-filter engine"
+```
+
+---
+
+## Self-Review Notes (plan vs spec)
+
+- B1 model (FieldSchema.kind, default jsonb=D1, mapType, column-only-scalar) → Task 1 ✅
+- Engine interface (CompileContext, operators kind, EngineId pg-filter) → Tasks 2–3 ✅
+- pg-filter engine (config from ctx, target tagging, buildPgFilter, legacy dialect=D2, WHERE-only=D3, error→ok:false) → Task 3 ✅
+- jsonb/data-filter unchanged (structural assignability) → noted in Task 2 ✅
+- live-match engine-independent (no pg-filter special-casing) → unchanged, confirmed in Task 8 smoke ✅
+- B3 three-pane (D4 lg/stacked), colored tree (tokens), creatable combobox, engine selector to right, schema kind control + one-click → Tasks 4–7 ✅
+- apps/web dep on @rfjs/pg-filter → Task 3 ✅
+- i18n en+zh-TW → Tasks 4, 8 ✅
+- Excluded B2/B4, no sort/pagination, no new sql-filter operators, no column uuid → not in plan ✅

--- a/docs/superpowers/plans/2026-06-16-query-builder-pg-filter.md
+++ b/docs/superpowers/plans/2026-06-16-query-builder-pg-filter.md
@@ -11,7 +11,7 @@
 **Spec:** `docs/superpowers/specs/2026-06-16-query-builder-pg-filter-design.md`
 **Decisions locked:** D1 default kind `jsonb` + one-click "top-level scalars → column"; D2 dialect `legacy`; D3 no sort/pagination in builder (WHERE preview only); D4 `lg` 3-column else stacked.
 
-All paths are under `apps/web/src/tools/query-builder/` unless noted. Run tests with `pnpm -F web vitest:run <pattern>`. Commit subjects lowercase (commitlint); never `--no-verify`. Commit messages in English.
+All paths are under `apps/web/src/tools/query-builder/` unless noted. Run tests with `pnpm -F web vitest:run <pattern>`. **Typecheck command is `pnpm -F web check-types`** (web has no `typecheck` script). Workspace `@rfjs/*` deps must be built once (`pnpm build:packages`) for vitest/build to resolve them — already done at baseline. Commit subjects lowercase (commitlint); never `--no-verify`. Commit messages in English.
 
 ---
 
@@ -225,7 +225,7 @@ Replace the `output` memo so it passes a `CompileContext` built from the include
 
 - [ ] **Step 3: Verify typecheck + existing engine tests still pass**
 
-Run: `pnpm -F web vitest:run engines && pnpm -F web typecheck`
+Run: `pnpm -F web vitest:run engines && pnpm -F web check-types`
 Expected: PASS (jsonb/data-filter unchanged and still satisfy `Engine`).
 
 - [ ] **Step 4: Commit**
@@ -455,7 +455,7 @@ export type {
 
 - [ ] **Step 7: Run, expect PASS + typecheck**
 
-Run: `pnpm -F web vitest:run pg-filter engines && pnpm -F web typecheck`
+Run: `pnpm -F web vitest:run pg-filter engines && pnpm -F web check-types`
 Expected: PASS.
 
 - [ ] **Step 8: Commit**
@@ -539,7 +539,7 @@ Add a one-click button above or below the field list (inside the Panel, after th
 
 - [ ] **Step 3: Verify typecheck + build**
 
-Run: `pnpm -F web typecheck`
+Run: `pnpm -F web check-types`
 Expected: PASS.
 
 - [ ] **Step 4: Commit**
@@ -688,7 +688,7 @@ import { FieldCombobox } from "./field-combobox";
 
 - [ ] **Step 7: Verify typecheck + tests**
 
-Run: `pnpm -F web vitest:run field-create && pnpm -F web typecheck`
+Run: `pnpm -F web vitest:run field-create && pnpm -F web check-types`
 Expected: PASS.
 
 - [ ] **Step 8: Commit**
@@ -771,7 +771,7 @@ export function dataTypeColor(dataType: string): string {
 
 - [ ] **Step 5: Run, expect PASS + typecheck**
 
-Run: `pnpm -F web vitest:run colors && pnpm -F web typecheck`
+Run: `pnpm -F web vitest:run colors && pnpm -F web check-types`
 Expected: PASS.
 
 - [ ] **Step 6: Commit**
@@ -939,7 +939,7 @@ function safeInfer(text: string): { schema: FieldSchema[]; error: string | null 
 
 - [ ] **Step 3: Verify typecheck + build (SSG)**
 
-Run: `pnpm -F web typecheck && pnpm -F web build`
+Run: `pnpm -F web check-types && pnpm -F web build`
 Expected: typecheck clean; Next build + SSG prerender succeed.
 
 - [ ] **Step 4: Commit**
@@ -969,7 +969,7 @@ zh-TW:
 
 - [ ] **Step 2: Full verification**
 
-Run: `pnpm -F web vitest:run && pnpm -F web typecheck && pnpm -F web build`
+Run: `pnpm -F web vitest:run && pnpm -F web check-types && pnpm -F web build`
 Expected: all query-builder unit tests pass; typecheck clean; build + SSG succeed.
 
 - [ ] **Step 3: Manual smoke (optional but recommended)**

--- a/docs/superpowers/specs/2026-06-16-query-builder-pg-filter-design.md
+++ b/docs/superpowers/specs/2026-06-16-query-builder-pg-filter-design.md
@@ -1,0 +1,156 @@
+# 設計：query-builder 加入 pg-filter 引擎 + 欄位種類模型 + 三欄彩色 UI
+
+日期：2026-06-16
+狀態：設計中(待 review)
+
+## 背景與目標
+
+`apps/web` 的 query-builder 工具目前是兩欄 ToolShell:左邊輸入(sample JSON → 推斷 schema + 巢狀樹建構),右邊輸出(引擎產出 + live-match)。引擎是個乾淨的 registry,目前有 `jsonb`(→ jsonb SQL)與 `data-filter`(→ 記憶體比對)。**現況:所有欄位一律視為 JSON 路徑,沒有「真欄位 vs jsonb」的概念。**
+
+剛 ship 的 **`@rfjs/pg-filter`**(PR #168)能把「真欄位過濾」與「jsonb 過濾」組成一棵混合樹。要在 query-builder 裡展示它「轉出來的 SQL 長怎樣」,就必須讓使用者把欄位標成 column 或 jsonb —— 否則 pg-filter 跟現有 jsonb 引擎產出無異、毫無價值。
+
+本案範圍(子專案 B 的兩塊):
+- **B1 — 欄位種類模型 + pg-filter 引擎**:讓欄位可標 column/jsonb,新增「Unified PG SQL」引擎。
+- **B3 — 三欄彩色 UI 重做**:把這個工具從兩欄 ToolShell 改成全寬三欄、巢狀樹上色。
+
+排除(各自獨立、之後另開 spec):**B2 反向讀取**(貼任一框反推其他框)、**B4 抽 canonical model / headless hook 成 public npm**。
+
+---
+
+## Part 1（B1）— 欄位種類模型 + pg-filter 引擎
+
+### 1.1 模型變更（`logic/types.ts`）
+
+`FieldSchema` 增加 `kind`,並讓 column 欄位帶一個 SQL 型別:
+
+```ts
+export type FieldKind = 'column' | 'jsonb';
+
+export interface FieldSchema {
+  path: string;
+  dataType: FieldType;        // string|numeric|date|boolean|object|array(不變)
+  elementType?: ElementType;
+  include: boolean;
+  kind: FieldKind;            // 新增
+}
+```
+
+- **canonical 樹(`BuilderCondition`)不動** —— 條件只描述 field/dataType/operator/value,維持與引擎無關。某個 field 是 column 還是 jsonb,由 schema 查得(引擎在 compile 時查)。這保持樹的純粹。
+- **column 只允許 scalar**:`kind:'column'` 僅當 `dataType ∈ {string,numeric,date,boolean}`。object/array 一律 jsonb(UI 禁止把它們設成 column)。
+- **dataType → sql-filter `ColumnType` 映射**:`string→text`、`numeric→numeric`、`date→timestamp`、`boolean→boolean`。(`uuid` 無法從 sample 推斷,本案不支援 column uuid。)
+
+> **決策 D1 — 推斷出的欄位預設 kind?**
+> 建議:預設全部 `jsonb`,使用者再把要當真欄位的勾成 column(顯式、無意外)。另在左欄提供一鍵「把頂層 scalar 全設為 column」加速常見情境(datasets 形狀:頂層欄位 + data blob)。
+
+### 1.2 引擎介面演進（`logic/engines/types.ts`）
+
+兩處加入「欄位種類」資訊,jsonb / data-filter 引擎忽略即可:
+
+```ts
+export type EngineId = 'jsonb' | 'data-filter' | 'pg-filter';   // 加 pg-filter
+
+export interface CompileContext {
+  fields: Array<{ path: string; kind: FieldKind; dataType: FieldType; elementType?: ElementType }>;
+}
+
+export interface Engine {
+  id: EngineId;
+  label: string;
+  operators(dataType: string, elementType?: string, kind?: FieldKind): OperatorSpec[]; // 加 kind
+  compile(group: FilterGroupLike, ctx: CompileContext): EngineOutput;                  // 加 ctx
+}
+```
+
+- `compile` 多收 `ctx`(欄位種類表)。`jsonb`/`data-filter` 簽名照收但不使用。
+- `operators` 多收 `kind`:pg-filter 在 column 欄位回傳 sql-filter 欄位運算子、在 jsonb 欄位回傳 jsonb-query 運算子。builder-tree 渲染運算子下拉時,本來就握有 field → 可查 kind 傳入。
+
+### 1.3 pg-filter 引擎（新檔 `logic/engines/pg-filter.ts`）
+
+```ts
+// 概念
+compile(group, ctx) {
+  const columns = ctx.fields.filter(f => f.kind === 'column')
+    .reduce((acc, f) => ({ ...acc, [f.path]: { column: f.path, type: mapType(f.dataType) } }), {});
+  const config: PgFilterConfig = { columns, jsonb: { column: 'data', dialect: 'legacy' } };
+  const tree = toPgFilterGroup(group, ctx);   // 依 kind 給每葉打 target
+  const { where, values } = buildPgFilter(config, { filter: tree });
+  return { ok: true, primary: where, secondary: JSON.stringify(values, null, 2) };
+}
+```
+
+- `toPgFilterGroup`:走訪 `FilterGroupLike`,每個葉子查 `ctx` 的 kind →
+  - column → `{ target:'column', column: field, operator, value }`
+  - jsonb → `{ target:'jsonb', field, dataType, operator, value, elementType?, filters? }`
+- `operators(dataType, elementType, kind)`:`kind==='column'` → sql-filter 欄位運算子矩陣(eq/neq/isnull/isnotnull 全型別;contains/startswith 限 text;gt/gte/lt/lte 限 numeric/timestamp/text);否則 → 沿用 jsonb 引擎的矩陣。
+- 錯誤(`ColumnQueryError`/`PgFilterError`/`JsonbQueryError`)→ `{ ok:false, error: err.message }`(沿用現有 try/catch 樣式)。
+
+> **決策 D2 — pg-filter 預覽用哪個 jsonb dialect?**
+> 建議:`legacy`,與同工具裡現有 jsonb 引擎一致(畫面風格統一)。備選:`jsonpath`(與 datasets 後端實際用的一致)。
+
+> **決策 D3 — 是否在 builder 裡也展示 sort / pagination?**
+> 建議:**否**。query-builder 的樹是「過濾樹」,沒有排序/分頁 UI。pg-filter 引擎只展示 `WHERE <where>` + 參數(column+jsonb 混合正是賣點)。sort/pagination 預覽留到未來(需要額外 UI)。
+
+### 1.4 live-match（不變）
+
+`runLiveMatch` 以 `@rfjs/data-filter` 對 sample 列做記憶體比對,**與選哪個引擎無關**(它吃 builder 樹,把所有 field 當路徑)。選 pg-filter 時 live-match 照常顯示命中列;若樹含 data-filter 無法涵蓋的 jsonb-only 運算子,維持現有 `uncoverable` 提示。pg-filter 引擎**不需**特別處理。
+
+---
+
+## Part 2（B3）— 三欄全寬彩色 UI
+
+把此工具從兩欄 `ToolShell` 換成**全寬三欄**版面(`ToolShell` 仍供其他簡單工具用)。
+
+```
+┌────────────┬─────────────────────────┬──────────────┐
+│ 左:資料源  │ 中:彩色巢狀樹           │ 右:輸出      │
+│            │                         │              │
+│ sample/貼上│ logic(and/or/nor/not)   │ 引擎切換     │
+│ 欄位清單:  │ /dataType/operator 上色 │ 轉換結果 SQL │
+│  include   │ 遞迴群組 + 條件         │ + 參數       │
+│  kind 切換 │ creatable 欄位 combobox │ live-match   │
+│  type      │                         │ 命中列       │
+└────────────┴─────────────────────────┴──────────────┘
+```
+
+### 2.1 左欄 — 資料源 + schema 控制
+- sample JSON textarea(現有)+ 推斷錯誤提示。
+- 欄位清單,每列:`include` 勾選、**`kind` 切換(column/jsonb,object/array 鎖死為 jsonb)**、`type` 下拉(現有)。
+- 一鍵「頂層 scalar → column」(見 D1)。
+
+### 2.2 中欄 — 彩色巢狀樹
+- 沿用現有遞迴 `GroupNode` / `ConditionRow` 邏輯,改版面與上色。
+- **上色走 `@rfjs/web-ui` Tailwind token,不硬寫色碼**:logic 運算子、dataType、filterOperator 各一組語意色(用既有 token 如 `signal`/`fault`/`muted` 或新增語意 token)。
+- 欄位 key 改 **creatable combobox**:下拉列出推斷出的欄位 + 允許自打新 key;打新 key 即時補一筆 `FieldSchema`(預設 `kind:'jsonb'`、`dataType:'string'`)。(完整「反向讀取」是 B2;此處僅單向新增欄位。)
+
+### 2.3 右欄 — 輸出
+- **引擎切換**(jsonb / data-filter / pg-filter)移到此欄頂(現在在中欄輸入區)。
+- 引擎輸出(primary SQL + secondary 參數,現有 PreviewPanel 邏輯)。
+- live-match 命中列(現有)。
+
+### 2.4 元件拆分
+- 新版面容器 `ui/three-pane.tsx`(取代此工具對 `ToolShell` 的使用;`ToolShell` 不動)。
+- 既有 `schema-panel` / `builder-tree` / `preview-panel` 拆進三欄;新增 `field-combobox.tsx`、配色用的小工具(token 對照,如 `logic-color.ts`)。
+- 既有 `logic/`(compile/engines/tree-ops/live-match/...)**幾乎不動**,只加 pg-filter 引擎與 ctx 串接。
+
+> **決策 D4 — 三欄在窄螢幕的退化?**
+> 建議:`lg` 以上三欄並排;以下垂直堆疊(左→中→右),沿用現有 RWD 樣式慣例。
+
+---
+
+## 相依與套件
+- `apps/web` 加 `@rfjs/pg-filter` dependency(純函式、platform neutral、瀏覽器安全;會帶進 sql-filter + jsonb-query,後者 apps/web 已依賴)。
+- i18n:新字串(kind 切換、pg-filter 標籤、combobox 提示、一鍵設 column 等)加進此工具 co-located 的 `messages.ts`(en + zh-TW)。
+
+## 測試策略
+- **logic(TDD,vitest)**:pg-filter 引擎 compile —— 純 column 樹、純 jsonb 樹、混合樹(驗證每葉 target + 產出 SQL 含對應片段 + 參數連號);`operators(...,kind)` 依 kind 回傳正確矩陣;`mapType` 映射;非法情境(column 設在 object/array 欄位應在 UI 擋掉,引擎層以 ctx 為準)。schema 預設 kind、creatable 新增欄位的 schema-infer 互動。
+- **UI**:沿用現有測試風格(元件渲染 + 互動);三欄版面在 lg/窄螢幕的結構;kind 切換驅動運算子清單改變。
+- 全程 co-located `*.spec.ts`;沿用 apps/web vitest 設定;確認 SSG build 仍過。
+
+## YAGNI / 範圍外
+- **B2 反向讀取**、**B4 public 抽取** 不在本案。
+- pg-filter 的 sort/pagination 預覽不做(D3)。
+- 不加新運算子到 sql-filter(用既有能力)。
+- column uuid 不支援(無法從 sample 推斷)。
+
+## 相關 memory
+[[query-builder-rework-b]](本案 = 其中 B1+B3)、[[sql-filter-and-datasets-query]](@rfjs/pg-filter 來源)、[[rfjs-open-source-and-layering]](B4 分層留待)、[[spec-language-traditional-chinese]]、[[commits-and-pr-in-english]]。

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -317,6 +317,9 @@ importers:
       '@rfjs/object-utils':
         specifier: workspace:*
         version: link:../../packages/object-utils
+      '@rfjs/pg-filter':
+        specifier: workspace:*
+        version: link:../../packages/pg-filter
       '@rfjs/web-core':
         specifier: workspace:*
         version: link:../../packages/web-core


### PR DESCRIPTION
## Summary

Extends the apps/web **query-builder** tool to showcase `@rfjs/pg-filter`: a new "pg-filter" engine previews the unified **column + jsonb** PostgreSQL SQL a filter tree compiles to. To make that meaningful, each inferred field can now be marked as a real SQL **column** or a **jsonb** path, and the tool is redesigned as a full-width 3-column colored layout.

This is sub-project B (slices B1 + B3) from the query-builder rework notes. B2 (reverse-read) and B4 (extract canonical model / headless hook to npm) remain out of scope.

### B1 — field-kind model + pg-filter engine (logic, TDD)
- `FieldSchema` gains `kind: "column" | "jsonb"` (default `jsonb`); `field-kind.ts` maps a scalar dataType → SQL column type and guards object/array out of column-hood.
- The `Engine` interface is widened: `operators(dataType, elementType?, kind?)` and `compile(group, ctx: CompileContext)`. The existing `jsonb` / `data-filter` engines are unchanged (narrower fns satisfy the wider type structurally).
- New `pg-filter` engine: builds a `PgFilterConfig` from the schema's column-kind fields, tags each leaf `target: column | jsonb`, and renders the mixed WHERE + params via `@rfjs/pg-filter`'s `buildPgFilter` (dialect `legacy`, WHERE-only — no sort/pagination in the builder). The engine is **schema-authoritative**: leaf dataType/kind come from the compile context, not a stale condition snapshot.

### B3 — 3-column UI
- Full-width 3 columns at `lg` (stacked below): left = data source + schema (with the per-field column/jsonb toggle + a "top-level scalars → columns" one-click), middle = colored nested tree, right = engine selector + SQL/params output + live match.
- Creatable field combobox (input + datalist; typing a new key adds a jsonb field). Token-based coloring (web-ui `signal/intake/yield/fault`) for logic ops and dataTypes.
- Operator reconciliation: when a field's kind/dataType or the engine changes, a stale operator is reset so the preview never silently errors.

### Process
brainstorm → design spec (zh-TW) → plan → subagent-driven TDD (8 tasks) → adversarial multi-lens review (17 findings → 8 confirmed, all fixed). Notable fixes from review: the field combobox now uses React `useId()` (was a module counter → hydration mismatch); compile is schema-authoritative (was a stale-snapshot → silently-wrong-SQL risk); excluded fields no longer degrade silently.

Spec/plan: `docs/superpowers/specs/2026-06-16-query-builder-pg-filter-design.md`, `docs/superpowers/plans/2026-06-16-query-builder-pg-filter.md`.

## Test Plan
- [x] New logic unit tests (TDD): `field-kind`, `field-create`, `colors`, and `engines/pg-filter` (column ops vs jsonb ops; pure-column / pure-jsonb / mixed / nested-group SQL with contiguous params; elemmatch passthrough; unsupported-op → ok:false).
- [x] Full apps/web suite: **115 tests pass**.
- [x] `pnpm -F web check-types` clean; `pnpm -F web build` compiles + SSG prerender succeeds.
- [x] Rebased onto latest `main` (#170 sidebar grouping, #171 web-core primary-package) — no file overlap, re-verified green.
- [ ] Manual: mark `name` as a column, add `name contains "A"` AND a jsonb `age > 10`, select the pg-filter engine → preview shows a mixed WHERE with `$1/$2` + params.

### Follow-up (optional, not in this PR)
Add `@rfjs/pg-filter` to the query-builder's `relatedPackages` in `@rfjs/web-core` so the new sidebar grouping (#170) can surface it under the pg-filter group.

🤖 Generated with [Claude Code](https://claude.com/claude-code)