### PR TITLE
feat(web): register @rfjs/sql-filter and @rfjs/pg-filter in the package catalog

### DIFF
--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -77,6 +77,8 @@
     "data-transform": { "description": "Data type transformation utilities (string/number/boolean/date)." },
     "data-label": { "description": "Compose display label strings from data paths, value maps, and templates." },
     "jsonb-query": { "description": "PostgreSQL JSONB query builder from filter metadata." },
+    "sql-filter": { "description": "Generic boolean filter-group to SQL with pluggable leaf renderers." },
+    "pg-filter": { "description": "Unified PostgreSQL filter builder over columns and JSONB." },
     "jwt": { "description": "JWT sign/verify/decode helper." },
     "mongo-query": { "description": "MongoDB query builder from filter metadata." },
     "object-utils": { "description": "Object manipulation utilities (flatten, paths, merge)." },

--- a/apps/web/src/messages/zh-TW.json
+++ b/apps/web/src/messages/zh-TW.json
@@ -77,6 +77,8 @@
     "data-transform": { "description": "資料型別轉換工具(字串/數字/布林/日期)。" },
     "data-label": { "description": "從資料路徑、值對應與樣板組合顯示用標籤字串。" },
     "jsonb-query": { "description": "從篩選 metadata 建構 PostgreSQL JSONB 查詢。" },
+    "sql-filter": { "description": "通用布林 filter-group 轉 SQL,可插拔 leaf 渲染器。" },
+    "pg-filter": { "description": "統一的 PostgreSQL 過濾建構器,涵蓋欄位與 JSONB。" },
     "jwt": { "description": "JWT 簽署/驗證/解碼工具。" },
     "mongo-query": { "description": "從篩選 metadata 建構 MongoDB 查詢。" },
     "object-utils": { "description": "物件操作工具(壓平、路徑、合併)。" },

--- a/packages/web-core/src/registry/packages.ts
+++ b/packages/web-core/src/registry/packages.ts
@@ -39,6 +39,21 @@ export const packageRegistry: PackageDefinition[] = [
     relatedTools: ['jsonb-query-generator'],
   },
   {
+    name: '@rfjs/sql-filter',
+    status: 'preview',
+    href: '/packages/sql-filter',
+    github: GITHUB,
+    tags: ['sql', 'filter'],
+  },
+  {
+    name: '@rfjs/pg-filter',
+    status: 'preview',
+    href: '/packages/pg-filter',
+    github: GITHUB,
+    tags: ['postgres', 'jsonb', 'sql', 'filter'],
+    relatedTools: ['query-builder'],
+  },
+  {
     name: '@rfjs/jwt',
     status: 'ready',
     href: '/packages/jwt',

--- a/packages/web-core/src/registry/tools.ts
+++ b/packages/web-core/src/registry/tools.ts
@@ -46,7 +46,7 @@ export const toolRegistry: ToolDefinition[] = [
     category: 'query',
     surface: 'web',
     status: 'preview',
-    relatedPackages: ['@rfjs/jsonb-query', '@rfjs/data-filter'],
+    relatedPackages: ['@rfjs/jsonb-query', '@rfjs/data-filter', '@rfjs/pg-filter'],
     tags: ['builder', 'jsonb', 'sql', 'nested'],
   },
   {


### PR DESCRIPTION
## Summary

Two shipped packages — **`@rfjs/sql-filter`** (PR #164) and **`@rfjs/pg-filter`** (PR #168) — were missing from the apps/web package catalog (`packageRegistry`), so they had no `/packages/<slug>` page and couldn't be referenced by tools. This registers them and links the query-builder tool to pg-filter.

- `packages/web-core/src/registry/packages.ts`: add `@rfjs/sql-filter` (tags `sql/filter`) and `@rfjs/pg-filter` (tags `postgres/jsonb/sql/filter`, `relatedTools: ['query-builder']`), both `status: preview` (not yet on npm).
- `packages/web-core/src/registry/tools.ts`: append `@rfjs/pg-filter` to query-builder's `relatedPackages` (primary stays `@rfjs/jsonb-query`, so sidebar grouping is unchanged) — also required by `registry.spec` (`relatedPackages` must exist in `packageRegistry`).
- `apps/web/src/messages/{en,zh-TW}.json`: add `Packages.sql-filter` / `Packages.pg-filter` descriptions (required by `i18n-content.spec` for every registered package, both locales).

No app logic changes; this is catalog/metadata only. Does not touch `apps/web/src/tools/query-builder/**` (so it's independent of the in-flight reverse-read work).

## Test Plan
- [x] `@rfjs/web-core` registry tests pass (12) — schema, unique names, `relatedPackages`/`relatedTools` cross-refs valid.
- [x] apps/web `i18n-content` + `nav` tests pass (7) — every package slug now has a description in both locales.
- [x] `check-types` clean (web-core + web); `pnpm -F web build` succeeds.
- [x] Build prerenders the two new pages: `/{en,zh-TW}/packages/sql-filter` and `/{en,zh-TW}/packages/pg-filter`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)