### PR TITLE
feat(web/query-builder): reverse-read editable canonical view

### DIFF
--- a/apps/web/src/tools/query-builder/logic/reverse.spec.ts
+++ b/apps/web/src/tools/query-builder/logic/reverse.spec.ts
@@ -37,8 +37,8 @@ describe("filterGroupToTree", () => {
     };
     const tree = filterGroupToTree(g, idGen());
     const cond = tree.children[0];
-    expect(cond.kind).toBe("condition");
-    if (cond.kind === "condition") {
+    expect(cond?.kind).toBe("condition");
+    if (cond?.kind === "condition") {
       expect(cond.operator).toBe("elemmatch");
       expect(cond.filters?.kind).toBe("group");
       expect(cond.filters?.children).toHaveLength(1);

--- a/apps/web/src/tools/query-builder/logic/reverse.spec.ts
+++ b/apps/web/src/tools/query-builder/logic/reverse.spec.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from "vitest";
 
 import { treeToFilterGroup } from "./compile";
-import { filterGroupToTree, parseFilterGroup } from "./reverse";
+import { filterGroupToTree, mergeFieldsFromTree, parseFilterGroup } from "./reverse";
 import type { FilterGroupLike } from "./compile";
+import type { FieldSchema } from "./types";
 
 const idGen = () => {
   let n = 0;
@@ -90,5 +91,35 @@ describe("parseFilterGroup", () => {
   it("rejects a leaf missing field/operator", () => {
     const r = parseFilterGroup(JSON.stringify({ logic: "and", filters: [{ field: "", dataType: "string", operator: "eq" }] }));
     expect(r).toEqual({ ok: false, error: "invalidShape" });
+  });
+});
+
+describe("mergeFieldsFromTree", () => {
+  const base: FieldSchema[] = [{ path: "age", dataType: "numeric", include: true, kind: "column" }];
+
+  it("appends missing fields with kind jsonb and the condition's dataType/elementType", () => {
+    const group: FilterGroupLike = { logic: "and", filters: [
+      { field: "age", dataType: "numeric", operator: "gt", value: 1 },
+      { field: "tags", dataType: "array", elementType: "string", operator: "contains", value: "x" },
+    ] };
+    const out = mergeFieldsFromTree(base, group);
+    expect(out).toHaveLength(2);
+    expect(out.find((f) => f.path === "tags")).toEqual({ path: "tags", dataType: "array", elementType: "string", include: true, kind: "jsonb" });
+  });
+
+  it("does not touch existing fields (keeps their kind)", () => {
+    const group: FilterGroupLike = { logic: "and", filters: [{ field: "age", dataType: "numeric", operator: "gt", value: 1 }] };
+    const out = mergeFieldsFromTree(base, group);
+    expect(out).toBe(base); // no additions → same reference
+    expect(out[0]?.kind).toBe("column");
+  });
+
+  it("includes fields nested in groups and elemmatch", () => {
+    const group: FilterGroupLike = { logic: "and", filters: [
+      { logic: "or", filters: [{ field: "name", dataType: "string", operator: "eq", value: "a" }] },
+      { field: "items", dataType: "array", elementType: "object", operator: "elemmatch", filters: { logic: "and", filters: [{ field: "sku", dataType: "string", operator: "eq", value: "1" }] } },
+    ] };
+    const out = mergeFieldsFromTree([], group);
+    expect(out.map((f) => f.path).sort()).toEqual(["items", "name", "sku"]);
   });
 });

--- a/apps/web/src/tools/query-builder/logic/reverse.spec.ts
+++ b/apps/web/src/tools/query-builder/logic/reverse.spec.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import { treeToFilterGroup } from "./compile";
+import { filterGroupToTree } from "./reverse";
+import type { FilterGroupLike } from "./compile";
+
+const idGen = () => {
+  let n = 0;
+  return () => `id-${n++}`;
+};
+
+describe("filterGroupToTree", () => {
+  it("round-trips through treeToFilterGroup (ids dropped on the way back)", () => {
+    const g: FilterGroupLike = {
+      logic: "and",
+      filters: [
+        { field: "age", dataType: "numeric", operator: "gt", value: 18 },
+        {
+          logic: "or",
+          filters: [
+            { field: "name", dataType: "string", operator: "eq", value: "Ada" },
+            { field: "tags", dataType: "array", elementType: "string", operator: "contains", value: "ml" },
+          ],
+        },
+      ],
+    };
+    expect(treeToFilterGroup(filterGroupToTree(g, idGen()))).toEqual(g);
+  });
+
+  it("maps an elemmatch leaf's filters into a nested BuilderGroup, not a group child", () => {
+    const g: FilterGroupLike = {
+      logic: "and",
+      filters: [
+        { field: "items", dataType: "array", elementType: "object", operator: "elemmatch", filters: { logic: "and", filters: [{ field: "sku", dataType: "string", operator: "eq", value: "x" }] } },
+      ],
+    };
+    const tree = filterGroupToTree(g, idGen());
+    const cond = tree.children[0];
+    expect(cond.kind).toBe("condition");
+    if (cond.kind === "condition") {
+      expect(cond.operator).toBe("elemmatch");
+      expect(cond.filters?.kind).toBe("group");
+      expect(cond.filters?.children).toHaveLength(1);
+    }
+    expect(treeToFilterGroup(tree)).toEqual(g);
+  });
+
+  it("assigns an id to every node", () => {
+    const g: FilterGroupLike = { logic: "and", filters: [{ field: "a", dataType: "string", operator: "eq", value: "1" }] };
+    const tree = filterGroupToTree(g, idGen());
+    expect(tree.id).toBe("id-0");
+    expect(tree.children[0]?.id).toBe("id-1");
+  });
+});

--- a/apps/web/src/tools/query-builder/logic/reverse.spec.ts
+++ b/apps/web/src/tools/query-builder/logic/reverse.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { treeToFilterGroup } from "./compile";
-import { filterGroupToTree } from "./reverse";
+import { filterGroupToTree, parseFilterGroup } from "./reverse";
 import type { FilterGroupLike } from "./compile";
 
 const idGen = () => {
@@ -50,5 +50,45 @@ describe("filterGroupToTree", () => {
     const tree = filterGroupToTree(g, idGen());
     expect(tree.id).toBe("id-0");
     expect(tree.children[0]?.id).toBe("id-1");
+  });
+});
+
+describe("parseFilterGroup", () => {
+  it("accepts a valid filter group", () => {
+    const text = JSON.stringify({ logic: "and", filters: [{ field: "age", dataType: "numeric", operator: "gt", value: 18 }] });
+    const r = parseFilterGroup(text);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.group.filters).toHaveLength(1);
+  });
+
+  it("accepts nested groups and elemmatch", () => {
+    const text = JSON.stringify({
+      logic: "or",
+      filters: [
+        { logic: "and", filters: [{ field: "a", dataType: "string", operator: "eq", value: "x" }] },
+        { field: "items", dataType: "array", elementType: "object", operator: "elemmatch", filters: { logic: "and", filters: [{ field: "sku", dataType: "string", operator: "eq", value: "1" }] } },
+      ],
+    });
+    expect(parseFilterGroup(text).ok).toBe(true);
+  });
+
+  it("rejects invalid JSON", () => {
+    const r = parseFilterGroup("{ not json");
+    expect(r).toEqual({ ok: false, error: "invalidJson" });
+  });
+
+  it("rejects a bad logic operator", () => {
+    const r = parseFilterGroup(JSON.stringify({ logic: "xor", filters: [] }));
+    expect(r).toEqual({ ok: false, error: "invalidShape" });
+  });
+
+  it("rejects filters that is not an array", () => {
+    const r = parseFilterGroup(JSON.stringify({ logic: "and", filters: {} }));
+    expect(r).toEqual({ ok: false, error: "invalidShape" });
+  });
+
+  it("rejects a leaf missing field/operator", () => {
+    const r = parseFilterGroup(JSON.stringify({ logic: "and", filters: [{ field: "", dataType: "string", operator: "eq" }] }));
+    expect(r).toEqual({ ok: false, error: "invalidShape" });
   });
 });

--- a/apps/web/src/tools/query-builder/logic/reverse.ts
+++ b/apps/web/src/tools/query-builder/logic/reverse.ts
@@ -1,0 +1,42 @@
+import type { FilterConditionLike, FilterGroupLike } from "./compile";
+import type {
+  BuilderCondition,
+  BuilderGroup,
+  BuilderItem,
+  ElementType,
+  FieldType,
+  LogicOp,
+} from "./types";
+
+// Inverse of treeToFilterGroup: rebuild an editable tree (with ids) from a
+// structural filter group. Round-trips: treeToFilterGroup(filterGroupToTree(g)) === g
+// for groups whose leaves are complete (field + operator present).
+export function filterGroupToTree(group: FilterGroupLike, makeId: () => string): BuilderGroup {
+  return {
+    kind: "group",
+    id: makeId(),
+    logic: group.logic as LogicOp,
+    children: group.filters.map((item) => toItem(item, makeId)),
+  };
+}
+
+function toItem(item: FilterConditionLike | FilterGroupLike, makeId: () => string): BuilderItem {
+  return "field" in item ? toCondition(item, makeId) : filterGroupToTree(item, makeId);
+}
+
+function toCondition(c: FilterConditionLike, makeId: () => string): BuilderCondition {
+  const out: BuilderCondition = {
+    kind: "condition",
+    id: makeId(),
+    field: c.field,
+    dataType: c.dataType as FieldType,
+    operator: c.operator,
+  };
+  if (c.elementType) out.elementType = c.elementType as ElementType;
+  if (c.operator === "elemmatch" && c.filters) {
+    out.filters = filterGroupToTree(c.filters, makeId);
+  } else if (c.value !== undefined) {
+    out.value = c.value;
+  }
+  return out;
+}

--- a/apps/web/src/tools/query-builder/logic/reverse.ts
+++ b/apps/web/src/tools/query-builder/logic/reverse.ts
@@ -40,3 +40,44 @@ function toCondition(c: FilterConditionLike, makeId: () => string): BuilderCondi
   }
   return out;
 }
+
+export type ReverseError = "invalidJson" | "invalidShape";
+
+const LOGIC_OPS: readonly string[] = ["and", "or", "nor", "not"];
+
+export function parseFilterGroup(
+  text: string,
+): { ok: true; group: FilterGroupLike } | { ok: false; error: ReverseError } {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return { ok: false, error: "invalidJson" };
+  }
+  if (!isValidGroup(parsed)) return { ok: false, error: "invalidShape" };
+  return { ok: true, group: parsed as FilterGroupLike };
+}
+
+function isObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+function isValidGroup(v: unknown): boolean {
+  if (!isObject(v)) return false;
+  if (typeof v.logic !== "string" || !LOGIC_OPS.includes(v.logic)) return false;
+  if (!Array.isArray(v.filters)) return false;
+  return v.filters.every(isValidItem);
+}
+
+function isValidItem(v: unknown): boolean {
+  if (!isObject(v)) return false;
+  return "field" in v ? isValidLeaf(v) : isValidGroup(v);
+}
+
+function isValidLeaf(v: Record<string, unknown>): boolean {
+  if (typeof v.field !== "string" || v.field.length === 0) return false;
+  if (typeof v.dataType !== "string") return false;
+  if (typeof v.operator !== "string" || v.operator.length === 0) return false;
+  if (v.operator === "elemmatch" && v.filters !== undefined) return isValidGroup(v.filters);
+  return true;
+}

--- a/apps/web/src/tools/query-builder/logic/reverse.ts
+++ b/apps/web/src/tools/query-builder/logic/reverse.ts
@@ -4,6 +4,7 @@ import type {
   BuilderGroup,
   BuilderItem,
   ElementType,
+  FieldSchema,
   FieldType,
   LogicOp,
 } from "./types";
@@ -80,4 +81,31 @@ function isValidLeaf(v: Record<string, unknown>): boolean {
   if (typeof v.operator !== "string" || v.operator.length === 0) return false;
   if (v.operator === "elemmatch" && v.filters !== undefined) return isValidGroup(v.filters);
   return true;
+}
+
+// Append fields referenced by the parsed group but absent from the schema, so
+// the builder's field options and the schema-authoritative compile see them.
+// Existing fields are left untouched (kind/dataType preserved).
+export function mergeFieldsFromTree(schema: FieldSchema[], group: FilterGroupLike): FieldSchema[] {
+  const known = new Set(schema.map((f) => f.path));
+  const additions: FieldSchema[] = [];
+
+  const walk = (g: FilterGroupLike): void => {
+    for (const item of g.filters) {
+      if ("field" in item) addLeaf(item);
+      else walk(item);
+    }
+  };
+  const addLeaf = (c: FilterConditionLike): void => {
+    if (!known.has(c.field)) {
+      known.add(c.field);
+      const f: FieldSchema = { path: c.field, dataType: c.dataType as FieldType, include: true, kind: "jsonb" };
+      if (c.elementType) f.elementType = c.elementType as ElementType;
+      additions.push(f);
+    }
+    if (c.operator === "elemmatch" && c.filters) walk(c.filters);
+  };
+
+  walk(group);
+  return additions.length ? [...schema, ...additions] : schema;
 }

--- a/apps/web/src/tools/query-builder/messages.ts
+++ b/apps/web/src/tools/query-builder/messages.ts
@@ -15,6 +15,9 @@ export const messages: LocaleMessages = {
       kindColumn: "column",
       kindJsonb: "jsonb",
       topLevelToColumns: "Top-level scalars → columns",
+      canonicalEditable: "Canonical filter (editable) — edit to rebuild the query",
+      reverseInvalidJson: "Invalid JSON",
+      reverseInvalidShape: "Not a valid filter group",
     },
   },
   "zh-TW": {
@@ -28,6 +31,9 @@ export const messages: LocaleMessages = {
       kindColumn: "欄位",
       kindJsonb: "jsonb",
       topLevelToColumns: "頂層 scalar 設為欄位",
+      canonicalEditable: "Canonical 篩選(可編輯)—— 編輯即反推查詢",
+      reverseInvalidJson: "無效的 JSON",
+      reverseInvalidShape: "不是合法的 filter group",
     },
   },
 };

--- a/apps/web/src/tools/query-builder/ui/canonical-editor.spec.tsx
+++ b/apps/web/src/tools/query-builder/ui/canonical-editor.spec.tsx
@@ -1,0 +1,42 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { CanonicalEditor } from "./canonical-editor";
+
+afterEach(cleanup);
+
+describe("CanonicalEditor", () => {
+  it("calls onParse with the edited text after the debounce window", () => {
+    vi.useFakeTimers();
+    const onParse = vi.fn();
+    render(<CanonicalEditor serialized="{}" errorText={null} hint="edit" onParse={onParse} />);
+    const ta = screen.getByLabelText("edit") as HTMLTextAreaElement;
+    fireEvent.focus(ta);
+    fireEvent.change(ta, { target: { value: '{"logic":"and","filters":[]}' } });
+    expect(onParse).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(300);
+    expect(onParse).toHaveBeenCalledWith('{"logic":"and","filters":[]}');
+    vi.useRealTimers();
+  });
+
+  it("does not overwrite the draft from serialized while the box is focused", () => {
+    const { rerender } = render(<CanonicalEditor serialized="A" errorText={null} hint="edit" onParse={() => {}} />);
+    const ta = screen.getByLabelText("edit") as HTMLTextAreaElement;
+    fireEvent.focus(ta);
+    fireEvent.change(ta, { target: { value: "B" } });
+    rerender(<CanonicalEditor serialized="C" errorText={null} hint="edit" onParse={() => {}} />);
+    expect(ta.value).toBe("B");
+  });
+
+  it("re-syncs the draft from serialized when not editing", () => {
+    const { rerender } = render(<CanonicalEditor serialized="A" errorText={null} hint="edit" onParse={() => {}} />);
+    const ta = screen.getByLabelText("edit") as HTMLTextAreaElement;
+    rerender(<CanonicalEditor serialized="C" errorText={null} hint="edit" onParse={() => {}} />);
+    expect(ta.value).toBe("C");
+  });
+
+  it("shows errorText when present", () => {
+    render(<CanonicalEditor serialized="{}" errorText="bad shape" hint="edit" onParse={() => {}} />);
+    expect(screen.getByText("bad shape")).toBeTruthy();
+  });
+});

--- a/apps/web/src/tools/query-builder/ui/canonical-editor.tsx
+++ b/apps/web/src/tools/query-builder/ui/canonical-editor.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { Panel } from "@rfjs/web-ui/components/panel";
+import { useEffect, useRef, useState } from "react";
+
+// Editable view of the canonical FilterGroupLike JSON. The tree is the source of
+// truth; this box reflects it only when not being edited (avoids clobbering the
+// user's draft / cursor). Edits are debounced before calling onParse.
+export function CanonicalEditor({
+  serialized,
+  errorText,
+  hint,
+  onParse,
+}: {
+  serialized: string;
+  errorText: string | null;
+  hint: string;
+  onParse: (text: string) => void;
+}) {
+  const [draft, setDraft] = useState(serialized);
+  const [editing, setEditing] = useState(false);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (!editing) setDraft(serialized);
+  }, [serialized, editing]);
+
+  useEffect(
+    () => () => {
+      if (timer.current) clearTimeout(timer.current);
+    },
+    [],
+  );
+
+  function onChange(text: string) {
+    setDraft(text);
+    if (timer.current) clearTimeout(timer.current);
+    timer.current = setTimeout(() => onParse(text), 300);
+  }
+
+  return (
+    <Panel title={hint}>
+      <textarea
+        aria-label={hint}
+        value={draft}
+        onChange={(e) => onChange(e.target.value)}
+        onFocus={() => setEditing(true)}
+        onBlur={() => setEditing(false)}
+        spellCheck={false}
+        rows={12}
+        className="w-full resize-y rounded-sm border bg-transparent p-2 font-mono text-sm"
+      />
+      {errorText ? <p className="mt-1 font-mono text-sm text-fault">{errorText}</p> : null}
+    </Panel>
+  );
+}

--- a/apps/web/src/tools/query-builder/ui/index.tsx
+++ b/apps/web/src/tools/query-builder/ui/index.tsx
@@ -9,12 +9,14 @@ import { treeToFilterGroup } from "@/tools/query-builder/logic/compile";
 import { ENGINE_IDS, getEngine, type EngineId } from "@/tools/query-builder/logic/engines";
 import { addInferredField } from "@/tools/query-builder/logic/field-create";
 import { runLiveMatch } from "@/tools/query-builder/logic/live-match";
+import { filterGroupToTree, mergeFieldsFromTree, parseFilterGroup, type ReverseError } from "@/tools/query-builder/logic/reverse";
 import { inferSchema } from "@/tools/query-builder/logic/schema-infer";
 import { emptyGroup } from "@/tools/query-builder/logic/tree-ops";
 import type { BuilderGroup, FieldSchema } from "@/tools/query-builder/logic/types";
 
 import { GroupNode } from "./builder-tree";
-import { PreviewPanel } from "./preview-panel";
+import { CanonicalEditor } from "./canonical-editor";
+import { PreviewPanel, LiveMatchView } from "./preview-panel";
 import { SchemaPanel } from "./schema-panel";
 import { ThreePane } from "./three-pane";
 
@@ -36,6 +38,22 @@ export function QueryBuilder() {
   const [error, setError] = useState<string | null>(() => safeInfer(SAMPLE).error);
   const [engineId, setEngineId] = useState<EngineId>("pg-filter");
   const [tree, setTree] = useState<BuilderGroup>(() => emptyGroup(id));
+  const [reverseError, setReverseError] = useState<ReverseError | null>(null);
+
+  function onReverseParse(text: string) {
+    if (text.trim() === "") {
+      setReverseError(null);
+      return;
+    }
+    const r = parseFilterGroup(text);
+    if (r.ok) {
+      setTree(filterGroupToTree(r.group, id));
+      setSchema((s) => mergeFieldsFromTree(s, r.group));
+      setReverseError(null);
+    } else {
+      setReverseError(r.error);
+    }
+  }
 
   function onSample(text: string) {
     setSampleText(text);
@@ -95,7 +113,25 @@ export function QueryBuilder() {
               </Button>
             ))}
           </div>
-          <PreviewPanel output={output} live={live} />
+          {engineId === "data-filter" ? (
+            <>
+              <CanonicalEditor
+                serialized={JSON.stringify(treeToFilterGroup(tree), null, 2)}
+                errorText={
+                  reverseError === "invalidJson"
+                    ? t("reverseInvalidJson")
+                    : reverseError === "invalidShape"
+                      ? t("reverseInvalidShape")
+                      : null
+                }
+                hint={t("canonicalEditable")}
+                onParse={onReverseParse}
+              />
+              <LiveMatchView live={live} />
+            </>
+          ) : (
+            <PreviewPanel output={output} live={live} />
+          )}
         </div>
       }
     />

--- a/apps/web/src/tools/query-builder/ui/preview-panel.tsx
+++ b/apps/web/src/tools/query-builder/ui/preview-panel.tsx
@@ -7,13 +7,25 @@ import { useTranslations } from "next-intl";
 import type { EngineOutput } from "@/tools/query-builder/logic/engines";
 import type { LiveMatchResult } from "@/tools/query-builder/logic/live-match";
 
-export function PreviewPanel({
-  output,
-  live,
-}: {
-  output: EngineOutput;
-  live: LiveMatchResult;
-}) {
+export function LiveMatchView({ live }: { live: LiveMatchResult }) {
+  const t = useTranslations("ToolUI");
+  return (
+    <div className="border-t border-border pt-2">
+      {live.uncoverable ? (
+        <p className="font-mono text-xs text-muted-foreground">{t("notPreviewable")}</p>
+      ) : (
+        <>
+          <p className="mb-1 font-mono text-xs text-muted-foreground">{t("matched", { count: live.count })}</p>
+          <pre className="max-h-48 overflow-auto font-mono text-xs text-muted-foreground">
+            {JSON.stringify(live.matched, null, 2)}
+          </pre>
+        </>
+      )}
+    </div>
+  );
+}
+
+export function PreviewPanel({ output, live }: { output: EngineOutput; live: LiveMatchResult }) {
   const t = useTranslations("ToolUI");
   return (
     <Panel
@@ -31,18 +43,7 @@ export function PreviewPanel({
         ) : (
           <p className="font-mono text-sm text-fault">{output.error}</p>
         )}
-        <div className="border-t border-border pt-2">
-          {live.uncoverable ? (
-            <p className="font-mono text-xs text-muted-foreground">{t("notPreviewable")}</p>
-          ) : (
-            <>
-              <p className="mb-1 font-mono text-xs text-muted-foreground">{t("matched", { count: live.count })}</p>
-              <pre className="max-h-48 overflow-auto font-mono text-xs text-muted-foreground">
-                {JSON.stringify(live.matched, null, 2)}
-              </pre>
-            </>
-          )}
-        </div>
+        <LiveMatchView live={live} />
       </div>
     </Panel>
   );

--- a/docs/superpowers/plans/2026-06-16-query-builder-reverse-read.md
+++ b/docs/superpowers/plans/2026-06-16-query-builder-reverse-read.md
@@ -1,0 +1,691 @@
+# query-builder 反向讀取(B2)Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 讓 query-builder 在選到 `data-filter` 引擎時,其 canonical `FilterGroupLike` JSON 輸出**就地可編輯**;debounced parse 後反向回寫中間那棵 canonical tree(唯一真相),並把樹用到、schema 還沒有的欄位補進 schema。SQL view 維持唯讀。
+
+**Architecture:** 純 logic 放 `logic/reverse.ts`(`filterGroupToTree` = `treeToFilterGroup` 的逆、`parseFilterGroup` 結構驗證、`mergeFieldsFromTree` 補欄位)。UI 加 presentational 的 `ui/canonical-editor.tsx`(draft + debounce,文字以 props 傳入故免 i18n provider 即可測)。`ui/index.tsx` 在 `engineId === "data-filter"` 時改渲染它,接 `onParse` → `setTree` + `setSchema`;從 `PreviewPanel` 抽 `LiveMatchView` 兩邊共用。
+
+**Tech Stack:** Next.js(client component)、next-intl、Vitest(jsdom,glob `**/*.spec.(ts|tsx)`,globals:true)、`@testing-library/react`、TypeScript、`@/` alias → `apps/web/src`。
+
+**起點 baseline:** `pnpm -F web exec vitest run` → 115 passed(24 files)。所有指令在 worktree 根 `/home/royfw/_/code/royfw/rfjs/.claude/worktrees/feat+query-builder-reverse` 執行;commit 用 `--no-verify`,footer `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`;commit/PR 一律英文。
+
+---
+
+## 現況型別(只讀,勿改;供引用)
+
+`logic/types.ts`:
+```ts
+export type LogicOp = "and" | "or" | "nor" | "not";
+export type FieldKind = "column" | "jsonb";
+export type ScalarType = "string" | "numeric" | "date" | "boolean";
+export type FieldType = ScalarType | "object" | "array";
+export type ElementType = ScalarType | "object";
+export interface BuilderGroup { kind: "group"; id: string; logic: LogicOp; children: BuilderItem[]; }
+export interface BuilderCondition { kind: "condition"; id: string; field: string; dataType: FieldType; elementType?: ElementType; operator: string; value?: unknown; filters?: BuilderGroup; }
+export type BuilderItem = BuilderGroup | BuilderCondition;
+export interface FieldSchema { path: string; dataType: FieldType; elementType?: ElementType; include: boolean; kind: FieldKind; }
+```
+`logic/compile.ts`:
+```ts
+export interface FilterGroupLike { logic: string; filters: Array<FilterConditionLike | FilterGroupLike>; }
+export interface FilterConditionLike { field: string; dataType: string; elementType?: string; operator: string; value?: unknown; filters?: FilterGroupLike; }
+export function treeToFilterGroup(group: BuilderGroup): FilterGroupLike { /* 既有:丟棄不完整條件、去 id、elemmatch 遞迴 */ }
+```
+
+## File Structure
+
+```
+apps/web/src/tools/query-builder/
+  logic/
+    reverse.ts        # 新:filterGroupToTree + parseFilterGroup + mergeFieldsFromTree + ReverseError
+    reverse.spec.ts   # 新
+  ui/
+    canonical-editor.tsx       # 新:可編輯框(presentational,props 傳文字)
+    canonical-editor.spec.tsx  # 新
+    preview-panel.tsx          # 改:抽出並 export LiveMatchView
+    index.tsx                  # 改:data-filter 分支接 CanonicalEditor + 反向 wiring
+  messages.ts                  # 改:加 ToolUI 扁平 key(canonicalEditable / reverseInvalidJson / reverseInvalidShape)
+```
+
+---
+
+## Task 1: `filterGroupToTree`(canonical → tree,round-trip)
+
+**Files:** Create `apps/web/src/tools/query-builder/logic/reverse.ts`, `apps/web/src/tools/query-builder/logic/reverse.spec.ts`
+
+- [ ] **Step 1: 寫失敗測試** — `logic/reverse.spec.ts`:
+```ts
+import { describe, expect, it } from "vitest";
+
+import { treeToFilterGroup } from "./compile";
+import { filterGroupToTree } from "./reverse";
+import type { FilterGroupLike } from "./compile";
+
+const idGen = () => {
+  let n = 0;
+  return () => `id-${n++}`;
+};
+
+describe("filterGroupToTree", () => {
+  it("round-trips through treeToFilterGroup (ids dropped on the way back)", () => {
+    const g: FilterGroupLike = {
+      logic: "and",
+      filters: [
+        { field: "age", dataType: "numeric", operator: "gt", value: 18 },
+        {
+          logic: "or",
+          filters: [
+            { field: "name", dataType: "string", operator: "eq", value: "Ada" },
+            { field: "tags", dataType: "array", elementType: "string", operator: "contains", value: "ml" },
+          ],
+        },
+      ],
+    };
+    expect(treeToFilterGroup(filterGroupToTree(g, idGen()))).toEqual(g);
+  });
+
+  it("maps an elemmatch leaf's filters into a nested BuilderGroup, not a group child", () => {
+    const g: FilterGroupLike = {
+      logic: "and",
+      filters: [
+        { field: "items", dataType: "array", elementType: "object", operator: "elemmatch", filters: { logic: "and", filters: [{ field: "sku", dataType: "string", operator: "eq", value: "x" }] } },
+      ],
+    };
+    const tree = filterGroupToTree(g, idGen());
+    const cond = tree.children[0];
+    expect(cond.kind).toBe("condition");
+    if (cond.kind === "condition") {
+      expect(cond.operator).toBe("elemmatch");
+      expect(cond.filters?.kind).toBe("group");
+      expect(cond.filters?.children).toHaveLength(1);
+    }
+    expect(treeToFilterGroup(tree)).toEqual(g);
+  });
+
+  it("assigns an id to every node", () => {
+    const g: FilterGroupLike = { logic: "and", filters: [{ field: "a", dataType: "string", operator: "eq", value: "1" }] };
+    const tree = filterGroupToTree(g, idGen());
+    expect(tree.id).toBe("id-0");
+    expect(tree.children[0]?.id).toBe("id-1");
+  });
+});
+```
+
+- [ ] **Step 2: 跑測試確認失敗** — Run: `pnpm -F web exec vitest run src/tools/query-builder/logic/reverse.spec.ts` → FAIL(`./reverse` 無法解析)。
+
+- [ ] **Step 3: 實作 `logic/reverse.ts`(本 task 只需 `filterGroupToTree`)**
+```ts
+import type { FilterConditionLike, FilterGroupLike } from "./compile";
+import type {
+  BuilderCondition,
+  BuilderGroup,
+  BuilderItem,
+  ElementType,
+  FieldType,
+  LogicOp,
+} from "./types";
+
+// Inverse of treeToFilterGroup: rebuild an editable tree (with ids) from a
+// structural filter group. Round-trips: treeToFilterGroup(filterGroupToTree(g)) === g
+// for groups whose leaves are complete (field + operator present).
+export function filterGroupToTree(group: FilterGroupLike, makeId: () => string): BuilderGroup {
+  return {
+    kind: "group",
+    id: makeId(),
+    logic: group.logic as LogicOp,
+    children: group.filters.map((item) => toItem(item, makeId)),
+  };
+}
+
+function toItem(item: FilterConditionLike | FilterGroupLike, makeId: () => string): BuilderItem {
+  return "field" in item ? toCondition(item, makeId) : filterGroupToTree(item, makeId);
+}
+
+function toCondition(c: FilterConditionLike, makeId: () => string): BuilderCondition {
+  const out: BuilderCondition = {
+    kind: "condition",
+    id: makeId(),
+    field: c.field,
+    dataType: c.dataType as FieldType,
+    operator: c.operator,
+  };
+  if (c.elementType) out.elementType = c.elementType as ElementType;
+  if (c.operator === "elemmatch" && c.filters) {
+    out.filters = filterGroupToTree(c.filters, makeId);
+  } else if (c.value !== undefined) {
+    out.value = c.value;
+  }
+  return out;
+}
+```
+
+- [ ] **Step 4: 跑測試確認通過** — Run: `pnpm -F web exec vitest run src/tools/query-builder/logic/reverse.spec.ts` → PASS(3 tests)。
+
+- [ ] **Step 5: commit**
+```bash
+git add apps/web/src/tools/query-builder/logic/reverse.ts apps/web/src/tools/query-builder/logic/reverse.spec.ts
+git commit --no-verify -m "$(cat <<'EOF'
+feat(web/query-builder): filterGroupToTree for reverse-read
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: `parseFilterGroup`(JSON + 結構驗證)
+
+**Files:** Modify `apps/web/src/tools/query-builder/logic/reverse.ts`, `apps/web/src/tools/query-builder/logic/reverse.spec.ts`
+
+- [ ] **Step 1: 追加失敗測試** — 在 `reverse.spec.ts` 末尾追加:
+```ts
+import { parseFilterGroup } from "./reverse";
+
+describe("parseFilterGroup", () => {
+  it("accepts a valid filter group", () => {
+    const text = JSON.stringify({ logic: "and", filters: [{ field: "age", dataType: "numeric", operator: "gt", value: 18 }] });
+    const r = parseFilterGroup(text);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.group.filters).toHaveLength(1);
+  });
+
+  it("accepts nested groups and elemmatch", () => {
+    const text = JSON.stringify({
+      logic: "or",
+      filters: [
+        { logic: "and", filters: [{ field: "a", dataType: "string", operator: "eq", value: "x" }] },
+        { field: "items", dataType: "array", elementType: "object", operator: "elemmatch", filters: { logic: "and", filters: [{ field: "sku", dataType: "string", operator: "eq", value: "1" }] } },
+      ],
+    });
+    expect(parseFilterGroup(text).ok).toBe(true);
+  });
+
+  it("rejects invalid JSON", () => {
+    const r = parseFilterGroup("{ not json");
+    expect(r).toEqual({ ok: false, error: "invalidJson" });
+  });
+
+  it("rejects a bad logic operator", () => {
+    const r = parseFilterGroup(JSON.stringify({ logic: "xor", filters: [] }));
+    expect(r).toEqual({ ok: false, error: "invalidShape" });
+  });
+
+  it("rejects filters that is not an array", () => {
+    const r = parseFilterGroup(JSON.stringify({ logic: "and", filters: {} }));
+    expect(r).toEqual({ ok: false, error: "invalidShape" });
+  });
+
+  it("rejects a leaf missing field/operator", () => {
+    const r = parseFilterGroup(JSON.stringify({ logic: "and", filters: [{ field: "", dataType: "string", operator: "eq" }] }));
+    expect(r).toEqual({ ok: false, error: "invalidShape" });
+  });
+});
+```
+
+- [ ] **Step 2: 跑測試確認失敗** — Run: `pnpm -F web exec vitest run src/tools/query-builder/logic/reverse.spec.ts` → FAIL(`parseFilterGroup` 未匯出)。
+
+- [ ] **Step 3: 追加實作到 `logic/reverse.ts`**
+```ts
+export type ReverseError = "invalidJson" | "invalidShape";
+
+const LOGIC_OPS: readonly string[] = ["and", "or", "nor", "not"];
+
+export function parseFilterGroup(
+  text: string,
+): { ok: true; group: FilterGroupLike } | { ok: false; error: ReverseError } {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return { ok: false, error: "invalidJson" };
+  }
+  if (!isValidGroup(parsed)) return { ok: false, error: "invalidShape" };
+  return { ok: true, group: parsed as FilterGroupLike };
+}
+
+function isObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+function isValidGroup(v: unknown): boolean {
+  if (!isObject(v)) return false;
+  if (typeof v.logic !== "string" || !LOGIC_OPS.includes(v.logic)) return false;
+  if (!Array.isArray(v.filters)) return false;
+  return v.filters.every(isValidItem);
+}
+
+function isValidItem(v: unknown): boolean {
+  if (!isObject(v)) return false;
+  return "field" in v ? isValidLeaf(v) : isValidGroup(v);
+}
+
+function isValidLeaf(v: Record<string, unknown>): boolean {
+  if (typeof v.field !== "string" || v.field.length === 0) return false;
+  if (typeof v.dataType !== "string") return false;
+  if (typeof v.operator !== "string" || v.operator.length === 0) return false;
+  if (v.operator === "elemmatch" && v.filters !== undefined) return isValidGroup(v.filters);
+  return true;
+}
+```
+
+- [ ] **Step 4: 跑測試確認通過** — Run: `pnpm -F web exec vitest run src/tools/query-builder/logic/reverse.spec.ts` → PASS(3 + 6 = 9 tests)。
+
+- [ ] **Step 5: commit**
+```bash
+git add apps/web/src/tools/query-builder/logic/reverse.ts apps/web/src/tools/query-builder/logic/reverse.spec.ts
+git commit --no-verify -m "$(cat <<'EOF'
+feat(web/query-builder): parseFilterGroup with shape validation
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: `mergeFieldsFromTree`(補缺欄位)
+
+**Files:** Modify `apps/web/src/tools/query-builder/logic/reverse.ts`, `apps/web/src/tools/query-builder/logic/reverse.spec.ts`
+
+- [ ] **Step 1: 追加失敗測試**:
+```ts
+import { mergeFieldsFromTree } from "./reverse";
+import type { FieldSchema } from "./types";
+
+describe("mergeFieldsFromTree", () => {
+  const base: FieldSchema[] = [{ path: "age", dataType: "numeric", include: true, kind: "column" }];
+
+  it("appends missing fields with kind jsonb and the condition's dataType/elementType", () => {
+    const group = { logic: "and", filters: [
+      { field: "age", dataType: "numeric", operator: "gt", value: 1 },
+      { field: "tags", dataType: "array", elementType: "string", operator: "contains", value: "x" },
+    ] } as const;
+    const out = mergeFieldsFromTree(base, group);
+    expect(out).toHaveLength(2);
+    expect(out.find((f) => f.path === "tags")).toEqual({ path: "tags", dataType: "array", elementType: "string", include: true, kind: "jsonb" });
+  });
+
+  it("does not touch existing fields (keeps their kind)", () => {
+    const group = { logic: "and", filters: [{ field: "age", dataType: "numeric", operator: "gt", value: 1 }] } as const;
+    const out = mergeFieldsFromTree(base, group);
+    expect(out).toBe(base); // no additions → same reference
+    expect(out[0].kind).toBe("column");
+  });
+
+  it("includes fields nested in groups and elemmatch", () => {
+    const group = { logic: "and", filters: [
+      { logic: "or", filters: [{ field: "name", dataType: "string", operator: "eq", value: "a" }] },
+      { field: "items", dataType: "array", elementType: "object", operator: "elemmatch", filters: { logic: "and", filters: [{ field: "sku", dataType: "string", operator: "eq", value: "1" }] } },
+    ] } as const;
+    const out = mergeFieldsFromTree([], group);
+    expect(out.map((f) => f.path).sort()).toEqual(["items", "name", "sku"]);
+  });
+});
+```
+
+- [ ] **Step 2: 跑測試確認失敗** — Run: `pnpm -F web exec vitest run src/tools/query-builder/logic/reverse.spec.ts` → FAIL(`mergeFieldsFromTree` 未匯出)。
+
+- [ ] **Step 3: 追加實作到 `logic/reverse.ts`**
+```ts
+import type { FieldSchema } from "./types";
+
+// Append fields referenced by the parsed group but absent from the schema, so
+// the builder's field options and the schema-authoritative compile see them.
+// Existing fields are left untouched (kind/dataType preserved).
+export function mergeFieldsFromTree(schema: FieldSchema[], group: FilterGroupLike): FieldSchema[] {
+  const known = new Set(schema.map((f) => f.path));
+  const additions: FieldSchema[] = [];
+
+  const walk = (g: FilterGroupLike): void => {
+    for (const item of g.filters) {
+      if ("field" in item) addLeaf(item);
+      else walk(item);
+    }
+  };
+  const addLeaf = (c: FilterConditionLike): void => {
+    if (!known.has(c.field)) {
+      known.add(c.field);
+      const f: FieldSchema = { path: c.field, dataType: c.dataType as FieldType, include: true, kind: "jsonb" };
+      if (c.elementType) f.elementType = c.elementType as ElementType;
+      additions.push(f);
+    }
+    if (c.operator === "elemmatch" && c.filters) walk(c.filters);
+  };
+
+  walk(group);
+  return additions.length ? [...schema, ...additions] : schema;
+}
+```
+(註:`FilterConditionLike` 已在檔首從 `./compile` import;`FieldType`/`ElementType` 已從 `./types` import。新增的 `FieldSchema` import 併入既有 `./types` import 行。)
+
+- [ ] **Step 4: 跑測試確認通過** — Run: `pnpm -F web exec vitest run src/tools/query-builder/logic/reverse.spec.ts` → PASS(9 + 3 = 12 tests)。
+
+- [ ] **Step 5: commit**
+```bash
+git add apps/web/src/tools/query-builder/logic/reverse.ts apps/web/src/tools/query-builder/logic/reverse.spec.ts
+git commit --no-verify -m "$(cat <<'EOF'
+feat(web/query-builder): mergeFieldsFromTree for reverse-read schema backfill
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: `CanonicalEditor` 元件(presentational + debounce)
+
+文字以 props 傳入(`hint` / `errorText`),故元件**不**用 `useTranslations`,測試免包 i18n provider。
+
+**Files:** Create `apps/web/src/tools/query-builder/ui/canonical-editor.tsx`, `apps/web/src/tools/query-builder/ui/canonical-editor.spec.tsx`
+
+- [ ] **Step 1: 寫失敗測試** — `ui/canonical-editor.spec.tsx`:
+```tsx
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { CanonicalEditor } from "./canonical-editor";
+
+afterEach(cleanup);
+
+describe("CanonicalEditor", () => {
+  it("calls onParse with the edited text after the debounce window", () => {
+    vi.useFakeTimers();
+    const onParse = vi.fn();
+    render(<CanonicalEditor serialized="{}" errorText={null} hint="edit" onParse={onParse} />);
+    const ta = screen.getByLabelText("edit") as HTMLTextAreaElement;
+    fireEvent.focus(ta);
+    fireEvent.change(ta, { target: { value: '{"logic":"and","filters":[]}' } });
+    expect(onParse).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(300);
+    expect(onParse).toHaveBeenCalledWith('{"logic":"and","filters":[]}');
+    vi.useRealTimers();
+  });
+
+  it("does not overwrite the draft from serialized while the box is focused", () => {
+    const { rerender } = render(<CanonicalEditor serialized="A" errorText={null} hint="edit" onParse={() => {}} />);
+    const ta = screen.getByLabelText("edit") as HTMLTextAreaElement;
+    fireEvent.focus(ta);
+    fireEvent.change(ta, { target: { value: "B" } });
+    rerender(<CanonicalEditor serialized="C" errorText={null} hint="edit" onParse={() => {}} />);
+    expect(ta.value).toBe("B"); // serialized change ignored while editing
+  });
+
+  it("re-syncs the draft from serialized when not editing", () => {
+    const { rerender } = render(<CanonicalEditor serialized="A" errorText={null} hint="edit" onParse={() => {}} />);
+    const ta = screen.getByLabelText("edit") as HTMLTextAreaElement;
+    rerender(<CanonicalEditor serialized="C" errorText={null} hint="edit" onParse={() => {}} />);
+    expect(ta.value).toBe("C");
+  });
+
+  it("shows errorText when present", () => {
+    render(<CanonicalEditor serialized="{}" errorText="bad shape" hint="edit" onParse={() => {}} />);
+    expect(screen.getByText("bad shape")).toBeTruthy();
+  });
+});
+```
+
+- [ ] **Step 2: 跑測試確認失敗** — Run: `pnpm -F web exec vitest run src/tools/query-builder/ui/canonical-editor.spec.tsx` → FAIL(`./canonical-editor` 無法解析)。
+
+- [ ] **Step 3: 實作 `ui/canonical-editor.tsx`**
+```tsx
+"use client";
+
+import { Panel } from "@rfjs/web-ui/components/panel";
+import { useEffect, useRef, useState } from "react";
+
+// Editable view of the canonical FilterGroupLike JSON. The tree is the source of
+// truth; this box reflects it only when not being edited (avoids clobbering the
+// user's draft / cursor). Edits are debounced before calling onParse.
+export function CanonicalEditor({
+  serialized,
+  errorText,
+  hint,
+  onParse,
+}: {
+  serialized: string;
+  errorText: string | null;
+  hint: string;
+  onParse: (text: string) => void;
+}) {
+  const [draft, setDraft] = useState(serialized);
+  const [editing, setEditing] = useState(false);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (!editing) setDraft(serialized);
+  }, [serialized, editing]);
+
+  useEffect(() => () => {
+    if (timer.current) clearTimeout(timer.current);
+  }, []);
+
+  function onChange(text: string) {
+    setDraft(text);
+    if (timer.current) clearTimeout(timer.current);
+    timer.current = setTimeout(() => onParse(text), 300);
+  }
+
+  return (
+    <Panel title={hint}>
+      <textarea
+        aria-label={hint}
+        value={draft}
+        onChange={(e) => onChange(e.target.value)}
+        onFocus={() => setEditing(true)}
+        onBlur={() => setEditing(false)}
+        spellCheck={false}
+        rows={12}
+        className="w-full resize-y rounded-sm border bg-transparent p-2 font-mono text-sm"
+      />
+      {errorText ? <p className="mt-1 font-mono text-sm text-fault">{errorText}</p> : null}
+    </Panel>
+  );
+}
+```
+
+- [ ] **Step 4: 跑測試確認通過** — Run: `pnpm -F web exec vitest run src/tools/query-builder/ui/canonical-editor.spec.tsx` → PASS(4 tests)。
+
+- [ ] **Step 5: commit**
+```bash
+git add apps/web/src/tools/query-builder/ui/canonical-editor.tsx apps/web/src/tools/query-builder/ui/canonical-editor.spec.tsx
+git commit --no-verify -m "$(cat <<'EOF'
+feat(web/query-builder): CanonicalEditor debounced editable JSON view
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: 抽 `LiveMatchView` + 接線 index.tsx + i18n + 完整驗證
+
+**Files:** Modify `apps/web/src/tools/query-builder/ui/preview-panel.tsx`, `apps/web/src/tools/query-builder/ui/index.tsx`, `apps/web/src/tools/query-builder/messages.ts`
+
+### 5a. 從 PreviewPanel 抽 `LiveMatchView`(兩邊共用,行為不變)
+
+- [ ] **Step 1: 改 `ui/preview-panel.tsx`** — 抽出並 export `LiveMatchView`,`PreviewPanel` 改用它(輸出/命中區塊外觀不變):
+```tsx
+"use client";
+
+import { CopyButton } from "@rfjs/web-ui/components/copy-button";
+import { Panel } from "@rfjs/web-ui/components/panel";
+import { useTranslations } from "next-intl";
+
+import type { EngineOutput } from "@/tools/query-builder/logic/engines";
+import type { LiveMatchResult } from "@/tools/query-builder/logic/live-match";
+
+export function LiveMatchView({ live }: { live: LiveMatchResult }) {
+  const t = useTranslations("ToolUI");
+  return (
+    <div className="border-t border-border pt-2">
+      {live.uncoverable ? (
+        <p className="font-mono text-xs text-muted-foreground">{t("notPreviewable")}</p>
+      ) : (
+        <>
+          <p className="mb-1 font-mono text-xs text-muted-foreground">{t("matched", { count: live.count })}</p>
+          <pre className="max-h-48 overflow-auto font-mono text-xs text-muted-foreground">
+            {JSON.stringify(live.matched, null, 2)}
+          </pre>
+        </>
+      )}
+    </div>
+  );
+}
+
+export function PreviewPanel({ output, live }: { output: EngineOutput; live: LiveMatchResult }) {
+  const t = useTranslations("ToolUI");
+  return (
+    <Panel
+      title={t("output")}
+      action={output.ok ? <CopyButton text={output.primary} label={t("copy")} /> : null}
+    >
+      <div className="flex flex-col gap-3">
+        {output.ok ? (
+          <>
+            <pre className="overflow-x-auto font-mono text-sm text-signal">{output.primary}</pre>
+            {output.secondary ? (
+              <pre className="overflow-x-auto font-mono text-xs text-muted-foreground">{output.secondary}</pre>
+            ) : null}
+          </>
+        ) : (
+          <p className="font-mono text-sm text-fault">{output.error}</p>
+        )}
+        <LiveMatchView live={live} />
+      </div>
+    </Panel>
+  );
+}
+```
+
+- [ ] **Step 2: 確認既有測試仍綠** — Run: `pnpm -F web exec vitest run src/tools/query-builder` → PASS(無回歸)。
+
+### 5b. i18n 扁平 key
+
+- [ ] **Step 3: 改 `messages.ts`** — 在 query-builder fragment 的 `ToolUI`(en 與 zh-TW 都要)各加三個**扁平** key(勿用 `error.*` 巢狀,否則與中央 `ToolUI.error` 撞、觸發 A 的碰撞守門測試):
+```ts
+// en.ToolUI 內追加:
+canonicalEditable: "Canonical filter (editable) — edit to rebuild the query",
+reverseInvalidJson: "Invalid JSON",
+reverseInvalidShape: "Not a valid filter group",
+// "zh-TW".ToolUI 內追加:
+canonicalEditable: "Canonical 篩選(可編輯)—— 編輯即反推查詢",
+reverseInvalidJson: "無效的 JSON",
+reverseInvalidShape: "不是合法的 filter group",
+```
+
+### 5c. 接線 index.tsx
+
+- [ ] **Step 4: 改 `ui/index.tsx`** — 加反向 state 與 wiring,並在 `engineId === "data-filter"` 改渲染 `CanonicalEditor` + `LiveMatchView`。
+
+新增 import:
+```ts
+import { filterGroupToTree, mergeFieldsFromTree, parseFilterGroup, type ReverseError } from "@/tools/query-builder/logic/reverse";
+import { CanonicalEditor } from "./canonical-editor";
+import { PreviewPanel, LiveMatchView } from "./preview-panel";
+```
+(把原本 `import { PreviewPanel } from "./preview-panel";` 改為上面這行含 `LiveMatchView`。)
+
+在 component 內、`const [tree, setTree] = ...` 之後加:
+```ts
+const [reverseError, setReverseError] = useState<ReverseError | null>(null);
+
+function onReverseParse(text: string) {
+  if (text.trim() === "") {
+    setReverseError(null);
+    return;
+  }
+  const r = parseFilterGroup(text);
+  if (r.ok) {
+    setTree(filterGroupToTree(r.group, id));
+    setSchema((s) => mergeFieldsFromTree(s, r.group));
+    setReverseError(null);
+  } else {
+    setReverseError(r.error);
+  }
+}
+```
+把 `output={...}` 的內容改成依引擎分支(引擎切換器保留,僅輸出區依 data-filter 切換):
+```tsx
+output={
+  <div className="flex flex-col gap-3">
+    <div className="flex flex-wrap gap-2">
+      {ENGINE_IDS.map((eid) => (
+        <Button
+          key={eid}
+          size="sm"
+          variant={eid === engineId ? "default" : "outline"}
+          onClick={() => setEngineId(eid)}
+        >
+          {getEngine(eid).label}
+        </Button>
+      ))}
+    </div>
+    {engineId === "data-filter" ? (
+      <>
+        <CanonicalEditor
+          serialized={JSON.stringify(treeToFilterGroup(tree), null, 2)}
+          errorText={
+            reverseError === "invalidJson"
+              ? t("reverseInvalidJson")
+              : reverseError === "invalidShape"
+                ? t("reverseInvalidShape")
+                : null
+          }
+          hint={t("canonicalEditable")}
+          onParse={onReverseParse}
+        />
+        <LiveMatchView live={live} />
+      </>
+    ) : (
+      <PreviewPanel output={output} live={live} />
+    )}
+  </div>
+}
+```
+(註:`treeToFilterGroup` 已在檔首 import;`t` 為既有 `useTranslations("ToolUI")`。原 `output` 區塊裡的引擎切換器移到這裡共用,勿重複。)
+
+### 5d. 完整驗證 + commit
+
+- [ ] **Step 5: 完整驗證**
+- Run: `pnpm -F web exec vitest run` → 預期全綠(115 baseline + reverse 12 + canonical-editor 4 = 131;若數字略有出入以全綠為準)。
+- Run: `pnpm -F web check-types` → 0 errors。
+- Run: `pnpm -F web lint` → clean。
+- Run: `pnpm -F web build` → 成功,`/tools/[slug]`(含 query-builder)SSG prerender 無錯。
+
+- [ ] **Step 6: commit**
+```bash
+git add apps/web/src/tools/query-builder
+git commit --no-verify -m "$(cat <<'EOF'
+feat(web/query-builder): reverse-read editable canonical view
+
+When the data-filter engine is selected, its canonical FilterGroupLike
+JSON becomes editable: a debounced parse rewrites the builder tree and
+backfills missing schema fields, while invalid input shows an inline
+error and leaves the tree unchanged. SQL engines stay read-only.
+Extracts LiveMatchView so the live preview shows in both modes.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Self-Review
+
+- **行為(可編輯 data-filter 框 → debounced parse → 回寫樹 + 補 schema)** → Task 5c。✅
+- **filterGroupToTree(逆 + elemmatch + id)** → Task 1。✅
+- **parseFilterGroup(invalidJson/invalidShape)** → Task 2。✅
+- **mergeFieldsFromTree(補缺、保留既有、elemmatch 巢狀)** → Task 3。✅
+- **防迴圈(編輯中不回染)+ debounce** → Task 4(CanonicalEditor)+ 測試。✅
+- **空字串不報錯不改樹** → Task 5c `onReverseParse` 的 `text.trim() === ""` 早退。✅
+- **SQL 唯讀 / live-match 兩邊都在** → Task 5a 抽 `LiveMatchView`、5c 分支。✅
+- **i18n 扁平 key 避免 A 碰撞守門** → Task 5b(`canonicalEditable`/`reverseInvalidJson`/`reverseInvalidShape`,非 `error.*`)。✅
+- **id 用 crypto.randomUUID(既有 `id`)避免 hydration 雷** → Task 5c 沿用既有 `id`。✅
+- **型別一致**:`ReverseError`、`filterGroupToTree(group, makeId)`、`mergeFieldsFromTree(schema, group)`、`CanonicalEditor` props 在各 task 一致。✅
+
+**YAGNI**:不反解 SQL、不做 mongo、不新增 tool、不抽 public lib、不動 sample→infer 與 schema 編輯既有流程。

--- a/docs/superpowers/specs/2026-06-16-query-builder-reverse-read-design.md
+++ b/docs/superpowers/specs/2026-06-16-query-builder-reverse-read-design.md
@@ -1,0 +1,96 @@
+# query-builder 反向讀取(B2)— 設計
+
+> 子專案 **B** 的第 4 塊中的 **B2**。B1(pg-filter 引擎 + field-kind)與 B3(三欄彩色 UI + creatable 欄位)已於 PR #172 ship。本案就地加在現有 `apps/web/src/tools/query-builder`,**不新增 tool**。B4(抽 public lib)仍 parked,不在本案。
+
+## 背景
+
+現在的 query-builder(#172 後)是三欄:**左** `SchemaPanel`(sample 資料 + schema 編輯)、**中** `GroupNode`(canonical 樹)、**右** 引擎切換器 + `PreviewPanel`(輸出 + live-match)。資料流是**單向 forward**:`tree → treeToFilterGroup → engine.compile → 輸出`。state 在 `ui/index.tsx`:`sampleText / schema / engineId / tree`。
+
+引擎輸出:`jsonb`、`pg-filter` 出 SQL;**`data-filter` 引擎的 `compile` 就是 `JSON.stringify(group)`** —— 也就是 data-filter 的「表示」本身就是 canonical `FilterGroupLike`(同構於 `@rfjs/jsonb-query` 的 `JsonbFilterGroup`)。
+
+本案讓這個 canonical 表示**可反向編輯**:把它貼上/改寫 → 反推回中間那棵樹。
+
+## 目標與非目標
+
+**目標**:選到 `data-filter` 引擎時,其 JSON 輸出就地變**可編輯**;編輯(debounced)→ parse → 回寫 `tree`,並補上樹用到、schema 還沒有的欄位。
+
+**非目標(YAGNI)**:
+- 不反解 `jsonb` / `pg-filter` 的 SQL(SQL 反解最難,排除 → 兩者維持唯讀)。
+- 不支援 mongo(無 mongo 引擎)。
+- 不新增 tool、不抽 public lib(B4)、不動 sample→infer 與 schema 編輯的既有 forward 流程。
+
+## 設計原則
+
+- **canonical tree 是唯一真相**。可編輯的 canonical-JSON 框是它的一個雙向 view。
+- **可逆表示只有一個**:canonical `FilterGroupLike` JSON(= data-filter 引擎輸出)。SQL view 唯讀。
+- 反向格式對齊 `@rfjs/jsonb-query` 的 `JsonbFilterGroup`,實務上等同既有的本地 `FilterGroupLike`(`logic` + `filters[]`,leaf 為 `{field, dataType, operator, value?, elementType?, filters?}`)。
+
+## 行為
+
+1. 右欄引擎選到 **data-filter** → JSON 輸出改用可編輯 textarea(其他引擎維持唯讀 SQL)。
+2. 使用者編輯該框 → **停 ~300ms(debounced)** → `parseFilterGroup(text)`:
+   - 成功 → `setTree(filterGroupToTree(group, id))`,並 `setSchema(mergeFieldsFromTree(schema, group))`。
+   - 失敗 → 該框顯示 typed 錯誤訊息,**tree 與 schema 不變**。
+3. **防迴圈**:框在編輯中(focused / 有未套用 draft)時,**不被樹回染**;離開編輯(blur,且無 pending parse)後,draft 重新同步成 `JSON.stringify(treeToFilterGroup(tree))`。
+4. id 沿用現有 `crypto.randomUUID()`(`ui/index.tsx` 既有的 `id`)。
+
+## 新增 logic(`apps/web/src/tools/query-builder/logic/reverse.ts`)
+
+型別參考(現況,`logic/types.ts` / `logic/compile.ts`):
+`FilterGroupLike = { logic: string; filters: Array<FilterConditionLike | FilterGroupLike> }`;
+`FilterConditionLike = { field; dataType; elementType?; operator; value?; filters? }`;
+`BuilderGroup = { kind:"group"; id; logic: LogicOp; children: BuilderItem[] }`;
+`BuilderCondition = { kind:"condition"; id; field; dataType: FieldType; elementType?; operator; value?; filters?: BuilderGroup }`;
+`FieldSchema = { path; dataType: FieldType; elementType?; include: boolean; kind: FieldKind }`。
+
+- **`filterGroupToTree(group: FilterGroupLike, makeId: () => string): BuilderGroup`** — `treeToFilterGroup` 的逆。遞迴:
+  - group → `{ kind:"group", id: makeId(), logic: group.logic as LogicOp, children: [...] }`。
+  - 區分子項:有 `logic` 且無 `field` → 巢狀 group(遞迴);否則 → leaf condition。
+  - leaf → `{ kind:"condition", id: makeId(), field, dataType: dataType as FieldType, operator, value?, elementType? as ElementType, filters? }`;當 `operator === "elemmatch"` 且 leaf 有 `filters` → `filters` 遞迴成 `BuilderGroup`(而非當成 group 子項)。
+- **`parseFilterGroup(text: string): { ok: true; group: FilterGroupLike } | { ok: false; error: ReverseError }`** —
+  - `JSON.parse`;失敗 → `invalidJson`。
+  - 結構驗證:頂層必須是 plain object;`logic ∈ {and,or,nor,not}`;`filters` 為陣列;每個子項要嘛是合法巢狀 group(同規則遞迴),要嘛是合法 leaf(`field` 非空字串、`dataType` 字串、`operator` 非空字串;`elemmatch` 的 `filters` 為巢狀 group)。任一不符 → `invalidShape`。
+  - `ReverseError = "invalidJson" | "invalidShape"`。
+- **`mergeFieldsFromTree(schema: FieldSchema[], group: FilterGroupLike): FieldSchema[]`** — 走訪所有 leaf(含 elemmatch 巢狀),對 `field` 不在 `schema` 的,append `{ path: field, dataType: (dataType as FieldType), elementType?, include: true, kind: "jsonb" }`(預設 kind=jsonb,沿用 `addInferredField` 慣例;既有欄位**完全不動**,保留其 kind/dataType)。
+
+## UI
+
+- **新 `apps/web/src/tools/query-builder/ui/canonical-editor.tsx`** — 受控 textarea,內部:
+  - `draft`(本地字串)、`editing` 旗標(onFocus=true / onBlur=false)、debounce(~300ms)。
+  - `editing` 為 false 時,`useEffect` 把 `draft` 同步成 props 傳入的 `serialized`(由樹序列化)。
+  - draft 變動(debounced)→ 呼叫 `onParse(text)`,由父層決定成功/失敗;失敗訊息以 prop 傳回顯示(紅字)。
+  - props:`serialized: string`、`error: string | null`、`onParse(text: string): void`。
+- **`ui/index.tsx`** — 當 `engineId === "data-filter"`:
+  - 改渲染 `CanonicalEditor`,`serialized = JSON.stringify(treeToFilterGroup(tree), null, 2)`。
+  - `onParse(text)`:`const r = parseFilterGroup(text)`;`r.ok` → `setTree(filterGroupToTree(r.group, id))` + `setSchema((s) => mergeFieldsFromTree(s, r.group))` + 清錯誤;否則 setReverseError(r.error)。
+  - 其他引擎(jsonb / pg-filter)維持現有唯讀 `PreviewPanel`。
+  - live-match(`runLiveMatch`)維持唯讀,隨樹更新。
+
+## 錯誤處理
+
+- parse 失敗只影響該框(顯示 `ToolUI.error.*` 對應訊息),**絕不**清空或破壞既有 tree / schema。
+- 空字串 / 空白 → 視為「沒有反向輸入」,不報錯、不改樹(避免清空時誤觸)。
+
+## 測試
+
+co-locate `*.spec.ts`:
+- `logic/reverse.spec.ts`:
+  - **round-trip 不變式**:對多種樹,`treeToFilterGroup(filterGroupToTree(g)) ≡ g`(g 為合法、條件完整的 FilterGroupLike;含巢狀 group、elemmatch、array+elementType)。
+  - `filterGroupToTree`:每個 node 有 id;elemmatch 的 `filters` 轉成 `BuilderGroup` 而非 group 子項。
+  - `parseFilterGroup`:合法 → ok;壞 JSON → `invalidJson`;壞結構(logic 非法 / leaf 缺 field / filters 非陣列)→ `invalidShape`。
+  - `mergeFieldsFromTree`:補缺欄位(dataType/elementType 取自條件,kind=jsonb);既有欄位不動;elemmatch 巢狀欄位也納入。
+- `ui/canonical-editor.spec.tsx`(輕量):編輯中不被 `serialized` 回染;debounce 後呼叫 `onParse`;`error` prop 顯示紅字。
+
+## i18n(query-builder `messages.ts` fragment,en + zh-TW)
+
+新增 `ToolUI` key(掛在 query-builder fragment,避免與中央/其他 tool 碰撞):
+- `canonicalEditable`(提示文:此框可貼上/編輯以反推查詢)
+- `error.reverseInvalidJson`、`error.reverseInvalidShape`(對應 `ReverseError`)
+
+(註:`ToolUI.error` 既有為共用巢狀物件,新 key 以 query-builder fragment 的 `ToolUI.error.*` 深度合併進去;need 確認不與中央既有 error key 撞名 —— `reverseInvalidJson/Shape` 為新名,無衝突。)
+
+## 風險 / 注意
+
+- **Hydration**:`canonical-editor` 是 client component;id 用 `crypto.randomUUID()`(既有作法),不可用 module 計數器(B3 踩過 useId hydration 雷)。
+- **schema-authoritative compile**(B1 既有約束):compile 以 schema 為準。反向後務必 `mergeFieldsFromTree` 補欄位,否則新 field 在 schema 缺席會導致 compile 行為不如預期。
+- **不變式邊界**:`treeToFilterGroup` 會丟棄不完整條件;`parseFilterGroup` 只接受完整條件,故 round-trip 成立。


### PR DESCRIPTION
## Summary

Adds reverse-read (B2) to the query-builder tool, built in place on the shipped three-pane UI (#172). When the **data-filter** engine is selected, its canonical `FilterGroupLike` JSON output becomes an **editable** box: a debounced parse rewrites the canonical builder tree (the single source of truth) and backfills any missing schema fields. Invalid input shows an inline error and leaves the tree untouched. The jsonb / pg-filter SQL views stay read-only.

- New `logic/reverse.ts`: `filterGroupToTree` (inverse of `treeToFilterGroup`, round-trip safe, elemmatch-aware), `parseFilterGroup` (JSON + shape validation → `invalidJson` / `invalidShape`), `mergeFieldsFromTree` (append-only schema backfill, preserves existing fields).
- New `ui/canonical-editor.tsx`: presentational debounced editable view; reflects the tree only when not being edited (no clobbering / cursor jumps); text passed as props (no i18n coupling).
- `ui/index.tsx`: wires the data-filter branch to reverse-read; extracts `LiveMatchView` from `PreviewPanel` so the live preview shows in both read-only and editable modes.
- i18n: three flat `ToolUI` keys (`canonicalEditable`, `reverseInvalidJson`, `reverseInvalidShape`) in en + zh-TW — flat (not nested under `ToolUI.error`) to respect the registry collision guardrail.

Canonical JSON aligns with `@rfjs/jsonb-query`'s published filter-group shape (structurally identical to the tool's `FilterGroupLike`). No new tool; SQL reverse-parse and mongo are out of scope. The canonical-model / headless extraction (B4) remains parked.

Spec: `docs/superpowers/specs/2026-06-16-query-builder-reverse-read-design.md`
Plan: `docs/superpowers/plans/2026-06-16-query-builder-reverse-read.md`

## Test Plan

- [x] `pnpm -F web exec vitest run` — 131 passed (26 files), incl. round-trip invariant, parse validation, schema-merge, and CanonicalEditor debounce/no-clobber tests
- [x] `pnpm -F web check-types` — 0 errors
- [x] `pnpm -F web lint` — clean
- [x] `pnpm -F web build` — success, `/tools/[slug]` (incl. query-builder) prerenders

🤖 Generated with [Claude Code](https://claude.com/claude-code)