### PR TITLE
feat(filter-builder): export treeToPgFilterGroup for structured pg-filter output

### DIFF
--- a/packages/filter-builder/src/engines/pg-filter.ts
+++ b/packages/filter-builder/src/engines/pg-filter.ts
@@ -1,10 +1,10 @@
-import { buildPgFilter, type PgFilterConfig, type PgFilterGroup, type PgLeaf } from "@rfjs/pg-filter";
+import { buildPgFilter, type PgFilterConfig } from "@rfjs/pg-filter";
 
-import type { FilterConditionLike, FilterGroupLike } from "../compile";
 import { mapColumnType } from "../field-kind";
+import { toPgGroup } from "../pg-group";
 import { arityOf } from "./arity";
 import { jsonbEngine } from "./jsonb";
-import type { CompileContext, CompileField, Engine, OperatorSpec } from "./types";
+import type { CompileContext, Engine, OperatorSpec } from "./types";
 
 const NULL_OPS = ["isnull", "isnotnull"];
 const COLUMN_TEXT_OPS = ["eq", "neq", "contains", "startswith", "gt", "gte", "lt", "lte", ...NULL_OPS];
@@ -19,35 +19,6 @@ function columnOps(dataType: string): string[] {
 
 function toSpecs(ops: string[]): OperatorSpec[] {
   return [...new Set(ops)].map((op) => ({ op, arity: arityOf(op) }));
-}
-
-function toPgLeaf(c: FilterConditionLike, byPath: Map<string, CompileField>): PgLeaf {
-  const f = byPath.get(c.field);
-  const kind = f?.kind ?? "jsonb";
-  if (kind === "column") {
-    return { target: "column", column: c.field, operator: c.operator, value: c.value } as PgLeaf;
-  }
-  const leaf = {
-    target: "jsonb",
-    field: c.field,
-    dataType: f?.dataType ?? c.dataType,
-    operator: c.operator,
-    ...(c.value !== undefined ? { value: c.value } : {}),
-    ...((f?.elementType ?? c.elementType) ? { elementType: f?.elementType ?? c.elementType } : {}),
-    ...(c.filters ? { filters: c.filters } : {}),
-  };
-  return leaf as unknown as PgLeaf;
-}
-
-function toPgGroup(group: FilterGroupLike, byPath: Map<string, CompileField>): PgFilterGroup {
-  return {
-    logic: group.logic as PgFilterGroup["logic"],
-    filters: group.filters.map((node) =>
-      "logic" in node
-        ? toPgGroup(node as FilterGroupLike, byPath)
-        : toPgLeaf(node as FilterConditionLike, byPath),
-    ),
-  };
 }
 
 export const pgFilterEngine: Engine = {

--- a/packages/filter-builder/src/index.ts
+++ b/packages/filter-builder/src/index.ts
@@ -8,3 +8,4 @@ export * from './field-create';
 export * from './schema-infer';
 export * from './live-match';
 export * from './engines';
+export * from './pg-group';

--- a/packages/filter-builder/src/pg-group.spec.ts
+++ b/packages/filter-builder/src/pg-group.spec.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import { treeToPgFilterGroup } from "./pg-group";
+import type { BuilderGroup, FieldSchema } from "./types";
+
+describe("treeToPgFilterGroup", () => {
+  it("tags a column-kind leaf with target:'column'", () => {
+    const schema: FieldSchema[] = [{ path: "name", dataType: "string", include: true, kind: "column" }];
+    const tree: BuilderGroup = {
+      kind: "group", id: "g", logic: "and",
+      children: [{ kind: "condition", id: "c", field: "name", dataType: "string", operator: "eq", value: "x" }],
+    };
+    expect(treeToPgFilterGroup(tree, schema)).toEqual({
+      logic: "and",
+      filters: [{ target: "column", column: "name", operator: "eq", value: "x" }],
+    });
+  });
+
+  it("tags a jsonb-kind leaf with target:'jsonb' and carries dataType", () => {
+    const schema: FieldSchema[] = [{ path: "score", dataType: "numeric", include: true, kind: "jsonb" }];
+    const tree: BuilderGroup = {
+      kind: "group", id: "g", logic: "and",
+      children: [{ kind: "condition", id: "c", field: "score", dataType: "numeric", operator: "gt", value: 5 }],
+    };
+    expect(treeToPgFilterGroup(tree, schema)).toEqual({
+      logic: "and",
+      filters: [{ target: "jsonb", field: "score", dataType: "numeric", operator: "gt", value: 5 }],
+    });
+  });
+
+  it("handles nested groups mixing column + jsonb", () => {
+    const schema: FieldSchema[] = [
+      { path: "name", dataType: "string", include: true, kind: "column" },
+      { path: "score", dataType: "numeric", include: true, kind: "jsonb" },
+    ];
+    const tree: BuilderGroup = {
+      kind: "group", id: "g", logic: "and",
+      children: [
+        { kind: "condition", id: "c1", field: "name", dataType: "string", operator: "eq", value: "a" },
+        {
+          kind: "group", id: "g2", logic: "or",
+          children: [
+            { kind: "condition", id: "c2", field: "score", dataType: "numeric", operator: "gt", value: 1 },
+            { kind: "condition", id: "c3", field: "name", dataType: "string", operator: "neq", value: "b" },
+          ],
+        },
+      ],
+    };
+    expect(treeToPgFilterGroup(tree, schema)).toEqual({
+      logic: "and",
+      filters: [
+        { target: "column", column: "name", operator: "eq", value: "a" },
+        {
+          logic: "or",
+          filters: [
+            { target: "jsonb", field: "score", dataType: "numeric", operator: "gt", value: 1 },
+            { target: "column", column: "name", operator: "neq", value: "b" },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("defaults an unknown field (not in schema) to a jsonb leaf", () => {
+    const tree: BuilderGroup = {
+      kind: "group", id: "g", logic: "and",
+      children: [{ kind: "condition", id: "c", field: "ghost", dataType: "string", operator: "eq", value: "z" }],
+    };
+    expect(treeToPgFilterGroup(tree, [])).toEqual({
+      logic: "and",
+      filters: [{ target: "jsonb", field: "ghost", dataType: "string", operator: "eq", value: "z" }],
+    });
+  });
+});

--- a/packages/filter-builder/src/pg-group.ts
+++ b/packages/filter-builder/src/pg-group.ts
@@ -1,0 +1,50 @@
+import type { PgFilterGroup, PgLeaf } from "@rfjs/pg-filter";
+
+import { treeToFilterGroup, type FilterConditionLike, type FilterGroupLike } from "./compile";
+import type { CompileField } from "./engines/types";
+import type { BuilderGroup, FieldSchema } from "./types";
+
+export function toPgLeaf(c: FilterConditionLike, byPath: Map<string, CompileField>): PgLeaf {
+  const f = byPath.get(c.field);
+  const kind = f?.kind ?? "jsonb";
+  if (kind === "column") {
+    return { target: "column", column: c.field, operator: c.operator, value: c.value } as PgLeaf;
+  }
+  const leaf = {
+    target: "jsonb",
+    field: c.field,
+    dataType: f?.dataType ?? c.dataType,
+    operator: c.operator,
+    ...(c.value !== undefined ? { value: c.value } : {}),
+    ...((f?.elementType ?? c.elementType) ? { elementType: f?.elementType ?? c.elementType } : {}),
+    ...(c.filters ? { filters: c.filters } : {}),
+  };
+  return leaf as unknown as PgLeaf;
+}
+
+export function toPgGroup(group: FilterGroupLike, byPath: Map<string, CompileField>): PgFilterGroup {
+  return {
+    logic: group.logic as PgFilterGroup["logic"],
+    filters: group.filters.map((node) =>
+      "logic" in node
+        ? toPgGroup(node as FilterGroupLike, byPath)
+        : toPgLeaf(node as FilterConditionLike, byPath),
+    ),
+  };
+}
+
+/**
+ * Build a structured, target-tagged PgFilterGroup from a builder tree + its schema.
+ * The schema's per-field `kind` (column|jsonb) drives leaf target tagging. This is the
+ * structured counterpart to the pg-filter engine's string-SQL output — consumers send it
+ * as the `filter` of a datasets/query API request.
+ */
+export function treeToPgFilterGroup(tree: BuilderGroup, schema: FieldSchema[]): PgFilterGroup {
+  const byPath = new Map<string, CompileField>(
+    schema.map((f) => [
+      f.path,
+      { path: f.path, kind: f.kind, dataType: f.dataType, elementType: f.elementType },
+    ]),
+  );
+  return toPgGroup(treeToFilterGroup(tree), byPath);
+}


### PR DESCRIPTION
## Summary

Part A of the query-builder UI/explorer split (see `2026-06-16-query-builder-ui-explorer-integrated-design.md`). The workbench datasets explorer needs the **structured** `PgFilterGroup` (target-tagged column|jsonb leaves) to send as a `POST /datasets/query` body — but `@rfjs/filter-builder`'s pg-filter engine only exposed a SQL *string*; the target-tagging (`toPgGroup`/`toPgLeaf`) was private inside the engine.

This extracts that mapping into `src/pg-group.ts` and adds a public high-level function:

```ts
treeToPgFilterGroup(tree: BuilderGroup, schema: FieldSchema[]): PgFilterGroup
```

Behavior-preserving: the pg-filter engine now imports `toPgGroup` from the new module (no duplication); its existing tests stay green.

## Test Plan
- [x] New `pg-group.spec.ts` (4 tests): column-kind → `target:'column'`; jsonb-kind → `target:'jsonb'` + dataType; nested mixed groups; unknown field defaults to jsonb leaf.
- [x] Full package green: 80 tests / 13 files; `engines/pg-filter.spec.ts` 6/6 unchanged (engine refactor is behavior-preserving).
- [x] `pnpm -F @rfjs/filter-builder typecheck` clean; `build` emits dist.

## For the consumer (workbench explorer, Part C)
Import from `@rfjs/filter-builder`:
```ts
import { treeToPgFilterGroup } from "@rfjs/filter-builder";
// tree from useFilterTree, schema = your column/jsonb FieldSchema[]
const filter = treeToPgFilterGroup(tree, schema);
await queryDatasets({ filter, page, pageSize });
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)