### PR TITLE
feat(web): register @rfjs/filter-builder in the package catalog

### DIFF
--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -79,6 +79,7 @@
     "jsonb-query": { "description": "PostgreSQL JSONB query builder from filter metadata." },
     "sql-filter": { "description": "Generic boolean filter-group to SQL with pluggable leaf renderers." },
     "pg-filter": { "description": "Unified PostgreSQL filter builder over columns and JSONB." },
+    "filter-builder": { "description": "Framework-agnostic canonical filter-tree model, schema inference, and engine compilation." },
     "jwt": { "description": "JWT sign/verify/decode helper." },
     "mongo-query": { "description": "MongoDB query builder from filter metadata." },
     "object-utils": { "description": "Object manipulation utilities (flatten, paths, merge)." },

--- a/apps/web/src/messages/zh-TW.json
+++ b/apps/web/src/messages/zh-TW.json
@@ -79,6 +79,7 @@
     "jsonb-query": { "description": "從篩選 metadata 建構 PostgreSQL JSONB 查詢。" },
     "sql-filter": { "description": "通用布林 filter-group 轉 SQL,可插拔 leaf 渲染器。" },
     "pg-filter": { "description": "統一的 PostgreSQL 過濾建構器,涵蓋欄位與 JSONB。" },
+    "filter-builder": { "description": "框架無關的 canonical 過濾樹模型、schema 推斷與引擎編譯。" },
     "jwt": { "description": "JWT 簽署/驗證/解碼工具。" },
     "mongo-query": { "description": "從篩選 metadata 建構 MongoDB 查詢。" },
     "object-utils": { "description": "物件操作工具(壓平、路徑、合併)。" },

--- a/packages/web-core/src/registry/packages.ts
+++ b/packages/web-core/src/registry/packages.ts
@@ -54,6 +54,14 @@ export const packageRegistry: PackageDefinition[] = [
     relatedTools: ['query-builder'],
   },
   {
+    name: '@rfjs/filter-builder',
+    status: 'preview',
+    href: '/packages/filter-builder',
+    github: GITHUB,
+    tags: ['filter', 'query-builder', 'tree'],
+    relatedTools: ['query-builder'],
+  },
+  {
     name: '@rfjs/jwt',
     status: 'ready',
     href: '/packages/jwt',

--- a/packages/web-core/src/registry/tools.ts
+++ b/packages/web-core/src/registry/tools.ts
@@ -46,7 +46,7 @@ export const toolRegistry: ToolDefinition[] = [
     category: 'query',
     surface: 'web',
     status: 'preview',
-    relatedPackages: ['@rfjs/jsonb-query', '@rfjs/data-filter', '@rfjs/pg-filter'],
+    relatedPackages: ['@rfjs/jsonb-query', '@rfjs/data-filter', '@rfjs/pg-filter', '@rfjs/filter-builder'],
     tags: ['builder', 'jsonb', 'sql', 'nested'],
   },
   {


### PR DESCRIPTION
## Summary

`@rfjs/filter-builder` (shipped in #175) is public but was missing from the apps/web package catalog. This registers it (mirrors #173 for sql-filter/pg-filter) and links it to the query-builder tool.

- `packages/web-core/src/registry/packages.ts`: add `@rfjs/filter-builder` (`status: preview`, tags `filter/query-builder/tree`, `relatedTools: ['query-builder']`).
- `packages/web-core/src/registry/tools.ts`: append `@rfjs/filter-builder` to query-builder's `relatedPackages` (primary stays `@rfjs/jsonb-query`; sidebar grouping unchanged) — also required by `registry.spec` (`relatedPackages` must exist in `packageRegistry`).
- `apps/web/src/messages/{en,zh-TW}.json`: add `Packages.filter-builder` descriptions (required by `i18n-content.spec`, both locales).

`@rfjs/filter-builder-ui` is intentionally NOT registered — it's a **private** package (not on npm), so it stays out of the public catalog.

## Test Plan
- [x] `@rfjs/web-core` registry tests pass (12).
- [x] apps/web `i18n-content` + `nav` tests pass (7).
- [x] `pnpm -F web build` succeeds; `/{en,zh-TW}/packages/filter-builder` prerender.

🤖 Generated with [Claude Code](https://claude.com/claude-code)