### PR TITLE
docs(filter-builder): README — layering, install guide, operator matrix

### DIFF
--- a/packages/filter-builder/README.md
+++ b/packages/filter-builder/README.md
@@ -1,0 +1,210 @@
+# @rfjs/filter-builder
+
+Framework-agnostic **canonical filter-tree** builder: an editable tree model with
+stable node IDs, immutable tree-ops, schema inference, reverse-parse, live
+in-memory matching, and a registry of **engines** that compile the same tree to
+different execution targets (PostgreSQL, JSONB, MongoDB, in-memory).
+
+This is the **orchestration layer** — it owns the shared tree shape and the
+operator/arity contract, and it is the single place that knows about *every*
+engine. It contains no UI.
+
+---
+
+## Where it sits
+
+```
+ execution engines  (each standalone, independently publishable)
+ ┌───────────────┬──────────────┬─────────────┬──────────────┬─────────────┐
+ │ @rfjs/        │ @rfjs/       │ @rfjs/      │ @rfjs/       │ @rfjs/      │
+ │ data-filter   │ jsonb-query  │ sql-filter  │ mongo-query  │ pg-filter   │
+ │ (in-memory)   │ (PG JSONB)   │ (columns)   │ (MongoDB)    │ (col+jsonb) │
+ └───────┬───────┴──────┬───────┴──────┬──────┴──────┬───────┴──────┬──────┘
+         └──────────────┴──────────────┼─────────────┴──────────────┘
+                                       ▼
+                          @rfjs/filter-builder          ← you are here
+              canonical tree · tree-ops · schema infer · reverse
+              · live match · engine registry (compile to any target)
+                                       ▼
+                         @rfjs/filter-builder-ui
+                React editor (<FilterTreeEditor>) over this package
+```
+
+- **This package** = the brain: data model + logic + compile. Framework-agnostic
+  (pure TS, no React). Consumed as built `dist/` (rebuild after `src` edits).
+- **[@rfjs/filter-builder-ui](../filter-builder-ui)** = the face: a React
+  `<FilterTreeEditor>` that edits the tree and delegates *all* logic back here.
+- **Engines** = the standalone executors. `filter-builder` depends on **all** of
+  them (see install note below).
+
+---
+
+## Install
+
+**You only need a single engine's behaviour, no visual builder** — install just
+that engine and call it directly; you do *not* need `filter-builder`:
+
+```bash
+npm i @rfjs/data-filter      # in-memory matching only
+# or @rfjs/jsonb-query / @rfjs/sql-filter / @rfjs/mongo-query / @rfjs/pg-filter
+```
+
+**You want the canonical tree + compile-to-any-engine (headless)** — install this
+package. It pulls in **all** engines as dependencies:
+
+```bash
+npm i @rfjs/filter-builder
+```
+
+**You want a ready-made React editor** — install the UI layer (it brings
+`filter-builder` with it):
+
+```bash
+npm i @rfjs/filter-builder @rfjs/filter-builder-ui   # + peer: react, react-dom
+```
+
+> ⚠️ `@rfjs/filter-builder` hard-depends on every engine
+> (`pg-filter`, `jsonb-query`, `sql-filter`, `mongo-query`, `data-filter`,
+> `data-transform`). Using it — or the UI — pulls them all in, even if you only
+> compile to one target. For a minimal footprint with a single engine and no
+> visual builder, install that engine alone.
+
+---
+
+## Core concepts
+
+### The canonical tree
+
+A nestable group whose leaves are field conditions, with **stable IDs** for
+editing:
+
+```ts
+type BuilderGroup = { kind: "group"; id: string; logic: "and"|"or"|"nor"|"not"; children: BuilderItem[] };
+type BuilderCondition = { kind: "condition"; id: string; field: string; dataType: FieldType; elementType?: ElementType; operator: string; value?: unknown; filters?: BuilderGroup };
+```
+
+`treeToFilterGroup(tree)` strips the IDs to the shared `FilterGroupLike` shape
+that engines consume.
+
+### The arity model — a value's *shape* is decided by its operator
+
+`arity.ts` is the single source of truth for how many values an operator takes:
+
+| arity  | value shape   | operators |
+|--------|---------------|-----------|
+| `none` | *(no value)*  | `isnull` `isnotnull` `isempty` `isnotempty` `elemmatch` |
+| `one`  | single value  | `eq` `neq` `gt` `gte` `lt` `lte` `contains` `startswith` `endswith` `ieq` `haskey` … |
+| `two`  | `[min, max]`  | `range` |
+| `list` | array         | `terms` `containsall` `nin` `hasanykey` `hasallkeys` |
+
+`arityOf(op)` returns the arity (defaults to `"one"`). Build value editors and
+validation off this — don't hard-code per-operator value handling.
+
+> So `eq` is **single-value**; to match "any of several values" use `terms`
+> (compiles to SQL `IN` / Mongo `$in`), not `eq` with an array.
+
+---
+
+## Usage
+
+```ts
+import {
+  emptyGroup, addCondition, updateNode,
+  treeToFilterGroup, getEngine,
+  inferSchema, runLiveMatch,
+} from "@rfjs/filter-builder";
+
+const id = () => crypto.randomUUID();
+
+// 1. build / edit the canonical tree (immutable ops return a new tree)
+let tree = emptyGroup(id);
+tree = addCondition(tree, tree.id, id);
+const condId = tree.children[0]!.id;
+tree = updateNode(tree, condId, { field: "age", dataType: "numeric", operator: "gt", value: 18 });
+
+// 2a. compile to an engine
+const out = getEngine("jsonb").compile(treeToFilterGroup(tree), {
+  fields: [{ path: "age", kind: "jsonb", dataType: "numeric" }],
+});
+// → { ok: true, primary: '(("data" #>> $1)::numeric > $2)', secondary: '[["age"],18]' }
+
+// 2b. …or evaluate it in memory
+const { matched } = runLiveMatch([{ age: 36 }, { age: 12 }], tree); // → [{ age: 36 }]
+
+// schema inference from sample rows
+const schema = inferSchema([{ age: 36, name: "Ada" }]); // → FieldSchema[]
+```
+
+Engine ids for `getEngine(id)`: `"data-filter"`, `"jsonb"`, `"sql-filter"`,
+`"mongo"`, `"pg-filter"`. Each returns an `Engine` with
+`operators(dataType, elementType?, kind?)` and `compile(group, ctx)`.
+
+---
+
+## Operator matrix
+
+Which operator each engine exposes, and the value shape (arity). For an
+operator's exact **semantics and compiled output**, see that engine's own README
+(linked below) — this table is the cross-engine map, not a re-statement of each
+engine's behaviour.
+
+| Operator | Arity | data-filter | jsonb-query | sql-filter¹ | mongo-query | Meaning |
+|----------|-------|:-----------:|:-----------:|:-----------:|:-----------:|---------|
+| `eq` | one | ✓ | ✓ | ✓ | ✓ | equals (mongo: `$eq`) |
+| `neq` | one | ✓ | ✓ | ✓ | ✓ | not equals |
+| `gt` `gte` `lt` `lte` | one | ✓ | ✓ | ✓ | ✓ | comparisons |
+| `range` | two `[min,max]` | ✓ | ✓ | – | ✓ | inclusive between |
+| `contains` | one² | ✓ | ✓ | ✓ | ✓ | substring (sql: `ILIKE`; mongo: `$regex`) |
+| `startswith` | one | ✓ | ✓ | ✓ | ✓ | prefix |
+| `endswith` | one | ✓ | ✓ | – | ✓ | suffix (sql column layer has no suffix op) |
+| `icontains` `istartswith` `iendswith` `ieq` `ineq` | one | – | ✓ | – | – | case-insensitive variants |
+| `terms` | list | ✓ | ✓ | – | ✓ | in a set (sql: —; mongo: `$in`) |
+| `nin` | list | – | – | – | ✓ | not in a set (`$nin`) |
+| `containsall` | list | ✓ | ✓ | – | – | array contains every value |
+| `isnull` `isnotnull` | none | ✓ | ✓ | ✓ | ✓ | null checks (mongo: `$eq`/`$ne null`) |
+| `isempty` `isnotempty` | none | – | ✓ | – | – | array empty / non-empty |
+| `haskey` | one | – | ✓ | – | – | object has key |
+| `hasanykey` `hasallkeys` | list | – | ✓ | – | – | object has any / all keys |
+| `elemmatch` | none³ | ✓ | ✓ | – | – | match an element of an array-of-objects |
+
+¹ **`sql-filter`** is the plain-column layer. `pg-filter` composes it with
+`jsonb-query`: a leaf with `target: 'column'` uses the **sql-filter** column set
+above; a leaf with `target: 'jsonb'` uses the **jsonb-query** set.
+
+² `contains` is single-value in general, but **data-filter** exposes it as
+`list` arity on `string` / string-array fields (contains-**any**).
+
+³ `elemmatch` carries a nested `BuilderGroup` (in `condition.filters`) rather
+than a scalar value.
+
+Arity comes from the shared `arity.ts` (the single source of truth); the
+per-engine ✓ marks are maintained against each engine's `operators()`. A
+drift-guard test in `@rfjs/filter-builder-ui` (`operators.spec.ts`) asserts
+every operator any engine returns is present in `OPERATOR_KEYS`, so a *new*
+operator can't slip in unnoticed — but the ✓/– cells here are hand-checked, so
+verify against the engine's own README if in doubt.
+
+---
+
+## Public API (by module)
+
+- **`types`** — `BuilderGroup`, `BuilderCondition`, `FieldSchema`, `LogicOp`, `FieldType`, `ElementType`, `FieldKind`
+- **`tree-ops`** — `emptyGroup`, `addCondition`, `addGroup`, `removeNode`, `updateNode`, `setLogic`
+- **`schema-infer`** — `inferSchema`
+- **`field-create`** / **`field-kind`** — `addInferredField`, `mapColumnType`, …
+- **`reverse`** — `parseFilterGroup`, `filterGroupToTree`, `mergeFieldsFromTree`
+- **`compile`** — `treeToFilterGroup`, `FilterGroupLike`
+- **`pg-group`** — `treeToPgFilterGroup`
+- **`live-match`** — `runLiveMatch`
+- **`value-coerce`** — value coercion helpers
+- **`engines`** — `getEngine`, `ENGINE_IDS`, `Engine`, `OperatorSpec`, `OperatorArity`, `CompileContext`
+
+## Related packages
+
+- **[@rfjs/filter-builder-ui](../filter-builder-ui)** — React `<FilterTreeEditor>` over this package.
+- Engines (for per-operator semantics & compiled output):
+  [@rfjs/data-filter](../data-filter) ·
+  [@rfjs/jsonb-query](../jsonb-query) ·
+  [@rfjs/sql-filter](../sql-filter) ·
+  [@rfjs/mongo-query](../mongo-query) ·
+  [@rfjs/pg-filter](../pg-filter)

--- a/packages/filter-builder/README.md
+++ b/packages/filter-builder/README.md
@@ -1,5 +1,7 @@
 # @rfjs/filter-builder
 
+> 繁體中文 → [README.zh-TW.md](./README.zh-TW.md)
+
 Framework-agnostic **canonical filter-tree** builder: an editable tree model with
 stable node IDs, immutable tree-ops, schema inference, reverse-parse, live
 in-memory matching, and a registry of **engines** that compile the same tree to

--- a/packages/filter-builder/README.zh-TW.md
+++ b/packages/filter-builder/README.zh-TW.md
@@ -1,0 +1,183 @@
+# @rfjs/filter-builder
+
+> English → [README.md](./README.md)
+
+框架無關的**標準篩選樹(canonical filter-tree)**建構器:具備穩定節點 ID 的可編輯樹模型、不可變的 tree-ops、schema 推斷、反向解析(reverse-parse)、即時記憶體比對,以及一個把同一棵樹編譯到不同執行目標(PostgreSQL、JSONB、MongoDB、記憶體)的**引擎(engine)註冊表**。
+
+這是**統合層(orchestration layer)**——它擁有共用的樹結構與 operator/arity 契約,也是唯一認得*所有*引擎的地方。本套件不含任何 UI。
+
+---
+
+## 定位(分層)
+
+```
+ 執行引擎(各自獨立、可單獨發布)
+ ┌───────────────┬──────────────┬─────────────┬──────────────┬─────────────┐
+ │ @rfjs/        │ @rfjs/       │ @rfjs/      │ @rfjs/       │ @rfjs/      │
+ │ data-filter   │ jsonb-query  │ sql-filter  │ mongo-query  │ pg-filter   │
+ │ (記憶體)      │ (PG JSONB)   │ (純欄位)    │ (MongoDB)    │ (欄位+jsonb)│
+ └───────┬───────┴──────┬───────┴──────┬──────┴──────┬───────┴──────┬──────┘
+         └──────────────┴──────────────┼─────────────┴──────────────┘
+                                       ▼
+                          @rfjs/filter-builder          ← 你在這裡
+              標準樹 · tree-ops · schema 推斷 · reverse
+              · 即時比對 · 引擎註冊表(編譯到任一目標)
+                                       ▼
+                         @rfjs/filter-builder-ui
+                本套件之上的 React 編輯器(<FilterTreeEditor>)
+```
+
+- **本套件** = 大腦:資料模型 + 邏輯 + 編譯。框架無關(純 TS、無 React)。以編譯後的 `dist/` 被消費(改 `src` 後需重建)。
+- **[@rfjs/filter-builder-ui](../filter-builder-ui)** = 臉:React `<FilterTreeEditor>`,負責編輯樹,所有邏輯都轉回本套件處理。
+- **引擎** = 各自獨立的執行器。`filter-builder` **相依全部**引擎(見下方安裝說明)。
+
+---
+
+## 安裝
+
+**只需要單一引擎的功能、不要視覺化建構器** —— 直接裝該引擎並呼叫它即可,**不需要** `filter-builder`:
+
+```bash
+npm i @rfjs/data-filter      # 只做記憶體比對
+# 或 @rfjs/jsonb-query / @rfjs/sql-filter / @rfjs/mongo-query / @rfjs/pg-filter
+```
+
+**要標準樹 + 編譯到任一引擎(無頭/headless)** —— 裝本套件,它會帶入**全部**引擎:
+
+```bash
+npm i @rfjs/filter-builder
+```
+
+**要現成的 React 編輯器** —— 裝 UI 層(它會一起帶入 `filter-builder`):
+
+```bash
+npm i @rfjs/filter-builder @rfjs/filter-builder-ui   # + peer:react、react-dom
+```
+
+> ⚠️ `@rfjs/filter-builder` **硬相依每一個引擎**
+> (`pg-filter`、`jsonb-query`、`sql-filter`、`mongo-query`、`data-filter`、
+> `data-transform`)。用它——或用 UI——就會把全部引擎帶進來,即使你只編譯到
+> 一種目標。若只要單一引擎且不需視覺化建構器,請單獨安裝該引擎以求最小體積。
+
+---
+
+## 核心概念
+
+### 標準樹(canonical tree)
+
+可巢狀的群組,葉節點是欄位條件,並帶有可供編輯的**穩定 ID**:
+
+```ts
+type BuilderGroup = { kind: "group"; id: string; logic: "and"|"or"|"nor"|"not"; children: BuilderItem[] };
+type BuilderCondition = { kind: "condition"; id: string; field: string; dataType: FieldType; elementType?: ElementType; operator: string; value?: unknown; filters?: BuilderGroup };
+```
+
+`treeToFilterGroup(tree)` 會去掉 ID,轉成引擎消費的共用 `FilterGroupLike` 結構。
+
+### arity 模型 —— 值的「形狀」由 operator 決定
+
+`arity.ts` 是「一個 operator 吃幾個值」的單一真相:
+
+| arity  | 值形狀        | operators |
+|--------|---------------|-----------|
+| `none` | *(無值)*      | `isnull` `isnotnull` `isempty` `isnotempty` `elemmatch` |
+| `one`  | 單一值        | `eq` `neq` `gt` `gte` `lt` `lte` `contains` `startswith` `endswith` `ieq` `haskey` … |
+| `two`  | `[min, max]`  | `range` |
+| `list` | 陣列          | `terms` `containsall` `nin` `hasanykey` `hasallkeys` |
+
+`arityOf(op)` 回傳 arity(預設 `"one"`)。請用它來決定值輸入元件與驗證,**不要**對每個 operator 各自寫死值處理邏輯。
+
+> 所以 `eq` 是**單一值**;要比對「多個值之中任一個」請用 `terms`
+> (會編譯成 SQL `IN` / Mongo `$in`),而不是把陣列塞給 `eq`。
+
+---
+
+## 用法
+
+```ts
+import {
+  emptyGroup, addCondition, updateNode,
+  treeToFilterGroup, getEngine,
+  inferSchema, runLiveMatch,
+} from "@rfjs/filter-builder";
+
+const id = () => crypto.randomUUID();
+
+// 1. 建立 / 編輯標準樹(不可變操作,回傳新樹)
+let tree = emptyGroup(id);
+tree = addCondition(tree, tree.id, id);
+const condId = tree.children[0]!.id;
+tree = updateNode(tree, condId, { field: "age", dataType: "numeric", operator: "gt", value: 18 });
+
+// 2a. 編譯到某個引擎
+const out = getEngine("jsonb").compile(treeToFilterGroup(tree), {
+  fields: [{ path: "age", kind: "jsonb", dataType: "numeric" }],
+});
+// → { ok: true, primary: '(("data" #>> $1)::numeric > $2)', secondary: '[["age"],18]' }
+
+// 2b. …或在記憶體中直接評估
+const { matched } = runLiveMatch([{ age: 36 }, { age: 12 }], tree); // → [{ age: 36 }]
+
+// 從樣本資料推斷 schema
+const schema = inferSchema([{ age: 36, name: "Ada" }]); // → FieldSchema[]
+```
+
+`getEngine(id)` 的引擎 id:`"data-filter"`、`"jsonb"`、`"sql-filter"`、`"mongo"`、`"pg-filter"`。每個回傳一個 `Engine`,含 `operators(dataType, elementType?, kind?)` 與 `compile(group, ctx)`。
+
+---
+
+## Operator 矩陣
+
+各引擎提供哪些 operator,以及值的形狀(arity)。某個 operator 的**確切語意與編譯輸出**請看該引擎自己的 README(下方連結)——這張表是「跨引擎地圖」,不是各引擎行為的重述。
+
+| Operator | Arity | data-filter | jsonb-query | sql-filter¹ | mongo-query | 意義 |
+|----------|-------|:-----------:|:-----------:|:-----------:|:-----------:|------|
+| `eq` | one | ✓ | ✓ | ✓ | ✓ | 等於(mongo:`$eq`) |
+| `neq` | one | ✓ | ✓ | ✓ | ✓ | 不等於 |
+| `gt` `gte` `lt` `lte` | one | ✓ | ✓ | ✓ | ✓ | 大小比較 |
+| `range` | two `[min,max]` | ✓ | ✓ | – | ✓ | 介於(含邊界) |
+| `contains` | one² | ✓ | ✓ | ✓ | ✓ | 子字串(sql:`ILIKE`;mongo:`$regex`) |
+| `startswith` | one | ✓ | ✓ | ✓ | ✓ | 開頭為 |
+| `endswith` | one | ✓ | ✓ | – | ✓ | 結尾為(sql 欄位層無此 op) |
+| `icontains` `istartswith` `iendswith` `ieq` `ineq` | one | – | ✓ | – | – | 不分大小寫版本 |
+| `terms` | list | ✓ | ✓ | – | ✓ | 屬於集合(sql:—;mongo:`$in`) |
+| `nin` | list | – | – | – | ✓ | 不屬於集合(`$nin`) |
+| `containsall` | list | ✓ | ✓ | – | – | 陣列包含全部值 |
+| `isnull` `isnotnull` | none | ✓ | ✓ | ✓ | ✓ | null 檢查(mongo:`$eq`/`$ne null`) |
+| `isempty` `isnotempty` | none | – | ✓ | – | – | 陣列為空 / 非空 |
+| `haskey` | one | – | ✓ | – | – | 物件含某鍵 |
+| `hasanykey` `hasallkeys` | list | – | ✓ | – | – | 物件含任一 / 全部鍵 |
+| `elemmatch` | none³ | ✓ | ✓ | – | – | 比對「物件陣列」中的元素 |
+
+¹ **`sql-filter`** 是純欄位層。`pg-filter` 把它與 `jsonb-query` 組合:`target: 'column'` 的葉節點走上表的 **sql-filter** 欄位集合;`target: 'jsonb'` 的葉節點走 **jsonb-query** 集合。
+
+² `contains` 一般是單值,但 **data-filter** 在 `string` / 字串陣列欄位上把它視為 `list` arity(contains-**any**,任一命中)。
+
+³ `elemmatch` 帶的是巢狀 `BuilderGroup`(在 `condition.filters`),而非純量值。
+
+arity 來自共用的 `arity.ts`(單一真相);各引擎的 ✓ 標記是依各引擎 `operators()` 維護。`@rfjs/filter-builder-ui` 裡有一個 drift-guard 測試(`operators.spec.ts`)確保任何引擎回傳的 operator 都存在於 `OPERATOR_KEYS`,所以**新增**的 operator 不會被漏掉——但表中的 ✓/– 格是人工核對,若有疑問請以各引擎自己的 README 為準。
+
+---
+
+## 公開 API(依模組)
+
+- **`types`** — `BuilderGroup`、`BuilderCondition`、`FieldSchema`、`LogicOp`、`FieldType`、`ElementType`、`FieldKind`
+- **`tree-ops`** — `emptyGroup`、`addCondition`、`addGroup`、`removeNode`、`updateNode`、`setLogic`
+- **`schema-infer`** — `inferSchema`
+- **`field-create`** / **`field-kind`** — `addInferredField`、`mapColumnType`、…
+- **`reverse`** — `parseFilterGroup`、`filterGroupToTree`、`mergeFieldsFromTree`
+- **`compile`** — `treeToFilterGroup`、`FilterGroupLike`
+- **`pg-group`** — `treeToPgFilterGroup`
+- **`live-match`** — `runLiveMatch`
+- **`value-coerce`** — 值轉換輔助
+- **`engines`** — `getEngine`、`ENGINE_IDS`、`Engine`、`OperatorSpec`、`OperatorArity`、`CompileContext`
+
+## 相關套件
+
+- **[@rfjs/filter-builder-ui](../filter-builder-ui)** — 本套件之上的 React `<FilterTreeEditor>`。
+- 引擎(各 operator 的語意與編譯輸出):
+  [@rfjs/data-filter](../data-filter) ·
+  [@rfjs/jsonb-query](../jsonb-query) ·
+  [@rfjs/sql-filter](../sql-filter) ·
+  [@rfjs/mongo-query](../mongo-query) ·
+  [@rfjs/pg-filter](../pg-filter)


### PR DESCRIPTION
Adds the missing `packages/filter-builder/README.md`.

## Contents
- **Layering diagram** — engines (standalone) → `filter-builder` (headless orchestration) → `filter-builder-ui` (React editor); what each layer owns.
- **Install guide** — three paths: a single engine alone (minimal), `filter-builder` headless, or `+ filter-builder-ui` for the React editor — with the caveat that `filter-builder` hard-depends on **all** engines.
- **Arity model** — `none`/`one`/`two`/`list` value shapes (incl. why `eq` is single-value and `terms` is the array/`IN` op).
- **Usage example** — build tree → `getEngine().compile()` / `runLiveMatch()`.
- **Operator matrix** — operator × arity × engine support (data-filter / jsonb-query / sql-filter / mongo-query), linking out to each engine's README for semantics rather than duplicating them.

## Design note (DRY)
Per discussion: this is the **single** cross-engine reference. Each engine keeps documenting its own semantics in its own README (different content, not copies); `arity.ts` + each engine's `operators()` remain the code-level single source of truth. The matrix links rather than re-states.

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)