### PR TITLE
docs(filter-stack): engine READMEs + zh-TW (sql-filter, pg-filter, filter-builder-ui, jsonb-query)

### DIFF
--- a/packages/filter-builder-ui/README.md
+++ b/packages/filter-builder-ui/README.md
@@ -1,0 +1,102 @@
+# @rfjs/filter-builder-ui
+
+> 繁體中文 → [README.zh-TW.md](./README.zh-TW.md)
+
+Thin **React** layer over [@rfjs/filter-builder](../filter-builder): a
+`<FilterTreeEditor>` component (plus a `useFilterTree()` hook and the value/field
+editors it uses), styled with [@rfjs/web-ui](../web-ui). It **edits/holds the
+tree only** — all logic (tree-ops, schema, compile, matching) lives in
+`filter-builder`. One component edits **any** engine's tree via the `engineId`
+prop.
+
+> **Private / internal.** Not published to npm. Consumed inside the monorepo via
+> Next.js `transpilePackages` (used from `src`, no build step). Peer deps:
+> `react`, `react-dom`.
+
+---
+
+## Usage
+
+```tsx
+"use client";
+import { FilterTreeEditor, useFilterTree } from "@rfjs/filter-builder-ui";
+import { getEngine, treeToFilterGroup } from "@rfjs/filter-builder";
+
+export function MyEditor() {
+  const { tree, schema, setTree, setSchema, createField } = useFilterTree();
+
+  // compile whenever you need the query (logic stays in filter-builder)
+  const out = getEngine("jsonb").compile(
+    treeToFilterGroup(tree),
+    { fields: schema.map((f) => ({ path: f.path, kind: f.kind, dataType: f.dataType, elementType: f.elementType })) },
+  );
+
+  return (
+    <FilterTreeEditor
+      group={tree}
+      engineId="jsonb"
+      schema={schema}
+      onChange={setTree}
+      onCreateField={createField}
+      labels={{
+        logic: { and: "ALL", or: "ANY", nor: "NONE", not: "NOT" },
+        addCondition: "+ condition", addGroup: "+ group",
+        removeGroup: "remove group", removeCondition: "remove condition",
+        elemMatch: "elemmatch",
+      }}
+    />
+  );
+}
+```
+
+## `<FilterTreeEditor>` props
+
+| prop | type | purpose |
+|------|------|---------|
+| `group` | `BuilderGroup` | the tree to render / edit |
+| `engineId` | `EngineId` | which engine's operators to offer (`"jsonb"` `"data-filter"` `"sql-filter"` `"mongo"` `"pg-filter"`) |
+| `schema` | `FieldSchema[]` | known fields — drives the field combobox, operator availability, and (pg-filter) column/jsonb kind |
+| `onChange` | `(next: BuilderGroup) => void` | called on every edit with the new tree |
+| `onCreateField` | `(path: string) => void` | user typed a field path not in `schema` |
+| `labels` | `FilterTreeLabels` | all UI strings (labels-as-props; see below) |
+| `onRemove?` / `depth?` | — | internal (used by the recursion) |
+
+The editor is fully controlled — it holds **no** tree state itself except a
+per-group *collapsed* view flag (collapsing is view-only and never enters
+`BuilderGroup`).
+
+## `FilterTreeLabels`
+
+```ts
+interface FilterTreeLabels {
+  logic: Record<"and"|"or"|"nor"|"not", string>;
+  addCondition: string; addGroup: string;
+  removeGroup: string; removeCondition: string;
+  elemMatch: string;
+  valueHint?: string;                       // placeholder for list/tag inputs
+  // group collapse:
+  toggleGroup?: string;                     // chevron aria-label
+  collapsedConditions?: string;             // unit word, e.g. "cond" → "2 cond"
+  collapsedGroups?: string;                 // unit word, e.g. "grp"  → "1 grp"
+  collapsedEmpty?: string;                  // empty-group summary
+  // operator i18n:
+  operatorLabels?: Record<string, string>;  // op key → localized label (else raw op)
+}
+```
+
+> `collapsed*` are **unit words**, not `{count}` templates — the component
+> prepends the number. (next-intl interprets `{count}` as an ICU var and would
+> throw if retrieved without it.)
+
+## Other exports
+
+- **`useFilterTree(init?)`** → `{ tree, schema, setTree, setSchema, createField }` — minimal state holder (wraps `filter-builder`'s `emptyGroup` / `addInferredField`).
+- **`ValueEditor`** — type/arity-aware value input (single, range, and tag/list inputs).
+- **`FieldCombobox`** — field picker with create-on-type.
+- **`OPERATOR_KEYS`** — canonical operator key list; build an `operatorLabels` map from it (`Object.fromEntries(OPERATOR_KEYS.map(k => [k, t(k)]))`).
+- **`colors`** — `logicBadge`, `dataTypeBadge`, `dataTypeShort`, `logicColor`, `dataTypeColor`.
+
+## Related
+
+- **[@rfjs/filter-builder](../filter-builder)** — the logic/data layer this renders (tree-ops, engines, compile, operator matrix).
+- **[@rfjs/web-ui](../web-ui)** — design tokens & components used for styling.

--- a/packages/filter-builder-ui/README.zh-TW.md
+++ b/packages/filter-builder-ui/README.zh-TW.md
@@ -1,0 +1,91 @@
+# @rfjs/filter-builder-ui
+
+> English → [README.md](./README.md)
+
+[@rfjs/filter-builder](../filter-builder) 之上的輕量 **React** 層:一個 `<FilterTreeEditor>` 元件(以及它用到的 `useFilterTree()` hook 與值/欄位編輯器),用 [@rfjs/web-ui](../web-ui) 上樣式。它**只負責編輯/持有樹**——所有邏輯(tree-ops、schema、編譯、比對)都在 `filter-builder`。同一個元件靠 `engineId` prop 就能編輯**任一**引擎的樹。
+
+> **私有 / 內部套件。** 不發布到 npm。在 monorepo 內透過 Next.js `transpilePackages` 以 `src` 直接消費(免 build)。Peer 相依:`react`、`react-dom`。
+
+---
+
+## 用法
+
+```tsx
+"use client";
+import { FilterTreeEditor, useFilterTree } from "@rfjs/filter-builder-ui";
+import { getEngine, treeToFilterGroup } from "@rfjs/filter-builder";
+
+export function MyEditor() {
+  const { tree, schema, setTree, setSchema, createField } = useFilterTree();
+
+  // 需要查詢時才編譯(邏輯都在 filter-builder)
+  const out = getEngine("jsonb").compile(
+    treeToFilterGroup(tree),
+    { fields: schema.map((f) => ({ path: f.path, kind: f.kind, dataType: f.dataType, elementType: f.elementType })) },
+  );
+
+  return (
+    <FilterTreeEditor
+      group={tree}
+      engineId="jsonb"
+      schema={schema}
+      onChange={setTree}
+      onCreateField={createField}
+      labels={{
+        logic: { and: "ALL", or: "ANY", nor: "NONE", not: "NOT" },
+        addCondition: "+ 條件", addGroup: "+ 群組",
+        removeGroup: "移除群組", removeCondition: "移除條件",
+        elemMatch: "elemmatch",
+      }}
+    />
+  );
+}
+```
+
+## `<FilterTreeEditor>` props
+
+| prop | 型別 | 用途 |
+|------|------|------|
+| `group` | `BuilderGroup` | 要渲染 / 編輯的樹 |
+| `engineId` | `EngineId` | 提供哪個引擎的 operator(`"jsonb"` `"data-filter"` `"sql-filter"` `"mongo"` `"pg-filter"`) |
+| `schema` | `FieldSchema[]` | 已知欄位 —— 驅動欄位 combobox、operator 可用性,以及(pg-filter)column/jsonb 種類 |
+| `onChange` | `(next: BuilderGroup) => void` | 每次編輯都以新樹回呼 |
+| `onCreateField` | `(path: string) => void` | 使用者輸入了 `schema` 沒有的欄位路徑 |
+| `labels` | `FilterTreeLabels` | 所有 UI 字串(labels-as-props;見下) |
+| `onRemove?` / `depth?` | — | 內部用(遞迴) |
+
+元件是全受控的 —— 除了每個群組的「收合」檢視旗標外不持有任何樹狀態(收合是純檢視,不會寫進 `BuilderGroup`)。
+
+## `FilterTreeLabels`
+
+```ts
+interface FilterTreeLabels {
+  logic: Record<"and"|"or"|"nor"|"not", string>;
+  addCondition: string; addGroup: string;
+  removeGroup: string; removeCondition: string;
+  elemMatch: string;
+  valueHint?: string;                       // list/tag 輸入的 placeholder
+  // 群組收合:
+  toggleGroup?: string;                     // chevron 的 aria-label
+  collapsedConditions?: string;             // 單位詞,如 "條件" → "2 條件"
+  collapsedGroups?: string;                 // 單位詞,如 "群組" → "1 群組"
+  collapsedEmpty?: string;                  // 空群組摘要
+  // operator 多語系:
+  operatorLabels?: Record<string, string>;  // op key → 在地化標籤(缺則顯示 raw op)
+}
+```
+
+> `collapsed*` 是**單位詞**,不是 `{count}` 模板 —— 數字由元件前綴。(next-intl 會把 `{count}` 當 ICU 變數,沒帶值就會丟錯。)
+
+## 其他匯出
+
+- **`useFilterTree(init?)`** → `{ tree, schema, setTree, setSchema, createField }` —— 最小狀態持有(包 `filter-builder` 的 `emptyGroup` / `addInferredField`)。
+- **`ValueEditor`** —— 依型別/arity 的值輸入(單值、range、tag/list)。
+- **`FieldCombobox`** —— 可即打即建的欄位選擇器。
+- **`OPERATOR_KEYS`** —— 標準 operator key 清單;用它組 `operatorLabels`(`Object.fromEntries(OPERATOR_KEYS.map(k => [k, t(k)]))`)。
+- **`colors`** —— `logicBadge`、`dataTypeBadge`、`dataTypeShort`、`logicColor`、`dataTypeColor`。
+
+## 相關套件
+
+- **[@rfjs/filter-builder](../filter-builder)** —— 本元件渲染的邏輯/資料層(tree-ops、引擎、編譯、operator 矩陣)。
+- **[@rfjs/web-ui](../web-ui)** —— 上樣式用的設計 token 與元件。

--- a/packages/jsonb-query/README.zh-TW.md
+++ b/packages/jsonb-query/README.zh-TW.md
@@ -73,6 +73,75 @@ qb.andWhere(where, params); // TypeORM QueryBuilder / knex.whereRaw(where, param
 這是 naive 的位置型 `?` 轉換做不到的。若要轉換既有的位置型結果，可使用
 底層的 `toNamedParams(result, prefix?)`。
 
+## 錯誤
+
+每個來自呼叫端輸入的問題都會丟出帶有穩定 `code` 的 `JsonbQueryError`；丟出其他型別代表內部 bug。
+
+```typescript
+import { JsonbQueryError } from '@rfjs/jsonb-query';
+
+try {
+  buildJsonbQuery('data', filter);
+} catch (e) {
+  if (e instanceof JsonbQueryError) {
+    // e.code: 'INVALID_COLUMN' | 'INVALID_DIALECT' | 'UNSUPPORTED_OPERATOR'
+    //       | 'INVALID_ELEMENT_TYPE' | 'INVALID_SCALAR_VALUE' | 'INVALID_ARRAY_VALUE'
+    //       | 'INVALID_OBJECT_VALUE' | 'EMPTY_FILTER_GROUP' | 'INVALID_PREFIX'
+    //       | 'PARAM_MISMATCH' | 'INVALID_SORT'
+  }
+}
+```
+
+## 索引
+
+| 運算子 | 有幫助的索引 |
+| --- | --- |
+| 物件 `contains`/`containsall`（`@>`）、`haskey`/`hasanykey`/`hasallkeys`（`?`/`?\|`/`?&`） | 預設 `GIN (col jsonb_ops)` |
+| `jsonpath` 方言述詞（`@?` / `@@`） | `GIN (col jsonb_path_ops)` |
+| 熱路徑上的 `legacy` 純量比較 | b-tree **expression** 索引，例如 `CREATE INDEX ON t ((data #>> '{status}'))` |
+
+`contains` / `icontains` / `startswith` / `istartswith` / `endswith` /
+`iendswith` **不**走索引（全表掃描）；大量子字串搜尋請改用 `pg_trgm` GIN 索引。
+jsonpath 的 `elemmatch` SQL-fallback 片段（物件或 `containsall` leaf）不會被
+`jsonb_path_ops` GIN 索引服務。
+
+## 排序
+
+`buildJsonbOrderBy` 把排序中繼資料轉成參數化的 `ORDER BY` 片段，重用與 `WHERE`
+建構器相同的路徑萃取與型別轉換。它**與方言無關**（排序一律萃取純量，jsonpath
+沒有排序構造），所以不接受 `dialect` 選項。用 `paramOffset` 接在 `WHERE` 之後組合：
+
+```typescript
+import { buildJsonbQuery, buildJsonbOrderBy } from '@rfjs/jsonb-query';
+
+const { where, values } = buildJsonbQuery('data', filter);
+const ob = buildJsonbOrderBy('data', [
+  { field: 'age', dataType: 'numeric', direction: 'desc', nulls: 'last' },
+  { field: 'name', dataType: 'string' }, // direction 預設 'asc'
+], { paramOffset: values.length });
+// ob.orderBy: '("data" #>> $3)::numeric desc nulls last, ("data" #>> $4) asc'
+await client.query(
+  `SELECT * FROM t WHERE ${where} ORDER BY ${ob.orderBy}`,
+  [...values, ...ob.values],
+);
+```
+
+`nulls` 可省略；省略則用 PostgreSQL 預設（`asc` → `NULLS LAST`，`desc` →
+`NULLS FIRST`）。空的 `sorts` 會回傳空字串 `orderBy`（直接省略 `ORDER BY`）。
+只有純量 `dataType` 可排序；不合法的 `dataType` / `direction` / `nulls` 會丟
+`JsonbQueryError`（code `INVALID_SORT`）。
+
+對具名綁定的查詢層（TypeORM QueryBuilder、Knex），用 `buildNamedJsonbOrderBy`
+（`:pN` 輸出）—— 即 `buildNamedJsonbQuery` 的 ORDER BY 對應版：
+
+```typescript
+const { orderBy, params } = buildNamedJsonbOrderBy('data', [
+  { field: 'age', dataType: 'numeric', direction: 'desc' },
+], { prefix: 'o' });
+// orderBy: '("data" #>> :o1)::numeric desc'   params: { o1: ['age'] }
+qb.addOrderBy(orderBy).setParameters(params);
+```
+
 ## 安全性
 
 條件的**值**與**欄位路徑**一律透過參數化處理，永遠不會插值到 SQL 中。**column** 引數是由開發者提供的識別符：系統會對其進行驗證並加上引號（`data`、`t.payload`），任何不符合純（選擇性限定）欄位參考的輸入都會被拒絕。
@@ -86,12 +155,12 @@ qb.andWhere(where, params); // TypeORM QueryBuilder / knex.whereRaw(where, param
 
 | dataType                          | operators                                                                  |
 | --------------------------------- | -------------------------------------------------------------------------- |
-| `string`                          | `eq` `neq` `isnull` `isnotnull` `contains` `startswith` `endswith` `terms` |
+| `string`                          | `eq` `neq` `isnull` `isnotnull` `contains` `startswith` `endswith` `terms` `icontains` `istartswith` `iendswith` `ieq` `ineq` |
 | `numeric`                         | `eq` `neq` `isnull` `isnotnull` `gt` `gte` `lt` `lte` `range` `terms`      |
 | `date`                            | `eq` `neq` `isnull` `isnotnull` `gt` `gte` `lt` `lte` `range` `terms`      |
 | `boolean`                         | `eq` `neq` `isnull` `isnotnull`                                            |
-| `object`                          | `eq` `neq` `contains` `isnull` `isnotnull`                                 |
-| `array` + 純量 `elementType`      | 元素運算子（見下方）+ `containsall` + `isnull` `isnotnull`                 |
+| `object`                          | `eq` `neq` `contains` `isnull` `isnotnull` `haskey` `hasanykey` `hasallkeys` |
+| `array` + 純量 `elementType`      | 元素運算子（見下方，`neq` = 值不存在）+ `containsall` + `isempty` `isnotempty` + `isnull` `isnotnull` |
 | `array` + `elementType: 'object'` | `elemmatch`                                                                |
 
 `range` 接受 2 個元素的 `[lo, hi]` 陣列；`terms` 接受非空陣列。
@@ -108,6 +177,40 @@ qb.andWhere(where, params); // TypeORM QueryBuilder / knex.whereRaw(where, param
 
 物件條件在兩種方言中產生相同 SQL（SQL/JSON path 述詞無法比較非純量值），
 且 `@>` 可使用 GIN 索引。
+
+### 物件鍵存在
+
+`haskey` / `hasanykey` / `hasallkeys` 測試物件**鍵**是否存在（jsonb `?` / `?|`
+/ `?&`），不論該鍵的值 —— 與測試「值」的 `isnotnull` 不同（鍵存在但值為 JSON
+`null` 時，`haskey: true` 但 `isnotnull: false`）。三者皆可用 GIN 索引。
+
+```typescript
+{ field: 'profile', dataType: 'object', operator: 'haskey', value: 'vip' }
+//  (("data" #> $1) ? $2)              values: [['profile'], 'vip']
+{ field: 'profile', dataType: 'object', operator: 'hasanykey', value: ['vip','premium'] }
+//  (("data" #> $1) ?| $2::text[])
+{ field: 'profile', dataType: 'object', operator: 'hasallkeys', value: ['vip','level'] }
+//  (("data" #> $1) ?& $2::text[])
+```
+
+> **`?` 佔位符衝突：**這些運算子會在 SQL 裡輸出字面的 `?` / `?|` / `?&`。
+> node-postgres 用 `$N` 佔位符，所以沒問題。把 `?` 當綁定佔位符的查詢層
+> （如 Knex `whereRaw`）會誤判 —— 請改用 `buildNamedJsonbQuery`（`:pN` 輸出），
+> 或使用 `$N` 的驅動。
+
+### 不分大小寫文字
+
+`icontains` / `istartswith` / `iendswith` / `ieq` / `ineq` 以不分大小寫比對字串。
+legacy 方言對兩側做 `lower()`；jsonpath 方言用 `like_regex … flag "i"`。
+
+> 兩種方言在非 ASCII 文字上的大小寫折疊略有差異：`lower()` 依資料庫 `LC_CTYPE`，
+> jsonpath `flag "i"` 用自己的 Unicode 規則。ASCII 文字結果相同。
+
+### 陣列是否為空
+
+`isempty` / `isnotempty` 測試純量元素陣列欄位是否有零個 / 至少一個元素
+（`jsonb_array_length`）。欄位不存在或非陣列值則**兩者皆非**（兩個運算子都回
+false）。兩種方言產生相同 SQL。
 
 ### JSON 陣列（純量元素）
 

--- a/packages/pg-filter/README.md
+++ b/packages/pg-filter/README.md
@@ -1,0 +1,98 @@
+# @rfjs/pg-filter
+
+> 繁體中文 → [README.zh-TW.md](./README.zh-TW.md)
+
+Unified PostgreSQL filter builder: **one filter tree that mixes plain SQL columns
+and JSONB paths**, compiled to a single parameterized `WHERE` / `ORDER BY` (plus
+`LIMIT` / `OFFSET`). It composes [@rfjs/sql-filter](../sql-filter) (the column
+side) and [@rfjs/jsonb-query](../jsonb-query) (the JSONB side) — each leaf
+declares its `target`, and `buildPgFilter` renders the whole tree together.
+
+---
+
+## Install
+
+```bash
+npm i @rfjs/pg-filter
+```
+
+## How it works
+
+```
+ one PgFilterGroup (and/or/nor/not, nested)
+ ├─ { target: 'column', column, operator, value }   ──▶ @rfjs/sql-filter  →  "name" ILIKE …
+ └─ { target: 'jsonb',  field,  operator, value }    ──▶ @rfjs/jsonb-query →  ("data" #>> …)::numeric > …
+                         │
+                         ▼
+        buildPgFilter(config, input)  ──▶  { where, orderBy, limit, offset, values, countValues }
+```
+
+Column leaves resolve against a **column allowlist + type map**; JSONB leaves
+resolve against a single JSONB **column** with a chosen dialect. The two streams
+of `$N` parameters are merged into one ordered `values` array.
+
+## Usage
+
+```ts
+import { buildPgFilter, type PgFilterConfig } from "@rfjs/pg-filter";
+
+const config: PgFilterConfig = {
+  columns: { name: { column: "name", type: "text" } },
+  jsonb: { column: "data", dialect: "legacy" }, // or 'jsonpath' (PG12+)
+};
+
+const { where, orderBy, limit, offset, values, countValues } = buildPgFilter(config, {
+  filter: {
+    logic: "and",
+    filters: [
+      { target: "column", column: "name", operator: "contains", value: "cust" },
+      { target: "jsonb", field: "score", dataType: "numeric", operator: "gt", value: 80 },
+    ],
+  },
+  sort: [{ target: "jsonb", field: "score", dataType: "numeric", direction: "desc" }],
+  page: 1,
+  pageSize: 20,
+});
+
+// run it
+const rows = await client.query(
+  `SELECT * FROM datasets WHERE ${where} ORDER BY ${orderBy} LIMIT ${limit} OFFSET ${offset}`,
+  values,
+);
+const total = await client.query(`SELECT count(*) FROM datasets WHERE ${where}`, countValues);
+```
+
+- `where` is never empty (`'true'` when there's no filter); `orderBy` is `''` when there's no sort.
+- `values` = WHERE params **++** ORDER BY params (for the main query). `countValues` = WHERE params only (a prefix of `values`) — use it for the `COUNT(*)` query.
+
+## Leaf & sort shapes
+
+```ts
+type PgColumnLeaf = { target: "column"; column: string; operator: ColumnOperator; value?: unknown };
+type PgJsonbLeaf  = { target: "jsonb"; field: string; dataType: JsonbDataType; operator: string;
+                      value?: unknown; elementType?: JsonbScalarType | "object"; filters?: JsonbFilterGroup };
+type PgSort = { target: "column"; column: string; direction?: "asc"|"desc"; nulls?: "first"|"last" }
+            | { target: "jsonb"; field: string; dataType: JsonbScalarType; direction?: "asc"|"desc"; nulls?: "first"|"last" };
+```
+
+## Operators
+
+`pg-filter` does **not** define its own operators — each leaf uses its target engine's set:
+
+- `target: 'column'` → the **scalar column** operators of [@rfjs/sql-filter](../sql-filter#column-operators--types) (`eq`/`neq`/`contains`/`startswith`/`gt`/`gte`/`lt`/`lte`/`isnull`/`isnotnull`; no `IN`, no range).
+- `target: 'jsonb'` → the full [@rfjs/jsonb-query](../jsonb-query) set (`terms`, `range`, `containsall`, case-insensitive variants, `haskey…`, `elemmatch`, …).
+
+See the cross-engine matrix in [@rfjs/filter-builder](../filter-builder#operator-matrix).
+
+## Public API
+
+- **`build`** — `buildPgFilter(config, input) → PgFilterResult`
+- **`types`** — `PgFilterConfig`, `PgFilterInput`, `PgFilterResult`, `PgFilterGroup`, `PgLeaf` (`PgColumnLeaf` | `PgJsonbLeaf`), `PgSort`
+- **`filter`** / **`order-by`** / **`pagination`** — the building blocks `build` composes
+- **`errors`** — pg-filter error types
+
+## Related
+
+- **[@rfjs/sql-filter](../sql-filter)** — the column engine.
+- **[@rfjs/jsonb-query](../jsonb-query)** — the JSONB engine.
+- **[@rfjs/filter-builder](../filter-builder)** — canonical editable tree that compiles to this (`treeToPgFilterGroup` + the `pg-filter` engine).

--- a/packages/pg-filter/README.zh-TW.md
+++ b/packages/pg-filter/README.zh-TW.md
@@ -1,0 +1,92 @@
+# @rfjs/pg-filter
+
+> English → [README.md](./README.md)
+
+統一的 PostgreSQL 篩選建構器:**同一棵篩選樹同時混用純 SQL 欄位與 JSONB 路徑**,編譯成單一參數化的 `WHERE` / `ORDER BY`(外加 `LIMIT` / `OFFSET`)。它組合了 [@rfjs/sql-filter](../sql-filter)(欄位端)與 [@rfjs/jsonb-query](../jsonb-query)(JSONB 端)—— 每個 leaf 自己宣告 `target`,`buildPgFilter` 把整棵樹一起渲染。
+
+---
+
+## 安裝
+
+```bash
+npm i @rfjs/pg-filter
+```
+
+## 運作方式
+
+```
+ 一棵 PgFilterGroup(and/or/nor/not,可巢狀)
+ ├─ { target: 'column', column, operator, value }   ──▶ @rfjs/sql-filter  →  "name" ILIKE …
+ └─ { target: 'jsonb',  field,  operator, value }    ──▶ @rfjs/jsonb-query →  ("data" #>> …)::numeric > …
+                         │
+                         ▼
+        buildPgFilter(config, input)  ──▶  { where, orderBy, limit, offset, values, countValues }
+```
+
+欄位 leaf 依**欄位白名單 + 型別表**解析;JSONB leaf 對單一 JSONB **欄位**用指定 dialect 解析。兩股 `$N` 參數會合併成一個有序的 `values` 陣列。
+
+## 用法
+
+```ts
+import { buildPgFilter, type PgFilterConfig } from "@rfjs/pg-filter";
+
+const config: PgFilterConfig = {
+  columns: { name: { column: "name", type: "text" } },
+  jsonb: { column: "data", dialect: "legacy" }, // 或 'jsonpath'(PG12+)
+};
+
+const { where, orderBy, limit, offset, values, countValues } = buildPgFilter(config, {
+  filter: {
+    logic: "and",
+    filters: [
+      { target: "column", column: "name", operator: "contains", value: "cust" },
+      { target: "jsonb", field: "score", dataType: "numeric", operator: "gt", value: 80 },
+    ],
+  },
+  sort: [{ target: "jsonb", field: "score", dataType: "numeric", direction: "desc" }],
+  page: 1,
+  pageSize: 20,
+});
+
+// 執行
+const rows = await client.query(
+  `SELECT * FROM datasets WHERE ${where} ORDER BY ${orderBy} LIMIT ${limit} OFFSET ${offset}`,
+  values,
+);
+const total = await client.query(`SELECT count(*) FROM datasets WHERE ${where}`, countValues);
+```
+
+- `where` 永不為空(無條件時為 `'true'`);`orderBy` 無排序時為 `''`。
+- `values` = WHERE 參數 **++** ORDER BY 參數(主查詢用);`countValues` = 只有 WHERE 參數(是 `values` 的前綴)—— 給 `COUNT(*)` 查詢用。
+
+## Leaf 與 sort 結構
+
+```ts
+type PgColumnLeaf = { target: "column"; column: string; operator: ColumnOperator; value?: unknown };
+type PgJsonbLeaf  = { target: "jsonb"; field: string; dataType: JsonbDataType; operator: string;
+                      value?: unknown; elementType?: JsonbScalarType | "object"; filters?: JsonbFilterGroup };
+type PgSort = { target: "column"; column: string; direction?: "asc"|"desc"; nulls?: "first"|"last" }
+            | { target: "jsonb"; field: string; dataType: JsonbScalarType; direction?: "asc"|"desc"; nulls?: "first"|"last" };
+```
+
+## Operator
+
+`pg-filter` **不自己定義** operator —— 每個 leaf 用它 target 引擎的集合:
+
+- `target: 'column'` → [@rfjs/sql-filter](../sql-filter#column-operator-與型別) 的**純量欄位** operator(`eq`/`neq`/`contains`/`startswith`/`gt`/`gte`/`lt`/`lte`/`isnull`/`isnotnull`;無 `IN`、無 range)。
+- `target: 'jsonb'` → [@rfjs/jsonb-query](../jsonb-query) 的完整集合(`terms`、`range`、`containsall`、不分大小寫版本、`haskey…`、`elemmatch` 等)。
+
+跨引擎矩陣見 [@rfjs/filter-builder](../filter-builder#operator-矩陣)。
+
+## 公開 API
+
+- **`build`** — `buildPgFilter(config, input) → PgFilterResult`
+- **`types`** — `PgFilterConfig`、`PgFilterInput`、`PgFilterResult`、`PgFilterGroup`、`PgLeaf`(`PgColumnLeaf` | `PgJsonbLeaf`)、`PgSort`
+- **`filter`** / **`order-by`** / **`pagination`** — `build` 組合的building blocks
+- **`errors`** — pg-filter 錯誤型別
+
+## 相關套件
+
+- **[@rfjs/sql-filter](../sql-filter)** — 欄位引擎。
+- **[@rfjs/jsonb-query](../jsonb-query)** — JSONB 引擎。
+- **[@rfjs/filter-builder](../filter-builder)** — 可編輯的標準樹,編譯到本套件(`treeToPgFilterGroup` + `pg-filter` 引擎)。

--- a/packages/sql-filter/README.md
+++ b/packages/sql-filter/README.md
@@ -1,5 +1,109 @@
 # @rfjs/sql-filter
 
-Generic boolean filter-group → SQL builder with pluggable leaf renderers. Built-in column leaf renders parameterized PostgreSQL `WHERE` / `ORDER BY` against a declared column allowlist.
+> 繁體中文 → [README.zh-TW.md](./README.zh-TW.md)
 
-See `docs/superpowers/specs/2026-06-15-sql-filter-design.md`.
+Generic boolean **filter-group → parameterized SQL** builder with **pluggable leaf
+renderers**. It owns the tree/logic (`and`/`or`/`nor`/`not`, arbitrary nesting)
+and delegates each leaf to a renderer you supply — so it knows *how to combine*
+conditions, not *what a condition means*. Ships a built-in **column** renderer for
+PostgreSQL `WHERE` / `ORDER BY` over a declared column allowlist. Zero runtime
+dependencies.
+
+This is the low-level core that [@rfjs/pg-filter](../pg-filter) builds on for the
+column side of its unified trees.
+
+---
+
+## Install
+
+```bash
+npm i @rfjs/sql-filter
+```
+
+## Two layers
+
+```
+ FilterGroup<L>  ──buildFilterGroup(group, renderLeaf, params)──▶  "a=$1 and (b=$2 or c=$3)"
+   (tree+logic)         every leaf L handed to YOUR renderLeaf
+        │
+        └─ built-in column layer: buildColumnQuery(config, group) ──▶ { where, values }
+                 leaves are { column, operator, value }, rendered safely
+                 against a column allowlist + type map
+```
+
+### 1. Generic core — bring your own leaf renderer
+
+```ts
+import { buildFilterGroup, ParamBuilder, type FilterGroup } from "@rfjs/sql-filter";
+
+type Leaf = { col: string; val: unknown };
+const group: FilterGroup<Leaf> = {
+  logic: "and",
+  filters: [{ col: "a", val: 1 }, { logic: "or", filters: [{ col: "b", val: 2 }, { col: "c", val: 3 }] }],
+};
+
+const params = new ParamBuilder();
+const where = buildFilterGroup(group, (leaf, p) => `${leaf.col} = ${p.add(leaf.val)}`, params);
+// where  → "a = $1 and (b = $2 or c = $3)"
+// params.values → [1, 2, 3]
+```
+
+`ParamBuilder.add(value)` returns the next `$N` placeholder and accumulates the
+value — so output is always parameterized (no value interpolation).
+
+### 2. Built-in column layer
+
+```ts
+import { buildColumnQuery, type ColumnConfig } from "@rfjs/sql-filter";
+
+const config: ColumnConfig = {
+  name: { column: "name", type: "text" },
+  createdAt: { column: "created_at", type: "timestamp" },
+};
+
+const { where, values } = buildColumnQuery(config, {
+  logic: "and",
+  filters: [
+    { column: "name", operator: "contains", value: "sales" },
+    { column: "createdAt", operator: "gte", value: "2026-01-01" },
+  ],
+});
+// where  → "\"name\" ilike '%' || $1 || '%' and \"created_at\" >= $2"
+// values → ["sales", "2026-01-01"]
+```
+
+`buildColumnOrderBy(config, sorts)` produces a parameterized `ORDER BY` the same way.
+
+## Column operators & types
+
+The column layer is intentionally a **scalar, single-value** surface (no `IN`,
+no range — those live in the JSONB / Mongo engines). Operators are validated
+against each column's declared `type`:
+
+| `ColumnType` | allowed `ColumnOperator` |
+|--------------|--------------------------|
+| `text` | `eq` `neq` `isnull` `isnotnull` `contains` `startswith` `gt` `gte` `lt` `lte` |
+| `numeric` / `timestamp` | `eq` `neq` `isnull` `isnotnull` `gt` `gte` `lt` `lte` |
+| `boolean` / `uuid` | `eq` `neq` `isnull` `isnotnull` |
+
+Values are single-value (`isnull`/`isnotnull` take none). An unknown column or a
+type-disallowed operator throws `ColumnQueryError`
+(`UNKNOWN_COLUMN` / `UNSUPPORTED_OPERATOR`).
+
+> For the cross-engine operator picture (which engine has `terms`/`range`/etc.),
+> see the matrix in [@rfjs/filter-builder](../filter-builder#operator-matrix).
+
+## Public API
+
+- **`engine`** — `buildFilterGroup(group, renderLeaf, params)`
+- **`param-builder`** — `ParamBuilder` (`add(value) → "$N"`, `.values`)
+- **`column`** — `buildColumnQuery`, `buildColumnOrderBy`, `ColumnConfig`, `ColumnCondition`, `ColumnOperator`, `ColumnType`, `ColumnSortSpec`
+- **`types`** — `FilterGroup<L>`, `LogicalOperator`
+- **`errors`** — `ColumnQueryError` (`code`: `UNKNOWN_COLUMN` | `UNSUPPORTED_OPERATOR` | `INVALID_PARAM_OFFSET`)
+
+## Related
+
+- **[@rfjs/pg-filter](../pg-filter)** — composes this (columns) with `jsonb-query` (JSONB) into one tree.
+- **[@rfjs/filter-builder](../filter-builder)** — canonical tree + cross-engine operator matrix.
+
+Design notes: `docs/superpowers/specs/2026-06-15-sql-filter-design.md`.

--- a/packages/sql-filter/README.zh-TW.md
+++ b/packages/sql-filter/README.zh-TW.md
@@ -1,0 +1,96 @@
+# @rfjs/sql-filter
+
+> English → [README.md](./README.md)
+
+通用的**布林 filter-group → 參數化 SQL** 產生器,搭配**可插拔的 leaf 渲染器**。它負責樹與邏輯(`and`/`or`/`nor`/`not`,任意巢狀),把每個 leaf 交給你提供的渲染器 —— 也就是它懂「**怎麼組合**條件」,不懂「條件是什麼意思」。內建一個 **column** 渲染器,對宣告過的欄位白名單產生 PostgreSQL `WHERE` / `ORDER BY`。零執行期相依。
+
+這是底層核心;[@rfjs/pg-filter](../pg-filter) 的欄位端就是建構在它之上。
+
+---
+
+## 安裝
+
+```bash
+npm i @rfjs/sql-filter
+```
+
+## 兩層
+
+```
+ FilterGroup<L>  ──buildFilterGroup(group, renderLeaf, params)──▶  "a=$1 and (b=$2 or c=$3)"
+   (樹 + 邏輯)         每個 leaf L 都交給「你的」renderLeaf
+        │
+        └─ 內建 column 層:buildColumnQuery(config, group) ──▶ { where, values }
+                 leaf 是 { column, operator, value },依欄位白名單 + 型別表安全渲染
+```
+
+### 1. 通用核心 —— 自帶 leaf 渲染器
+
+```ts
+import { buildFilterGroup, ParamBuilder, type FilterGroup } from "@rfjs/sql-filter";
+
+type Leaf = { col: string; val: unknown };
+const group: FilterGroup<Leaf> = {
+  logic: "and",
+  filters: [{ col: "a", val: 1 }, { logic: "or", filters: [{ col: "b", val: 2 }, { col: "c", val: 3 }] }],
+};
+
+const params = new ParamBuilder();
+const where = buildFilterGroup(group, (leaf, p) => `${leaf.col} = ${p.add(leaf.val)}`, params);
+// where  → "a = $1 and (b = $2 or c = $3)"
+// params.values → [1, 2, 3]
+```
+
+`ParamBuilder.add(value)` 回傳下一個 `$N` 佔位並累積該值 —— 所以輸出永遠是參數化的(不會把值字串拼接進 SQL)。
+
+### 2. 內建 column 層
+
+```ts
+import { buildColumnQuery, type ColumnConfig } from "@rfjs/sql-filter";
+
+const config: ColumnConfig = {
+  name: { column: "name", type: "text" },
+  createdAt: { column: "created_at", type: "timestamp" },
+};
+
+const { where, values } = buildColumnQuery(config, {
+  logic: "and",
+  filters: [
+    { column: "name", operator: "contains", value: "sales" },
+    { column: "createdAt", operator: "gte", value: "2026-01-01" },
+  ],
+});
+// where  → "\"name\" ilike '%' || $1 || '%' and \"created_at\" >= $2"
+// values → ["sales", "2026-01-01"]
+```
+
+`buildColumnOrderBy(config, sorts)` 用同樣方式產生參數化的 `ORDER BY`。
+
+## Column operator 與型別
+
+column 層刻意是**純量、單一值**的介面(沒有 `IN`、沒有 range —— 那些在 JSONB / Mongo 引擎)。operator 會依欄位宣告的 `type` 驗證:
+
+| `ColumnType` | 允許的 `ColumnOperator` |
+|--------------|-------------------------|
+| `text` | `eq` `neq` `isnull` `isnotnull` `contains` `startswith` `gt` `gte` `lt` `lte` |
+| `numeric` / `timestamp` | `eq` `neq` `isnull` `isnotnull` `gt` `gte` `lt` `lte` |
+| `boolean` / `uuid` | `eq` `neq` `isnull` `isnotnull` |
+
+值都是單一值(`isnull`/`isnotnull` 不帶值)。未知欄位或型別不允許的 operator 會丟 `ColumnQueryError`(`UNKNOWN_COLUMN` / `UNSUPPORTED_OPERATOR`)。
+
+> 跨引擎的 operator 全貌(哪個引擎有 `terms`/`range` 等)請見 [@rfjs/filter-builder](../filter-builder#operator-矩陣) 的矩陣。
+
+## 公開 API
+
+- **`engine`** — `buildFilterGroup(group, renderLeaf, params)`
+- **`param-builder`** — `ParamBuilder`(`add(value) → "$N"`、`.values`)
+- **`column`** — `buildColumnQuery`、`buildColumnOrderBy`、`ColumnConfig`、`ColumnCondition`、`ColumnOperator`、`ColumnType`、`ColumnSortSpec`
+- **`types`** — `FilterGroup<L>`、`LogicalOperator`
+- **`errors`** — `ColumnQueryError`(`code`:`UNKNOWN_COLUMN` | `UNSUPPORTED_OPERATOR` | `INVALID_PARAM_OFFSET`)
+
+## 相關套件
+
+- **[@rfjs/pg-filter](../pg-filter)** — 把本套件(欄位)與 `jsonb-query`(JSONB)組成同一棵樹。
+- **[@rfjs/filter-builder](../filter-builder)** — 標準樹 + 跨引擎 operator 矩陣。
+
+設計筆記:`docs/superpowers/specs/2026-06-15-sql-filter-design.md`。


### PR DESCRIPTION
Fills the README gaps across the filter package stack, bilingual (en + zh-TW), following the DRY rule from the filter-builder README discussion: each engine documents **its own** operators/semantics; operator detail links to the [filter-builder matrix](../filter-builder) rather than being duplicated.

## What's added

| Package | Before | After |
|---|---|---|
| **sql-filter** (published) | 5-line stub, no zh | full README + zh-TW (generic core + `renderLeaf`, built-in column layer, column ops/types) |
| **pg-filter** (published) | **no README** | new README + zh-TW (composes sql-filter + jsonb-query via per-leaf `target`; `buildPgFilter` result shape) |
| **filter-builder-ui** (private) | **no README** | new README + zh-TW (`<FilterTreeEditor>` props, `FilterTreeLabels` incl. collapse + operator i18n, `useFilterTree`, exports) |
| **jsonb-query** (published) | en 341L / zh 197L (behind) | zh-TW synced to en — adds Errors, Indexing, Sorting, Key-existence, Case-insensitive, Array-emptiness; operators table brought to parity |

## Notes
- Diagrams are **ASCII** (render on both GitHub and npm); no Mermaid/embedded HTML (npm sanitizes those).
- Links to `../filter-builder` resolve once #184 (the filter-builder README) merges — these two are companion docs PRs.
- Docs-only; no code. Pre-commit lint-staged ran clean (no code touched).

Done in a git worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)