### PR TITLE
chore(web): vercel.json for standalone apps/web deploy

### DIFF
--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "nextjs",
+  "buildCommand": "cd ../.. && pnpm turbo run build --filter=web",
+  "ignoreCommand": "cd ../.. && npx turbo-ignore web"
+}


### PR DESCRIPTION
Lets **only `apps/web`** deploy to Vercel from this turborepo.

## What's in `apps/web/vercel.json`
```json
{
  "framework": "nextjs",
  "buildCommand": "cd ../.. && pnpm turbo run build --filter=web",
  "ignoreCommand": "cd ../.. && npx turbo-ignore web"
}
```
- **buildCommand** runs from the repo root via turbo, so web's workspace deps build first in topo order — including `@rfjs/filter-builder`'s `dist` (which web consumes as built output, not transpiled). Verified locally: `pnpm turbo run build --filter=web` → 11 tasks succeed.
- **ignoreCommand** uses `turbo-ignore` so Vercel skips the build when `web` and its deps are unchanged (saves build minutes on a monorepo).

## Vercel dashboard steps (one-time, can't live in vercel.json)
1. New Project → import this repo.
2. **Root Directory** = `apps/web` (this is what makes Vercel read `apps/web/vercel.json`). Keep "Include files outside the Root Directory" enabled (auto for monorepos) so the pnpm workspace installs at the repo root.
3. Framework / Build / Ignore command: auto-filled from `vercel.json`. Install command: leave default (Vercel installs the pnpm workspace at the root; respects `packageManager: pnpm@10.24.0`).
4. **Node**: default 24.x is fine (matches the repo's `.nvmrc`).
5. **Env (optional)**: `NEXT_PUBLIC_WORKBENCH_URL` → the workbench's URL, for the "open in workbench" cross-links (unset = they point at localhost; doesn't affect the build).

## Notes
- `apps/web` is self-contained: no `@rfjs/core`/`@rfjs/db`, no DB, no external API. Its only server bit is the `app/api/tools/jwt-decode` route, which runs as a Vercel function.
- Independent of GitLab CI (web has no Dockerfile / isn't in the K8s build-deploy scope) — Vercel becomes web's deploy path.
- Did **not** pin `engines.node` in `apps/web/package.json`: Vercel defaults to 24.x already, and a strict `24.x` could trip the repo's strict pnpm engine checks for contributors not on Node 24 locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)