### PR TITLE
fix(web): mobile nav drawer trapped behind the blurred header

### DIFF
--- a/apps/web/src/components/layout/mobile-nav.tsx
+++ b/apps/web/src/components/layout/mobile-nav.tsx
@@ -3,8 +3,8 @@
 import { Button } from "@rfjs/web-ui/components/button";
 import { Menu, X } from "lucide-react";
 import { useTranslations } from "next-intl";
-import { useEffect, useRef } from "react";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 
 import { AppSidebar } from "./app-sidebar";
 
@@ -21,9 +21,13 @@ export function MobileNav() {
       if (e.key === "Escape") setOpen(false);
     };
     document.addEventListener("keydown", onKey);
+    // Lock background scroll while the drawer is open.
+    const prevOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
     panelRef.current?.focus();
     return () => {
       document.removeEventListener("keydown", onKey);
+      document.body.style.overflow = prevOverflow;
       opener?.focus();
     };
   }, [open]);
@@ -40,32 +44,43 @@ export function MobileNav() {
       >
         <Menu className="size-5" />
       </Button>
-      {open ? (
-        <div className="fixed inset-0 z-50 flex">
-          <button
-            aria-label={t("closeMenu")}
-            className="absolute inset-0 bg-bedrock/70"
-            onClick={() => setOpen(false)}
-          />
-          <div
-            ref={panelRef}
-            tabIndex={-1}
-            role="dialog"
-            aria-modal="true"
-            aria-label={t("openMenu")}
-            className="relative z-10 h-full w-72 max-w-[80%] overflow-y-auto border-r border-border bg-slab outline-none"
-          >
-            <div className="flex justify-end p-2">
-              <Button variant="ghost" size="icon" aria-label={t("closeMenu")} onClick={() => setOpen(false)}>
-                <X className="size-5" />
-              </Button>
-            </div>
-            <div onClick={() => setOpen(false)}>
-              <AppSidebar />
-            </div>
-          </div>
-        </div>
-      ) : null}
+      {/* Portal to <body>: the header's `backdrop-blur` makes it the containing
+          block for `position: fixed` descendants, which would trap this overlay
+          inside the 56px header. Rendering at the body escapes that. */}
+      {open
+        ? createPortal(
+            <div className="fixed inset-0 z-50 flex">
+              <button
+                aria-label={t("closeMenu")}
+                className="absolute inset-0 bg-bedrock/70"
+                onClick={() => setOpen(false)}
+              />
+              <div
+                ref={panelRef}
+                tabIndex={-1}
+                role="dialog"
+                aria-modal="true"
+                aria-label={t("openMenu")}
+                className="relative z-10 h-full w-72 max-w-[80%] overflow-y-auto border-r border-border bg-slab outline-none"
+              >
+                <div className="flex justify-end p-2">
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    aria-label={t("closeMenu")}
+                    onClick={() => setOpen(false)}
+                  >
+                    <X className="size-5" />
+                  </Button>
+                </div>
+                <div onClick={() => setOpen(false)}>
+                  <AppSidebar />
+                </div>
+              </div>
+            </div>,
+            document.body,
+          )
+        : null}
     </div>
   );
 }


### PR DESCRIPTION
## Symptom
On narrow screens, tapping the top-left hamburger opened a drawer that appeared **stuck behind / clipped into the header** ("按了被擋在後面") instead of covering the screen.

## Root cause
`AppHeader` uses `backdrop-blur` (= `backdrop-filter`). Like `transform`/`filter`, `backdrop-filter` makes that element the **containing block for `position: fixed` descendants**. `MobileNav`'s drawer (`fixed inset-0 z-50`) is a descendant of the header, so `inset-0` resolved to the **56px header box**, not the viewport — trapping the overlay in the top strip.

## Fix
Render the drawer through a **React Portal to `document.body`** so it escapes the header's containing block and `fixed inset-0` is viewport-relative again (same portal pattern used for the filter-tree tooltip). Also lock background scroll while the drawer is open.

- Portal only mounts when `open` (client interaction) → SSR-safe; `next build` passes.
- No behavior change otherwise (Esc-to-close, focus return, backdrop click, close-on-navigate all preserved).

## Verified
`apps/web`: check-types ✓ · lint ✓ · 65 tests ✓ · `next build` ✓ (browser visual confirmation still recommended on a phone viewport).

🤖 Generated with [Claude Code](https://claude.com/claude-code)