### PR TITLE
fix(es-query): correct not-group semantics (negated AND, not negated OR)

### DIFF
--- a/packages/es-query/README.md
+++ b/packages/es-query/README.md
@@ -73,12 +73,14 @@ buildSearchBody(tree, {
 
 ## Group logic → `bool`
 
-| group | bool clause |
-|---|---|
-| `and` | `must` |
-| `or`  | `should` (+ `minimum_should_match: 1`) |
-| `not` | `must_not` |
-| `nor` | `must_not` |
+| group | meaning | bool clause |
+|---|---|---|
+| `and` | all match | `must: [...]` |
+| `or`  | any match | `should: [...]` (+ `minimum_should_match: 1`) |
+| `not` | not all — `¬(a ∧ b)` | `must_not: [{ bool: { must: [...] } }]` |
+| `nor` | none match — `¬(a ∨ b)` | `must_not: [...]` |
+
+`not` and `nor` differ once a group has two or more children (for a single child both reduce to `must_not: [child]`) — matching `@rfjs/jsonb-query` / `@rfjs/sql-filter` (`not (a and b)` vs `not (a or b)`).
 
 ## Operators → clauses
 

--- a/packages/es-query/README.zh-TW.md
+++ b/packages/es-query/README.zh-TW.md
@@ -74,12 +74,14 @@ buildSearchBody(tree, {
 
 ## 群組邏輯 → `bool`
 
-| 群組 | bool 子句 |
-|---|---|
-| `and` | `must` |
-| `or`  | `should`（+ `minimum_should_match: 1`） |
-| `not` | `must_not` |
-| `nor` | `must_not` |
+| 群組 | 意義 | bool 子句 |
+|---|---|---|
+| `and` | 全部成立 | `must: [...]` |
+| `or`  | 擇一成立 | `should: [...]`（+ `minimum_should_match: 1`） |
+| `not` | 非全部 —— `¬(a ∧ b)` | `must_not: [{ bool: { must: [...] } }]` |
+| `nor` | 皆不成立 —— `¬(a ∨ b)` | `must_not: [...]` |
+
+`not` 與 `nor` 在群組有兩個以上子節點時才不同（單一子節點時兩者都化簡為 `must_not: [child]`）—— 與 `@rfjs/jsonb-query` / `@rfjs/sql-filter` 一致（`not (a and b)` vs `not (a or b)`）。
 
 ## 運算子 → 子句
 

--- a/packages/es-query/src/buildEsQuery.spec.ts
+++ b/packages/es-query/src/buildEsQuery.spec.ts
@@ -63,13 +63,52 @@ describe('buildEsQuery', () => {
     });
   });
 
-  it('not group → must_not', () => {
+  it('not group (single child) → must_not', () => {
     const meta: EsFilterMetadata = {
       logic: 'not',
       filters: [{ field: 'status', condition: 'eq', value: 'archived' }],
     };
     expect(buildEsQuery(meta)).toEqual({
       bool: { must_not: [{ term: { status: 'archived' } }] },
+    });
+  });
+
+  // not = NOT(a AND b) = "not all"; the children must be wrapped in a single
+  // bool/must so must_not negates their conjunction (not each one).
+  it('not group (multi child) → must_not of bool/must (negated AND)', () => {
+    const meta: EsFilterMetadata = {
+      logic: 'not',
+      filters: [
+        { field: 'status', condition: 'eq', value: 'open' },
+        { field: 'age', condition: 'gt', dataType: 'number', value: 18 },
+      ],
+    };
+    expect(buildEsQuery(meta)).toEqual({
+      bool: {
+        must_not: [
+          {
+            bool: {
+              must: [{ term: { status: 'open' } }, { range: { age: { gt: 18 } } }],
+            },
+          },
+        ],
+      },
+    });
+  });
+
+  // nor = NOT(a OR b) = "none match" = each clause directly under must_not.
+  it('nor group (multi child) → must_not of each clause (negated OR)', () => {
+    const meta: EsFilterMetadata = {
+      logic: 'nor',
+      filters: [
+        { field: 'status', condition: 'eq', value: 'open' },
+        { field: 'age', condition: 'gt', dataType: 'number', value: 18 },
+      ],
+    };
+    expect(buildEsQuery(meta)).toEqual({
+      bool: {
+        must_not: [{ term: { status: 'open' } }, { range: { age: { gt: 18 } } }],
+      },
     });
   });
 });

--- a/packages/es-query/src/buildEsQuery.ts
+++ b/packages/es-query/src/buildEsQuery.ts
@@ -5,7 +5,6 @@ import {
   type EsBoolQuery,
   type EsDialect,
   type EsFilterMetadata,
-  type EsLogicalOperator,
   type EsQueryClause,
 } from './types';
 
@@ -13,19 +12,11 @@ export interface BuildEsQueryOptions {
   dialect?: EsDialect;
 }
 
-const BUCKET: Record<EsLogicalOperator, 'must' | 'should' | 'must_not'> = {
-  and: 'must',
-  or: 'should',
-  not: 'must_not',
-  nor: 'must_not',
-};
-
 export function buildEsQuery(
   metadata: EsFilterMetadata,
   opts: BuildEsQueryOptions = {},
 ): EsBoolQuery {
   const dialect = opts.dialect ?? 'elasticsearch';
-  const bucket = BUCKET[metadata.logic] ?? 'must';
 
   const clauses: EsQueryClause[] = metadata.filters.map((child) => {
     if (isEsFilterMetadata(child)) return buildEsQuery(child, opts);
@@ -33,7 +24,21 @@ export function buildEsQuery(
     return {};
   });
 
-  const bool: EsBoolQuery['bool'] = { [bucket]: clauses };
-  if (metadata.logic === 'or') bool.minimum_should_match = 1;
-  return { bool };
+  switch (metadata.logic) {
+    case 'or':
+      // any match
+      return { bool: { should: clauses, minimum_should_match: 1 } };
+    case 'nor':
+      // none match: NOT(a OR b) — each clause directly excluded
+      return { bool: { must_not: clauses } };
+    case 'not': {
+      // not all: NOT(a AND b) — exclude the conjunction, not each clause
+      const negated: EsQueryClause =
+        clauses.length === 1 ? clauses[0] : { bool: { must: clauses } };
+      return { bool: { must_not: [negated] } };
+    }
+    case 'and':
+    default:
+      return { bool: { must: clauses } };
+  }
 }


### PR DESCRIPTION
## Problem

A multi-child `not` group means **NOT(a AND b)** = "not all match", but `buildEsQuery` compiled it to `must_not: [a, b]`, which is **NOT(a OR b)** = "none match" — i.e. it produced `nor` semantics. The original single-child `not` test passed only because `not` and `nor` coincide for one child, hiding the bug.

This surfaced from a design question: should es-query unify its logical operators to `'and' | 'or' | 'nor'` like `mongo-query`? Checking the family showed the opposite — `jsonb-query` and `sql-filter` both keep **4** operators and distinguish `not` (`not (a and b)`) from `nor` (`not (a or b)`). Elasticsearch can express this too, so es-query should match that family, not drop to mongo's 3 (mongo lacks a group-level `$not`).

## Fix

| group | meaning | bool clause |
|---|---|---|
| `and` | all | `must: [...]` |
| `or` | any | `should: [...]` + `minimum_should_match: 1` |
| `not` | not all — ¬(a∧b) | `must_not: [{ bool: { must: [...] } }]` |
| `nor` | none — ¬(a∨b) | `must_not: [...]` |

Single-child `not`/`nor` reduce to `must_not: [child]` (unchanged output). Parallels `sql-filter` / `jsonb-query`.

## Tests
- Added multi-child `not` (→ negated AND wrapper) and multi-child `nor` (→ negated OR) cases that lock the distinction.
- es-query 27/27, filter-builder 100/100 (engine delegates, so its single-child `not` test is unchanged). typecheck + lint clean.
- READMEs (en + zh-TW) updated.

Folds into the still-unreleased `@rfjs/es-query` initial changeset — no separate changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)