### PR TITLE
feat(form-builder): grid layout for ConfigForm (ConfigFormBuilder P1)

### DIFF
--- a/docs/superpowers/plans/2026-06-26-config-form-builder-p1-grid.md
+++ b/docs/superpowers/plans/2026-06-26-config-form-builder-p1-grid.md
@@ -1,0 +1,244 @@
+# ConfigFormBuilder — Phase 1 (grid basics) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Add grid layout to the config-driven form — per-field `width` and form-level `columns` in `@rfjs/form-builder`, and CSS-grid rendering with RWD in `@rfjs/form-builder-ui`'s `<ConfigForm>`.
+
+**Architecture:** Extend the existing (merged) P1 packages. `width`/`columns` are display-only — `configToZod` is untouched. Backward-compatible: default `width:'full'` + `columns:1` reproduces today's single-column form.
+
+**Tech Stack:** TypeScript, zod v4, React 19, Tailwind (via web-ui), vitest (node + jsdom), @testing-library/react.
+
+## Global Constraints
+
+- `@rfjs/form-builder` builds to `dist/` via tsdown; `@rfjs/form-builder-ui` exports `src/` (consumed via transpilePackages). zod is v4 (`^4.0.0`).
+- Data-type vocabulary stays aligned with `@rfjs/filter-builder`.
+- `configToZod` behaviour MUST NOT change (width/columns are layout-only).
+- `width` values: `'full' | 'half'`; default (absent) = `'full'`. `columns` values: `1 | 2 | 3 | 4`; default (absent) = `1`.
+- A `'full'` field spans all columns (`grid-column: 1 / -1`); `'half'` occupies one grid cell.
+- Co-locate `*.spec.ts(x)`. Conventional Commits; pre-commit hook must pass (no `--no-verify` for code). The fresh worktree needs `pnpm install` (Task 1).
+
+---
+
+### Task 1: Engine — `width` + `columns` types and schema
+
+**Files:**
+- Modify: `packages/form-builder/src/types.ts`
+- Modify: `packages/form-builder/src/config-schema.ts`
+- Test: `packages/form-builder/src/config-schema.spec.ts` (add cases)
+
+**Interfaces produced:**
+- `type FieldWidth = 'full' | 'half'`; `FieldConfig.width?: FieldWidth`
+- `FormConfig.columns?: 1 | 2 | 3 | 4`
+- `FormConfigSchema` validates both.
+
+- [ ] **Step 1: Install deps in the worktree**
+
+Run: `pnpm install` (repo root — fresh worktree). Then build the engine so downstream typechecks see new types later: `pnpm -F @rfjs/form-builder build`.
+
+- [ ] **Step 2: Write the failing tests**
+
+Append to `packages/form-builder/src/config-schema.spec.ts`:
+```ts
+describe('grid layout fields', () => {
+  it('accepts columns and per-field width', () => {
+    const cfg = {
+      version: 1,
+      columns: 2,
+      fields: [
+        { key: 'name', label: 'Name', component: 'Input', dataType: 'string', width: 'half' },
+        { key: 'bio', label: 'Bio', component: 'Textarea', dataType: 'string', width: 'full' },
+      ],
+    };
+    expect(parseFormConfig(cfg)).toEqual(cfg);
+  });
+
+  it('rejects an out-of-range columns value', () => {
+    expect(FormConfigSchema.safeParse({ version: 1, columns: 5, fields: [] }).success).toBe(false);
+  });
+
+  it('rejects an unknown width value', () => {
+    const bad = { version: 1, fields: [{ key: 'x', label: 'X', component: 'Input', dataType: 'string', width: 'wide' }] };
+    expect(FormConfigSchema.safeParse(bad).success).toBe(false);
+  });
+
+  it('still accepts a config without columns/width (backward compatible)', () => {
+    expect(FormConfigSchema.safeParse({ version: 1, fields: [{ key: 'a', label: 'A', component: 'Input', dataType: 'string' }] }).success).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 3: Run tests — verify the new ones fail**
+
+Run: `pnpm -F @rfjs/form-builder vitest:run`
+Expected: the two reject-tests FAIL (schema currently allows extra keys? no — zod objects strip unknown keys by default, so `columns:5`/`width:'wide'` are stripped and parse succeeds → the `.success === false` assertions fail). This confirms the schema needs the new fields.
+
+- [ ] **Step 4: Add the types**
+
+In `packages/form-builder/src/types.ts`, add the width type and fields:
+```ts
+export type FieldWidth = 'full' | 'half';
+```
+Add `width?: FieldWidth;` to `FieldConfig` (after `options?`):
+```ts
+export interface FieldConfig {
+  key: string;
+  label: string;
+  component: FieldComponent;
+  dataType: FieldType;
+  required?: boolean;
+  placeholder?: string;
+  defaultValue?: unknown;
+  options?: FieldOption[];
+  width?: FieldWidth;
+}
+```
+Add `columns?: 1 | 2 | 3 | 4;` to `FormConfig`:
+```ts
+export interface FormConfig {
+  version: number;
+  fields: FieldConfig[];
+  columns?: 1 | 2 | 3 | 4;
+}
+```
+
+- [ ] **Step 5: Update the schema**
+
+In `packages/form-builder/src/config-schema.ts`:
+- add to `fieldConfigSchema` (after `options`): `width: z.enum(['full', 'half']).optional(),`
+- add to `FormConfigSchema`'s object: `columns: z.union([z.literal(1), z.literal(2), z.literal(3), z.literal(4)]).optional(),`
+
+The `ZodType<FormConfig>` annotation must still hold — `z.literal` union output `1|2|3|4` and `z.enum(['full','half'])` output `'full'|'half'` match the TS types. If TS complains, run `pnpm -F @rfjs/form-builder typecheck` and reconcile (do not loosen the TS types).
+
+- [ ] **Step 6: Run tests + typecheck + build**
+
+Run: `pnpm -F @rfjs/form-builder vitest:run` → all pass (existing + 4 new).
+Run: `pnpm -F @rfjs/form-builder typecheck` → clean.
+Run: `pnpm -F @rfjs/form-builder build` → dist re-emitted (so `@rfjs/form-builder-ui` sees the new types in Task 2).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/form-builder/src
+git commit -m "feat(form-builder): add per-field width and form columns to config"
+```
+
+---
+
+### Task 2: `<ConfigForm>` — CSS-grid rendering with RWD
+
+**Files:**
+- Modify: `packages/form-builder-ui/src/config-form.tsx`
+- Test: `packages/form-builder-ui/src/config-form.spec.tsx` (add cases; keep existing passing)
+
+**Interfaces consumed:** `FieldConfig.width`, `FormConfig.columns` from `@rfjs/form-builder` (Task 1).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `packages/form-builder-ui/src/config-form.spec.tsx`:
+```tsx
+describe('grid layout', () => {
+  const gridConfig: FormConfig = {
+    version: 1,
+    columns: 2,
+    fields: [
+      { key: 'name', label: 'Name', component: 'Input', dataType: 'string', width: 'half' },
+      { key: 'bio', label: 'Bio', component: 'Textarea', dataType: 'string', width: 'full' },
+    ],
+  };
+
+  it('sets the form column count from config.columns', () => {
+    const { container } = render(<ConfigForm config={gridConfig} onSubmit={() => {}} />);
+    const form = container.querySelector('form')!;
+    expect(form.getAttribute('data-columns')).toBe('2');
+    expect(form.style.getPropertyValue('--form-cols')).toBe('2');
+  });
+
+  it('spans full-width fields across all columns and leaves half fields in one cell', () => {
+    const { container } = render(<ConfigForm config={gridConfig} onSubmit={() => {}} />);
+    const half = container.querySelector('[data-width="half"]') as HTMLElement;
+    const full = container.querySelector('[data-width="full"]') as HTMLElement;
+    expect(half.style.gridColumn).toBe('');
+    expect(full.style.gridColumn).toBe('1 / -1');
+  });
+
+  it('defaults to a single column when config.columns is absent', () => {
+    const cfg: FormConfig = { version: 1, fields: [{ key: 'a', label: 'A', component: 'Input', dataType: 'string' }] };
+    const { container } = render(<ConfigForm config={cfg} onSubmit={() => {}} />);
+    expect(container.querySelector('form')!.getAttribute('data-columns')).toBe('1');
+    // a field with no explicit width defaults to full → spans the single column
+    expect((container.querySelector('[data-width="full"]') as HTMLElement).style.gridColumn).toBe('1 / -1');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests — verify the new ones fail**
+
+Run: `pnpm -F @rfjs/form-builder-ui vitest:run`
+Expected: FAIL — `data-columns` / `--form-cols` / `data-width` not present yet.
+
+- [ ] **Step 3: Update `<ConfigForm>`**
+
+Replace the `return (...)` block in `packages/form-builder-ui/src/config-form.tsx` with the grid version (compute `columns`, grid class + CSS var, per-field span, full-spanning submit row):
+```tsx
+  const columns = config.columns ?? 1;
+
+  return (
+    <form
+      onSubmit={handleSubmit((values) => onSubmit(values as Record<string, unknown>))}
+      className="grid grid-cols-1 gap-4 md:[grid-template-columns:repeat(var(--form-cols),minmax(0,1fr))]"
+      style={{ '--form-cols': columns } as React.CSSProperties}
+      data-columns={columns}
+    >
+      {config.fields.map((field) => {
+        const width = field.width ?? 'full';
+        return (
+          <div
+            key={field.key}
+            className="flex flex-col gap-1.5"
+            data-width={width}
+            style={width === 'full' ? { gridColumn: '1 / -1' } : undefined}
+          >
+            <Label htmlFor={field.key}>{field.label}</Label>
+            <Controller
+              control={control}
+              name={field.key}
+              render={({ field: rhf }) => (
+                <FieldControl field={field} value={rhf.value} onChange={rhf.onChange} />
+              )}
+            />
+          </div>
+        );
+      })}
+      <div style={{ gridColumn: '1 / -1' }}>
+        <Button type="submit" className="self-start">
+          {submitLabel}
+        </Button>
+      </div>
+    </form>
+  );
+```
+(Rationale: base `grid-cols-1` = mobile single column / RWD; `md:` arbitrary property uses the `--form-cols` var so the explicit column count applies only at ≥ md. `data-columns`/`data-width` make the layout assertable in jsdom, which doesn't compute grid geometry.)
+
+- [ ] **Step 4: Run tests + typecheck**
+
+Run: `pnpm -F @rfjs/form-builder-ui vitest:run` → all pass (the 3 existing config-form tests + the 3 new grid tests + field-control tests).
+Run: `pnpm -F @rfjs/form-builder-ui check-types` → clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/form-builder-ui/src
+git commit -m "feat(form-builder-ui): render ConfigForm as a responsive grid"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:** Phase 1 of the spec = grid basics: engine `width`/`columns` + schema (Task 1) ✓; `<ConfigForm>` CSS-grid + RWD (Task 2) ✓. Multilingual labels, list-ops, `<ConfigFormBuilder>`, the web tool, and drag (`@dnd-kit`) are later phases — out of scope here.
+
+**Placeholder scan:** none — exact code given for every change.
+
+**Type consistency:** `FieldWidth`/`width`/`columns` names match across types, schema, and the component. `data-columns`/`data-width`/`--form-cols` are consistent between the component (Task 2 Step 3) and the tests (Task 2 Step 1). `configToZod` is untouched, as the constraint requires.
+
+**Backward compatibility:** a config without `columns`/`width` → `data-columns="1"`, fields default to `'full'` spanning the single column — identical to today's single-column form. The 3 existing config-form tests and all config-schema tests must remain green (verified in Task 2 Step 4 / Task 1 Step 6).

--- a/docs/superpowers/specs/2026-06-26-config-form-builder-design.md
+++ b/docs/superpowers/specs/2026-06-26-config-form-builder-design.md
@@ -1,0 +1,69 @@
+# ConfigFormBuilder（視覺化表單建構器）— 設計規格
+
+**日期：** 2026-06-26
+**狀態：** 草稿（待審查）
+**分支：** `worktree-feat-config-form-builder`
+
+## 1. 摘要
+
+把視覺化表單建構器提前（原 roadmap 的 P3）：一個 **query-builder 式**的 `<ConfigFormBuilder>` —— 用 UI 挑欄位型別、排序、逐欄收合編輯，設定 **grid 版面**，即時預覽且與 Config(JSON) **雙向**，並支援**多語**。最後以 `form-builder` 這個 tool 出現在 `apps/web`。全部建在 P1 已合併的 `@rfjs/form-builder`（引擎）+ `@rfjs/form-builder-ui`（`<ConfigForm>`）之上。
+
+## 2. 背景
+
+- P1（PR #191，已併入 main）交付了 `@rfjs/form-builder`（`FormConfig`/`FieldConfig` 型別、`FormConfigSchema`、`configToZod`）與 `@rfjs/form-builder-ui`（`<ConfigForm>`、`FieldControl`）+ workbench 靜態 dogfood。
+- 本子專案 = **視覺編輯器 + grid 版面 + apps/web tool**，是 `filter-builder-ui` 的 `FilterTreeEditor` 在 form 領域的對應物。
+- shadcn **registry 散佈（A）** 仍是另一個獨立後續計畫，不在本規格。
+
+## 3. 已定案設計（來自 mockup 反覆驗證）
+
+- **排版**：query-builder 式 —— 欄位編輯區**全寬垂直**、預覽/JSON **堆疊在下方**（不用三欄擠壓）。
+- **兩層收合**：**大收合**（整個 Fields 區段一鍵收 + Collapse all）+ **小收合**（每張欄位卡各自展開/收合，收合時只顯示摘要：名稱 · 型別 · 寬度 · required）。
+- **grid 版面**：表單層 `columns` + 每欄 `width`（Full/Half），預覽渲染為**自適應網格**（Full 跨整列）。
+- **RWD**：窄螢幕自動收側欄、屬性網格轉單欄、預覽網格轉單欄。
+- **重排**：欄位以**拖曳排序**（`@dnd-kit`）—— 本專案即導入。
+- **多語 label**：`FieldConfig.label` 可為單字串或 per-locale；**builder 內可逐語言編輯 label**，預覽與表單依語言切換（本子專案一併處理，不延後）。
+- **JSON 雙向**：Config(JSON) 分頁可編輯，解析回視覺模型（`parseFormConfig` 驗證）。
+
+## 4. 架構與套件
+
+### `@rfjs/form-builder`（引擎，擴充）
+- `FieldConfig` 新增 `width?: 'full' | 'half'`（預設 `'full'`）。
+- `FormConfig` 新增 `columns?: 1 | 2 | 3 | 4`（預設 `1`）。
+- `label` 型別擴充為 `LocalizedLabel = string | Record<string, string>`；新增 `resolveLabel(label, locale, fallbackLocale?): string`。
+- **list-ops**（tree-ops 的對應）—— 純函式，回傳新的 `FormConfig`：`addField`、`removeField`、`updateField`、`moveField`（重排）。
+- `FormConfigSchema` 更新以驗證 `width`/`columns`/`LocalizedLabel`。
+- `configToZod` **不變**（width/columns/label 屬版面與顯示，不影響 data 驗證）。
+
+### `@rfjs/form-builder-ui`（擴充）
+- `<ConfigForm>`：新增 **grid 渲染**（`columns` + 每欄 `width` → CSS grid）與 `locale` prop（透過 `resolveLabel` 顯示 label）。
+- 新增 deps：`@dnd-kit/core` + `@dnd-kit/sortable` + `@dnd-kit/utilities`（拖曳排序）。
+- 新增 `<ConfigFormBuilder>`：視覺編輯器 —— 型別調色盤、**@dnd-kit 拖曳可重排**欄位清單、可收合欄位卡（型別/key/label/width/required 屬性編輯 + Select options 編輯）、columns 控制、**大收合**、即時預覽分頁 + JSON 分頁。接受 `locales: string[]` prop：>1 種語言時 label 編輯顯示**逐語言輸入**、`config.label` 存為 `Record<locale,string>`。builder 介面採 labels-as-props i18n（同 `filter-builder-ui`）。
+
+### `apps/web`
+- 新 tool `src/tools/form-builder/{index.ts, ui.tsx, messages.ts}`，包 `<ConfigFormBuilder>`；在 `@rfjs/web-core` 的 `toolRegistry` 註冊（id `form-builder`、category `generator`、surface `web`、status `preview`、relatedPackages `['@rfjs/form-builder','@rfjs/form-builder-ui']`）；加 `TOOL_COMPONENTS` 映射、`transpilePackages`、deps。i18n en/zh-TW。
+
+## 5. 分階段（各自一份 plan，依序實作）
+
+- **Phase 1 — grid 基礎**：引擎加 `width`/`columns` + schema 驗證；`<ConfigForm>` 改用 CSS grid 渲染（含 RWD 單欄）。小而穩，先打底。
+- **Phase 2 — 引擎 list-ops + 多語**：`addField`/`removeField`/`updateField`/`moveField` + `resolveLabel` + `LocalizedLabel` schema。純引擎、好測。
+- **Phase 3 — `<ConfigFormBuilder>` 視覺編輯器**：調色盤、**@dnd-kit 拖曳重排**欄位清單、兩層收合、屬性/options 編輯、**逐語言 label 編輯**、columns 控制、即時預覽 + JSON 雙向。最大塊。
+- **Phase 4 — apps/web tool**：包成 `form-builder` 工具 + i18n + 註冊。
+
+## 6. 開放決策（審查/各 phase 起點定奪）
+
+1. **重排 UX → 定案：拖曳（`@dnd-kit`）**。本專案即導入並使用（後續 filter/排序場景也會用到，先熟悉）。
+2. **多語 label 編輯 → 定案：本專案一併處理**。引擎 `LocalizedLabel` + `resolveLabel`；builder 逐語言編輯、表單依 `locale` 渲染。
+3. `columns` 上限定 **4**。
+4. tool 落點：先 `apps/web`（showcase）；workbench 之後可再掛。
+
+## 7. 測試
+
+- **引擎**：list-ops（add/remove/update/move 的純函式行為）、`resolveLabel`、schema（width/columns/LocalizedLabel 接受與拒絕）、確認 `configToZod` 不受影響。
+- **UI**：`<ConfigForm>` grid 渲染（columns/width/Full 跨欄、RWD 單欄）；`<ConfigFormBuilder>` 互動（新增/刪除/重排/編輯、兩層收合、columns、JSON 雙向回填）。
+- **web tool**：typecheck + 渲染煙霧測試。
+
+## 8. 非目標（YAGNI）
+
+- 巢狀「分組 / section / 多步驟」—— 之後再說（表單先扁平）。
+- registry 散佈（A）—— 獨立計畫。
+- `configToZod` 行為變更 —— 不動（版面/顯示不影響 data 驗證）。

--- a/packages/form-builder-ui/src/config-form.spec.tsx
+++ b/packages/form-builder-ui/src/config-form.spec.tsx
@@ -33,3 +33,37 @@ describe('ConfigForm', () => {
     await waitFor(() => expect(onSubmit).toHaveBeenCalledWith({ name: 'Ada', bio: undefined }));
   });
 });
+
+describe('grid layout', () => {
+  const gridConfig: FormConfig = {
+    version: 1,
+    columns: 2,
+    fields: [
+      { key: 'name', label: 'Name', component: 'Input', dataType: 'string', width: 'half' },
+      { key: 'bio', label: 'Bio', component: 'Textarea', dataType: 'string', width: 'full' },
+    ],
+  };
+
+  it('sets the form column count from config.columns', () => {
+    const { container } = render(<ConfigForm config={gridConfig} onSubmit={() => {}} />);
+    const form = container.querySelector('form')!;
+    expect(form.getAttribute('data-columns')).toBe('2');
+    expect(form.style.getPropertyValue('--form-cols')).toBe('2');
+  });
+
+  it('spans full-width fields across all columns and leaves half fields in one cell', () => {
+    const { container } = render(<ConfigForm config={gridConfig} onSubmit={() => {}} />);
+    const half = container.querySelector('[data-width="half"]') as HTMLElement;
+    const full = container.querySelector('[data-width="full"]') as HTMLElement;
+    expect(half.style.gridColumn).toBe('');
+    expect(full.style.gridColumn).toBe('1 / -1');
+  });
+
+  it('defaults to a single column when config.columns is absent', () => {
+    const cfg: FormConfig = { version: 1, fields: [{ key: 'a', label: 'A', component: 'Input', dataType: 'string' }] };
+    const { container } = render(<ConfigForm config={cfg} onSubmit={() => {}} />);
+    expect(container.querySelector('form')!.getAttribute('data-columns')).toBe('1');
+    // a field with no explicit width defaults to full → spans the single column
+    expect((container.querySelector('[data-width="full"]') as HTMLElement).style.gridColumn).toBe('1 / -1');
+  });
+});

--- a/packages/form-builder-ui/src/config-form.tsx
+++ b/packages/form-builder-ui/src/config-form.tsx
@@ -24,23 +24,40 @@ export function ConfigForm({ config, defaultValues, onSubmit, submitLabel = 'Sub
   const resolver = React.useMemo(() => zodResolver(configToZod(config)), [config]);
   const { control, handleSubmit } = useForm({ resolver, defaultValues });
 
+  const columns = config.columns ?? 1;
+
   return (
-    <form onSubmit={handleSubmit((values) => onSubmit(values as Record<string, unknown>))} className="flex flex-col gap-4">
-      {config.fields.map((field) => (
-        <div key={field.key} className="flex flex-col gap-1.5">
-          <Label htmlFor={field.key}>{field.label}</Label>
-          <Controller
-            control={control}
-            name={field.key}
-            render={({ field: rhf }) => (
-              <FieldControl field={field} value={rhf.value} onChange={rhf.onChange} />
-            )}
-          />
-        </div>
-      ))}
-      <Button type="submit" className="self-start">
-        {submitLabel}
-      </Button>
+    <form
+      onSubmit={handleSubmit((values) => onSubmit(values as Record<string, unknown>))}
+      className="grid grid-cols-1 gap-4 md:[grid-template-columns:repeat(var(--form-cols),minmax(0,1fr))]"
+      style={{ '--form-cols': columns } as React.CSSProperties}
+      data-columns={columns}
+    >
+      {config.fields.map((field) => {
+        const width = field.width ?? 'full';
+        return (
+          <div
+            key={field.key}
+            className="flex flex-col gap-1.5"
+            data-width={width}
+            style={width === 'full' ? { gridColumn: '1 / -1' } : undefined}
+          >
+            <Label htmlFor={field.key}>{field.label}</Label>
+            <Controller
+              control={control}
+              name={field.key}
+              render={({ field: rhf }) => (
+                <FieldControl field={field} value={rhf.value} onChange={rhf.onChange} />
+              )}
+            />
+          </div>
+        );
+      })}
+      <div style={{ gridColumn: '1 / -1' }}>
+        <Button type="submit" className="self-start">
+          {submitLabel}
+        </Button>
+      </div>
     </form>
   );
 }

--- a/packages/form-builder-ui/src/config-form.tsx
+++ b/packages/form-builder-ui/src/config-form.tsx
@@ -30,7 +30,7 @@ export function ConfigForm({ config, defaultValues, onSubmit, submitLabel = 'Sub
     <form
       onSubmit={handleSubmit((values) => onSubmit(values as Record<string, unknown>))}
       className="grid grid-cols-1 gap-4 md:[grid-template-columns:repeat(var(--form-cols),minmax(0,1fr))]"
-      style={{ '--form-cols': columns } as React.CSSProperties}
+      style={{ '--form-cols': String(columns) } as React.CSSProperties}
       data-columns={columns}
     >
       {config.fields.map((field) => {

--- a/packages/form-builder/src/config-schema.spec.ts
+++ b/packages/form-builder/src/config-schema.spec.ts
@@ -42,3 +42,30 @@ describe('FormConfigSchema', () => {
     expect(FormConfigSchema.safeParse({ version: 1.5, fields: [] }).success).toBe(false);
   });
 });
+
+describe('grid layout fields', () => {
+  it('accepts columns and per-field width', () => {
+    const cfg = {
+      version: 1,
+      columns: 2,
+      fields: [
+        { key: 'name', label: 'Name', component: 'Input', dataType: 'string', width: 'half' },
+        { key: 'bio', label: 'Bio', component: 'Textarea', dataType: 'string', width: 'full' },
+      ],
+    };
+    expect(parseFormConfig(cfg)).toEqual(cfg);
+  });
+
+  it('rejects an out-of-range columns value', () => {
+    expect(FormConfigSchema.safeParse({ version: 1, columns: 5, fields: [] }).success).toBe(false);
+  });
+
+  it('rejects an unknown width value', () => {
+    const bad = { version: 1, fields: [{ key: 'x', label: 'X', component: 'Input', dataType: 'string', width: 'wide' }] };
+    expect(FormConfigSchema.safeParse(bad).success).toBe(false);
+  });
+
+  it('still accepts a config without columns/width (backward compatible)', () => {
+    expect(FormConfigSchema.safeParse({ version: 1, fields: [{ key: 'a', label: 'A', component: 'Input', dataType: 'string' }] }).success).toBe(true);
+  });
+});

--- a/packages/form-builder/src/config-schema.ts
+++ b/packages/form-builder/src/config-schema.ts
@@ -17,11 +17,13 @@ const fieldConfigSchema = z.object({
   placeholder: z.string().optional(),
   defaultValue: z.unknown().optional(),
   options: z.array(fieldOptionSchema).optional(),
+  width: z.enum(['full', 'half']).optional(),
 });
 
 export const FormConfigSchema: ZodType<FormConfig> = z.object({
   version: z.number().int(),
   fields: z.array(fieldConfigSchema),
+  columns: z.union([z.literal(1), z.literal(2), z.literal(3), z.literal(4)]).optional(),
 });
 
 export function parseFormConfig(input: unknown): FormConfig {

--- a/packages/form-builder/src/types.ts
+++ b/packages/form-builder/src/types.ts
@@ -5,6 +5,8 @@ export type FieldType = ScalarType | 'object' | 'array';
 // P1 renderable components (Switch deferred — no web-ui Switch yet).
 export type FieldComponent = 'Input' | 'Textarea' | 'Select' | 'Checkbox' | 'Date';
 
+export type FieldWidth = 'full' | 'half';
+
 export interface FieldOption {
   label: string;
   value: string | number;
@@ -19,9 +21,11 @@ export interface FieldConfig {
   placeholder?: string;
   defaultValue?: unknown;
   options?: FieldOption[];
+  width?: FieldWidth;
 }
 
 export interface FormConfig {
   version: number;
   fields: FieldConfig[];
+  columns?: 1 | 2 | 3 | 4;
 }


### PR DESCRIPTION
## What

**Phase 1** of the **ConfigFormBuilder** sub-project — *grid basics*. Adds responsive multi-column layout to the config-driven form.

- **`@rfjs/form-builder`**: `FieldConfig.width?: 'full' | 'half'` + `FormConfig.columns?: 1 | 2 | 3 | 4` on the types and `FormConfigSchema`. Display-only — **`configToZod` is untouched**.
- **`@rfjs/form-builder-ui`**: `<ConfigForm>` now renders a **responsive CSS grid** — single column on mobile, the explicit `columns` count at ≥ `md` (via a `--form-cols` CSS var); `full` fields span all columns, `half` fields occupy one cell; the submit row spans full width.

**Backward-compatible:** a config without `columns`/`width` → `columns=1`, fields default to `full` → identical to the previous single-column form. The existing `<ConfigForm>` tests stay green.

This PR also lands the **design spec** and **Phase-1 plan** under `docs/superpowers/` for reviewer context.

## Roadmap (follow-on PRs)

This is the first of a phased build of the visual form builder (the form-domain twin of `filter-builder-ui`'s `FilterTreeEditor`):

- **P2** — engine `list-ops` (add/remove/update/move) + multilingual labels (`LocalizedLabel` + `resolveLabel`)
- **P3** — `<ConfigFormBuilder>` visual editor: `@dnd-kit` drag reorder, two-level collapse (panel + per-field), per-field property/options editing, per-locale label editing, columns control, live preview + JSON round-trip
- **P4** — `apps/web` `form-builder` tool wrapping it

(shadcn **registry distribution** remains a separate later plan.)

## Testing

- `@rfjs/form-builder`: **16/16** unit tests (schema accepts grid fields, rejects out-of-range `columns` / unknown `width`, backward-compat).
- `@rfjs/form-builder-ui`: **10/10** (grid: `data-columns`/`--form-cols`, per-field `full` span vs `half` cell, single-column default + the 3 existing form tests).
- Built TDD, task-by-task, with per-task spec+quality review and a final whole-branch review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
