### PR TITLE
feat(form-builder): finish & ship ConfigFormBuilder — columns/JSON/key/i18n + apps/web tool (P3c+P4)

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -2,7 +2,7 @@ import createNextIntlPlugin from "next-intl/plugin";
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  transpilePackages: ["@rfjs/web-ui", "@rfjs/web-core", "@rfjs/filter-builder-ui"],
+  transpilePackages: ["@rfjs/web-ui", "@rfjs/web-core", "@rfjs/filter-builder-ui", "@rfjs/form-builder-ui"],
 };
 
 const withNextIntl = createNextIntlPlugin("./src/i18n/request.ts");

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,6 +15,8 @@
   "dependencies": {
     "@rfjs/filter-builder": "workspace:*",
     "@rfjs/filter-builder-ui": "workspace:*",
+    "@rfjs/form-builder": "workspace:*",
+    "@rfjs/form-builder-ui": "workspace:*",
     "@rfjs/data-filter": "workspace:*",
     "@rfjs/es-client": "workspace:*",
     "@rfjs/es-query": "workspace:*",

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -89,6 +89,7 @@
     "sql-filter": { "description": "Generic boolean filter-group to SQL with pluggable leaf renderers." },
     "pg-filter": { "description": "Unified PostgreSQL filter builder over columns and JSONB." },
     "filter-builder": { "description": "Framework-agnostic canonical filter-tree model, schema inference, and engine compilation." },
+    "form-builder": { "description": "Visual form config builder — compose and edit JSON-driven form schemas with a live preview." },
     "es-query": { "description": "Elasticsearch / OpenSearch query builder — compile a filter-tree to bool queries." },
     "es-client": { "description": "Client-agnostic Elasticsearch / OpenSearch execution layer: search, pagination, highlight." },
     "jwt": { "description": "JWT sign/verify/decode helper." },

--- a/apps/web/src/messages/zh-TW.json
+++ b/apps/web/src/messages/zh-TW.json
@@ -89,6 +89,7 @@
     "sql-filter": { "description": "通用布林 filter-group 轉 SQL,可插拔 leaf 渲染器。" },
     "pg-filter": { "description": "統一的 PostgreSQL 過濾建構器,涵蓋欄位與 JSONB。" },
     "filter-builder": { "description": "框架無關的 canonical 過濾樹模型、schema 推斷與引擎編譯。" },
+    "form-builder": { "description": "視覺化表單設定建構器 —— 以拖放方式組合 JSON 驅動的表單 schema，並即時預覽。" },
     "es-query": { "description": "Elasticsearch / OpenSearch 查詢建構器 —— 把過濾樹編譯成 bool query。" },
     "es-client": { "description": "與 client 無關的 Elasticsearch / OpenSearch 執行層：搜尋、分頁、highlight。" },
     "jwt": { "description": "JWT 簽署/驗證/解碼工具。" },

--- a/apps/web/src/tools/form-builder/index.ts
+++ b/apps/web/src/tools/form-builder/index.ts
@@ -1,0 +1,5 @@
+import type { ToolModule } from "@/tools/types";
+
+import { FormBuilderTool } from "./ui";
+
+export const tool: ToolModule = { id: "form-builder", Component: FormBuilderTool };

--- a/apps/web/src/tools/form-builder/messages.ts
+++ b/apps/web/src/tools/form-builder/messages.ts
@@ -1,0 +1,26 @@
+import type { LocaleMessages } from "@/tools/types";
+
+export const messages: LocaleMessages = {
+  en: {
+    Tools: {
+      "form-builder": {
+        title: "Form Builder",
+        description: "Visually build a form config (JSON) with drag-and-drop fields and a live preview.",
+      },
+    },
+    ToolUI: {
+      fbTitle: "FORM BUILDER",
+    },
+  },
+  "zh-TW": {
+    Tools: {
+      "form-builder": {
+        title: "表單建構器",
+        description: "透過拖放欄位視覺化建構表單設定（JSON），並即時預覽結果。",
+      },
+    },
+    ToolUI: {
+      fbTitle: "表單建構器",
+    },
+  },
+};

--- a/apps/web/src/tools/form-builder/ui.tsx
+++ b/apps/web/src/tools/form-builder/ui.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import { ConfigFormBuilder } from "@rfjs/form-builder-ui";
+
+export function FormBuilderTool() {
+  return (
+    <div className="flex flex-col gap-5">
+      <ConfigFormBuilder locales={["en", "zh-TW"]} />
+    </div>
+  );
+}

--- a/apps/web/src/tools/index.spec.ts
+++ b/apps/web/src/tools/index.spec.ts
@@ -21,6 +21,7 @@ const EXPECTED_WEB_TOOL_IDS = [
   "es-query-builder",
   "es-client-demo",
   "pg-filter-builder",
+  "form-builder",
 ].sort();
 
 describe("implementation registry", () => {

--- a/apps/web/src/tools/index.ts
+++ b/apps/web/src/tools/index.ts
@@ -4,6 +4,7 @@ import type { ToolModule } from "./types";
 
 import { tool as dataFilterBuilder } from "./data-filter-builder";
 import { tool as dataFilterTester } from "./data-filter-tester";
+import { tool as formBuilder } from "./form-builder";
 import { tool as esClientDemo } from "./es-client-demo";
 import { tool as esQueryBuilder } from "./es-query-builder";
 import { tool as jsonbQueryBuilder } from "./jsonb-query-builder";
@@ -31,6 +32,7 @@ export const toolModules: ToolModule[] = [
   esQueryBuilder,
   esClientDemo,
   pgFilterBuilder,
+  formBuilder,
 ];
 
 export const TOOL_COMPONENTS: Record<string, ComponentType> = Object.fromEntries(

--- a/apps/web/src/tools/messages.ts
+++ b/apps/web/src/tools/messages.ts
@@ -2,6 +2,7 @@ import type { LocaleMessages } from "./types";
 
 import { messages as dataFilterBuilder } from "./data-filter-builder/messages";
 import { messages as dataFilterTester } from "./data-filter-tester/messages";
+import { messages as formBuilder } from "./form-builder/messages";
 import { messages as esClientDemo } from "./es-client-demo/messages";
 import { messages as esQueryBuilder } from "./es-query-builder/messages";
 import { messages as jsonbQueryBuilder } from "./jsonb-query-builder/messages";
@@ -29,4 +30,5 @@ export const toolMessages: LocaleMessages[] = [
   esQueryBuilder,
   esClientDemo,
   pgFilterBuilder,
+  formBuilder,
 ];

--- a/docs/superpowers/plans/2026-06-26-config-form-builder-p3c-p4.md
+++ b/docs/superpowers/plans/2026-06-26-config-form-builder-p3c-p4.md
@@ -1,0 +1,220 @@
+# ConfigFormBuilder — Phase 3c + 4 (finish & ship) Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Finish the visual builder (columns control, Config(JSON) round-trip, key editing, per-locale labels) and **ship it** as the `apps/web` `form-builder` tool.
+
+**Architecture:** Extend `<ConfigFormBuilder>`/`FieldRow` (merged P3a/P3b) on the ref-based `useConfigBuilder` hook, then wire it into `apps/web` via the registry-driven tool system (`toolModules` → `TOOL_COMPONENTS`, `@rfjs/web-core` `toolRegistry`, `transpilePackages`, per-tool i18n).
+
+**Tech Stack:** React 19, @dnd-kit, @rfjs/web-ui, @rfjs/web-core, next-intl, vitest jsdom, @testing-library/react.
+
+## Global Constraints
+
+- Use the engine via the hook (`setColumns`, `replace`, `update`); `replace` is ref-based (P3b) so JSON round-trip is safe.
+- `parseFormConfig` (from `@rfjs/form-builder`) validates pasted JSON; on failure show an error and do not call `replace`.
+- Native `<select>` for editor chrome (columns, type, width) — testable. web-ui `Input`/`Button`/`Checkbox` elsewhere.
+- Per-locale: `<ConfigFormBuilder locales={['en','zh-TW']}>`; with >1 locale the label editor shows one input per locale and `label` becomes `Record<locale,string>`; with 1 locale it stays a single string input. `resolveLabel` already renders both.
+- Key editing commits **on blur** (key is the dnd id + React key — editing per-keystroke would remount and lose focus).
+- apps/web tool follows the existing pattern exactly (see `data-filter-builder`): `tools/form-builder/{index.ts,ui.tsx,messages.ts}` + add to `toolModules` + `@rfjs/web-core` `toolRegistry` + `transpilePackages` + deps. Deferred (note in PR): panel-level "collapse all".
+- Co-locate `*.spec.tsx`. Conventional Commits; pre-commit passes (no `--no-verify`). Fresh worktree → `pnpm install`.
+
+---
+
+### Task 1: Columns control in `<ConfigFormBuilder>`
+
+**Files:** Modify `packages/form-builder-ui/src/config-form-builder.tsx` + `config-form-builder.spec.tsx`.
+
+- [ ] **Step 1:** `pnpm install`.
+- [ ] **Step 2: Failing test.** Add:
+```tsx
+it('sets form columns from the columns control', () => {
+  const onChange = vi.fn();
+  render(<ConfigFormBuilder initialConfig={initial} onChange={onChange} />);
+  fireEvent.change(screen.getByLabelText(/columns/i), { target: { value: '2' } });
+  expect(onChange).toHaveBeenLastCalledWith(expect.objectContaining({ columns: 2 }));
+});
+```
+(`vi` import + `onChange` may need adding to the spec's imports.)
+- [ ] **Step 3: Run — fail.**
+- [ ] **Step 4: Implement.** In the palette toolbar `<div>`, add a columns control:
+```tsx
+<label className="ml-auto flex items-center gap-1.5 text-xs text-muted-foreground">
+  Columns
+  <select
+    className="h-8 rounded-md border border-input bg-background px-2 text-sm text-foreground"
+    aria-label="columns"
+    value={builder.config.columns ?? 1}
+    onChange={(e) => builder.setColumns(Number(e.target.value) as FormConfig['columns'])}
+  >
+    {[1, 2, 3, 4].map((n) => <option key={n} value={n}>{n}</option>)}
+  </select>
+</label>
+```
+- [ ] **Step 5: Run + check-types + commit.** `git commit -m "feat(form-builder-ui): add columns control to ConfigFormBuilder"`
+
+---
+
+### Task 2: Config(JSON) round-trip tab
+
+**Files:** Modify `config-form-builder.tsx` + `config-form-builder.spec.tsx`.
+
+**Behavior:** two tabs — **Builder** (current editor) and **JSON**. JSON tab shows `JSON.stringify(config, null, 2)` in a textarea; on edit, parse via `parseFormConfig` → `builder.replace(parsed)`; on parse error show a message and don't replace.
+
+- [ ] **Step 1: Failing tests.** Add:
+```tsx
+it('shows the config as JSON and applies edits back (round-trip)', () => {
+  const onChange = vi.fn();
+  render(<ConfigFormBuilder initialConfig={initial} onChange={onChange} />);
+  fireEvent.click(screen.getByRole('tab', { name: /json/i }));
+  const ta = screen.getByLabelText(/config json/i) as HTMLTextAreaElement;
+  const next = { version: 1, fields: [{ key: 'email', label: 'Email', component: 'Input', dataType: 'string' }] };
+  fireEvent.change(ta, { target: { value: JSON.stringify(next) } });
+  expect(onChange).toHaveBeenLastCalledWith(expect.objectContaining({ fields: [expect.objectContaining({ key: 'email' })] }));
+});
+it('shows an error for invalid JSON and does not apply it', () => {
+  const onChange = vi.fn();
+  render(<ConfigFormBuilder initialConfig={initial} onChange={onChange} />);
+  fireEvent.click(screen.getByRole('tab', { name: /json/i }));
+  fireEvent.change(screen.getByLabelText(/config json/i), { target: { value: '{ not json' } });
+  expect(screen.getByText(/invalid/i)).toBeTruthy();
+  expect(onChange).not.toHaveBeenCalled();
+});
+```
+- [ ] **Step 2: Run — fail.**
+- [ ] **Step 3: Implement.** Add a tab state (`'builder' | 'json'`) and a JSON panel. Use simple `role="tab"` buttons (native, testable). JSON panel:
+```tsx
+const [tab, setTab] = React.useState<'builder' | 'json'>('builder');
+const [jsonError, setJsonError] = React.useState<string | null>(null);
+
+function onJsonChange(text: string) {
+  try {
+    const parsed = parseFormConfig(JSON.parse(text));
+    setJsonError(null);
+    builder.replace(parsed);
+  } catch (err) {
+    setJsonError(err instanceof Error ? err.message : 'Invalid config');
+  }
+}
+```
+Render two `<button role="tab">` (Builder / JSON) and switch the body. JSON body:
+```tsx
+<div>
+  <textarea
+    aria-label="config json"
+    className="h-64 w-full rounded-md border border-input bg-background p-3 font-mono text-xs"
+    defaultValue={JSON.stringify(builder.config, null, 2)}
+    onChange={(e) => onJsonChange(e.target.value)}
+  />
+  {jsonError ? <p className="mt-1 text-xs text-destructive">Invalid config: {jsonError}</p> : null}
+</div>
+```
+(Import `parseFormConfig` from `@rfjs/form-builder`. Keep the Builder tab content — palette + dnd list + preview — as-is, shown when `tab==='builder'`. The preview can stay always-visible or move under Builder; keep it under Builder.)
+- [ ] **Step 4: Run + check-types + commit.** `git commit -m "feat(form-builder-ui): add Config(JSON) round-trip tab"`
+
+---
+
+### Task 3: Key editing (commit on blur)
+
+**Files:** Modify `field-row.tsx` + `field-row.spec.tsx`.
+
+**Behavior:** a **Key** input in the property editor; local state while typing, commit `onUpdate({ key })` on blur (avoids remount-per-keystroke since key is the dnd/React id).
+
+- [ ] **Step 1: Failing test.** Add:
+```tsx
+it('commits a key change on blur', () => {
+  const { onUpdate } = renderRow(base);
+  const keyInput = screen.getByLabelText('key for name');
+  fireEvent.change(keyInput, { target: { value: 'full_name' } });
+  expect(onUpdate).not.toHaveBeenCalled(); // not on each keystroke
+  fireEvent.blur(keyInput);
+  expect(onUpdate).toHaveBeenCalledWith({ key: 'full_name' });
+});
+```
+- [ ] **Step 2: Run — fail.**
+- [ ] **Step 3: Implement.** In `FieldRow`, add local key draft state synced to `field.key`, and a Key input in the editor grid (before Label):
+```tsx
+const [keyDraft, setKeyDraft] = React.useState(field.key);
+React.useEffect(() => setKeyDraft(field.key), [field.key]);
+// ...
+<label className="flex flex-col gap-1 text-xs text-muted-foreground">Key
+  <Input className="h-8 font-mono" aria-label={`key for ${field.key}`} value={keyDraft}
+    onChange={(e) => setKeyDraft(e.target.value)}
+    onBlur={() => { if (keyDraft && keyDraft !== field.key) onUpdate({ key: keyDraft }); }} />
+</label>
+```
+- [ ] **Step 4: Run + check-types + commit.** `git commit -m "feat(form-builder-ui): add key editing (commit on blur) to FieldRow"`
+
+---
+
+### Task 4: Per-locale label editing
+
+**Files:** Modify `field-row.tsx` + `field-row.spec.tsx`; thread `locales` through `config-form-builder.tsx`.
+
+**Behavior:** `FieldRow` takes `locales: string[]` (default `['en']`). With 1 locale → single Label input (current). With >1 → one Label input per locale (`aria-label="label (LOCALE) for KEY"`); editing locale L sets `label` to a record: `{ ...(typeof field.label === 'string' ? {} : field.label), [L]: value }` (seed the default locale's existing string under the first locale when converting). `ConfigFormBuilder` passes its `locales` to each `FieldRow`.
+
+- [ ] **Step 1: Failing test.** Add:
+```tsx
+it('edits a per-locale label when multiple locales', () => {
+  const onUpdate = vi.fn();
+  render(<DndContext><SortableContext items={['name']}>
+    <FieldRow field={{ key: 'name', label: 'Name', component: 'Input', dataType: 'string' }}
+      locales={['en', 'zh-TW']} onUpdate={onUpdate} onRemove={() => {}} />
+  </SortableContext></DndContext>);
+  fireEvent.change(screen.getByLabelText('label (zh-TW) for name'), { target: { value: '姓名' } });
+  expect(onUpdate).toHaveBeenCalledWith({ label: { en: 'Name', 'zh-TW': '姓名' } });
+});
+```
+(For the single-locale default, the existing `label for name` test must still pass.)
+- [ ] **Step 2: Run — fail.**
+- [ ] **Step 3: Implement.** Add `locales?: string[]` to `FieldRowProps` (default `['en']`). Helper to read a locale's text and to write one:
+```tsx
+function localeText(label: FieldConfig['label'], loc: string, fallback: string): string {
+  if (typeof label === 'string') return loc === fallback ? label : '';
+  return label[loc] ?? '';
+}
+function setLocaleLabel(label: FieldConfig['label'], loc: string, value: string, locales: string[]): FieldConfig['label'] {
+  const base: Record<string, string> = typeof label === 'string' ? { [locales[0] ?? 'en']: label } : { ...label };
+  base[loc] = value;
+  return base;
+}
+```
+In the editor body, replace the single Label input: if `locales.length <= 1`, keep the current single `Input` (`aria-label={`label for ${field.key}`}`, value `labelOf(field.label)`, `onUpdate({label})`); else render one `Input` per locale with `aria-label={`label (${loc}) for ${field.key}`}`, value `localeText(field.label, loc, locales[0]!)`, `onChange={(e)=>onUpdate({ label: setLocaleLabel(field.label, loc, e.target.value, locales) })}`.
+In `config-form-builder.tsx`, add `locales?: string[]` to its props and pass `locales={locales}` to each `<FieldRow>`.
+- [ ] **Step 4: Run + check-types + commit.** All form-builder-ui tests pass (single-locale path unchanged). `git commit -m "feat(form-builder-ui): per-locale label editing in FieldRow"`
+
+---
+
+### Task 5: Ship — `apps/web` `form-builder` tool
+
+**Files:**
+- Create: `apps/web/src/tools/form-builder/{index.ts, ui.tsx, messages.ts}`
+- Modify: `apps/web/src/tools/index.ts` (add to `toolModules`)
+- Modify: `packages/web-core/src/registry/tools.ts` (add `toolRegistry` entry)
+- Modify: `apps/web/next.config.js` (`transpilePackages`), `apps/web/package.json` (deps)
+
+- [ ] **Step 1: Confirm patterns.** Read `apps/web/src/tools/data-filter-builder/{index.ts,ui.tsx,messages.ts}`, `apps/web/src/tools/index.ts` (how `toolModules` is assembled), and `packages/web-core/src/registry/schemas.ts` (ToolDefinition + category enum). Mirror them.
+
+- [ ] **Step 2: Implement.**
+  - `tools/form-builder/ui.tsx` (`'use client'`): renders `<ConfigFormBuilder locales={['en','zh-TW']} />` inside the shared tool shell; uses `useTranslations('ToolUI')` for any chrome text. Import from `@rfjs/form-builder-ui`.
+  - `tools/form-builder/index.ts`: `export const tool: ToolModule = { id: 'form-builder', Component: FormBuilderTool };`
+  - `tools/form-builder/messages.ts`: `Tools` namespace (title/description) + `ToolUI` keys, for `en` and `zh-TW`, matching the shape in `data-filter-builder/messages.ts`.
+  - `tools/index.ts`: add the form-builder tool module to the `toolModules` array (so `TOOL_COMPONENTS['form-builder']` resolves).
+  - `packages/web-core/src/registry/tools.ts`: add `{ id: 'form-builder', category: 'generator', surface: 'web', status: 'preview', relatedPackages: ['@rfjs/form-builder', '@rfjs/form-builder-ui'], tags: ['form', 'builder', 'config'] }` (confirm `'generator'` is in the category enum; if not, use the closest valid one and note it).
+  - `apps/web/next.config.js`: add `"@rfjs/form-builder-ui"` to `transpilePackages`.
+  - `apps/web/package.json`: add `"@rfjs/form-builder": "workspace:*"` and `"@rfjs/form-builder-ui": "workspace:*"`. Run `pnpm install`.
+
+- [ ] **Step 3: Verify.** The existing `apps/web/src/tools/index.spec.ts` cross-checks `TOOL_COMPONENTS` against the registry — run `pnpm -F web vitest:run` (or the app's test script) and `pnpm -F web check-types`. Build `@rfjs/form-builder` first if needed (`pnpm -F @rfjs/form-builder build`). Confirm the registry↔components consistency test passes for the new tool. Interactive page render is manual (note in PR).
+
+- [ ] **Step 4: Commit.** `git commit -m "feat(web): add form-builder tool (ConfigFormBuilder)"`
+
+---
+
+## Self-Review
+
+**Spec coverage:** P3c = columns control (T1), Config(JSON) round-trip (T2), key editing (T3), per-locale labels (T4); P4 = apps/web tool (T5). Deferred: panel-level "collapse all" (minor polish — note in PR).
+
+**Placeholder scan:** code given for T1-T4; T5 is wiring against confirmed patterns with a "read the sample tool first" step (the apps/web message/registry shapes are project-specific — the implementer mirrors `data-filter-builder`).
+
+**Type consistency:** `setColumns(Number(...) as FormConfig['columns'])`; `replace` for JSON; `locales` threaded builder→FieldRow; `parseFormConfig` for round-trip. Single-locale label path preserved (existing `label for KEY` tests stay green); multi-locale uses `label (LOCALE) for KEY`.
+
+**Regression watch:** existing FieldRow/ConfigFormBuilder/ConfigForm tests must stay green — T4 keeps the single-locale Input, T1/T2 add controls without removing the palette/list/preview, T3 adds a Key input. T5's `apps/web` registry-consistency spec must pass with the new tool.

--- a/packages/form-builder-ui/src/config-form-builder.spec.tsx
+++ b/packages/form-builder-ui/src/config-form-builder.spec.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent, within } from '@testing-library/react';
 import { ConfigFormBuilder } from './config-form-builder';
 import type { FormConfig } from '@rfjs/form-builder';
@@ -24,5 +24,12 @@ describe('ConfigFormBuilder', () => {
     render(<ConfigFormBuilder initialConfig={initial} />);
     fireEvent.click(screen.getByRole('button', { name: /remove field/i }));
     expect(screen.queryByLabelText('label for name')).toBeNull();
+  });
+
+  it('sets form columns from the columns control', () => {
+    const onChange = vi.fn();
+    render(<ConfigFormBuilder initialConfig={initial} onChange={onChange} />);
+    fireEvent.change(screen.getByLabelText(/columns/i), { target: { value: '2' } });
+    expect(onChange).toHaveBeenLastCalledWith(expect.objectContaining({ columns: 2 }));
   });
 });

--- a/packages/form-builder-ui/src/config-form-builder.spec.tsx
+++ b/packages/form-builder-ui/src/config-form-builder.spec.tsx
@@ -32,4 +32,23 @@ describe('ConfigFormBuilder', () => {
     fireEvent.change(screen.getByLabelText(/columns/i), { target: { value: '2' } });
     expect(onChange).toHaveBeenLastCalledWith(expect.objectContaining({ columns: 2 }));
   });
+
+  it('shows the config as JSON and applies edits back (round-trip)', () => {
+    const onChange = vi.fn();
+    render(<ConfigFormBuilder initialConfig={initial} onChange={onChange} />);
+    fireEvent.click(screen.getByRole('tab', { name: /json/i }));
+    const ta = screen.getByLabelText(/config json/i) as HTMLTextAreaElement;
+    const next = { version: 1, fields: [{ key: 'email', label: 'Email', component: 'Input', dataType: 'string' }] };
+    fireEvent.change(ta, { target: { value: JSON.stringify(next) } });
+    expect(onChange).toHaveBeenLastCalledWith(expect.objectContaining({ fields: [expect.objectContaining({ key: 'email' })] }));
+  });
+
+  it('shows an error for invalid JSON and does not apply it', () => {
+    const onChange = vi.fn();
+    render(<ConfigFormBuilder initialConfig={initial} onChange={onChange} />);
+    fireEvent.click(screen.getByRole('tab', { name: /json/i }));
+    fireEvent.change(screen.getByLabelText(/config json/i), { target: { value: '{ not json' } });
+    expect(screen.getByText(/invalid/i)).toBeTruthy();
+    expect(onChange).not.toHaveBeenCalled();
+  });
 });

--- a/packages/form-builder-ui/src/config-form-builder.tsx
+++ b/packages/form-builder-ui/src/config-form-builder.tsx
@@ -54,6 +54,17 @@ export function ConfigFormBuilder({ initialConfig = EMPTY, onChange, locale = 'e
             + {c}
           </Button>
         ))}
+        <label className="ml-auto flex items-center gap-1.5 text-xs text-muted-foreground">
+          Columns
+          <select
+            className="h-8 rounded-md border border-input bg-background px-2 text-sm text-foreground"
+            aria-label="columns"
+            value={builder.config.columns ?? 1}
+            onChange={(e) => builder.setColumns(Number(e.target.value) as FormConfig['columns'])}
+          >
+            {[1, 2, 3, 4].map((n) => <option key={n} value={n}>{n}</option>)}
+          </select>
+        </label>
       </div>
 
       <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={onDragEnd}>

--- a/packages/form-builder-ui/src/config-form-builder.tsx
+++ b/packages/form-builder-ui/src/config-form-builder.tsx
@@ -11,6 +11,7 @@ import {
 } from '@dnd-kit/core';
 import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
 import type { FieldComponent, FormConfig } from '@rfjs/form-builder';
+import { parseFormConfig } from '@rfjs/form-builder';
 import { Button } from '@rfjs/web-ui/components/button';
 
 import { useConfigBuilder } from './use-config-builder';
@@ -30,6 +31,8 @@ export function ConfigFormBuilder({ initialConfig = EMPTY, onChange, locale = 'e
   const builder = useConfigBuilder(initialConfig, onChange);
   const sensors = useSensors(useSensor(PointerSensor));
   const ids = builder.config.fields.map((f) => f.key);
+  const [tab, setTab] = React.useState<'builder' | 'json'>('builder');
+  const [jsonError, setJsonError] = React.useState<string | null>(null);
 
   function onDragEnd(event: DragEndEvent) {
     const { active, over } = event;
@@ -39,57 +42,102 @@ export function ConfigFormBuilder({ initialConfig = EMPTY, onChange, locale = 'e
     if (from !== -1 && to !== -1) builder.move(from, to);
   }
 
+  function onJsonChange(text: string) {
+    try {
+      const parsed = parseFormConfig(JSON.parse(text));
+      setJsonError(null);
+      builder.replace(parsed);
+    } catch (err) {
+      setJsonError(err instanceof Error ? err.message : 'Invalid config');
+    }
+  }
+
   return (
     <div className="flex flex-col gap-5">
-      <div className="flex flex-wrap gap-2">
-        {PALETTE.map((c) => (
-          <Button
-            key={c}
-            type="button"
-            variant="outline"
-            size="sm"
-            aria-label={`Add ${c}`}
-            onClick={() => builder.add(makeField(c))}
-          >
-            + {c}
-          </Button>
-        ))}
-        <label className="ml-auto flex items-center gap-1.5 text-xs text-muted-foreground">
-          Columns
-          <select
-            className="h-8 rounded-md border border-input bg-background px-2 text-sm text-foreground"
-            aria-label="columns"
-            value={builder.config.columns ?? 1}
-            onChange={(e) => builder.setColumns(Number(e.target.value) as FormConfig['columns'])}
-          >
-            {[1, 2, 3, 4].map((n) => <option key={n} value={n}>{n}</option>)}
-          </select>
-        </label>
+      <div className="flex gap-2 border-b border-input">
+        <button
+          role="tab"
+          type="button"
+          aria-selected={tab === 'builder'}
+          className="px-3 py-1.5 text-sm font-medium"
+          onClick={() => setTab('builder')}
+        >
+          Builder
+        </button>
+        <button
+          role="tab"
+          type="button"
+          aria-selected={tab === 'json'}
+          className="px-3 py-1.5 text-sm font-medium"
+          onClick={() => setTab('json')}
+        >
+          JSON
+        </button>
       </div>
 
-      <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={onDragEnd}>
-        <SortableContext items={ids} strategy={verticalListSortingStrategy}>
-          <div className="flex flex-col gap-2">
-            {builder.config.fields.map((field) => (
-              <FieldRow
-                key={field.key}
-                field={field}
-                onUpdate={(patch) => builder.update(field.key, patch)}
-                onRemove={() => builder.remove(field.key)}
-              />
+      {tab === 'builder' ? (
+        <>
+          <div className="flex flex-wrap gap-2">
+            {PALETTE.map((c) => (
+              <Button
+                key={c}
+                type="button"
+                variant="outline"
+                size="sm"
+                aria-label={`Add ${c}`}
+                onClick={() => builder.add(makeField(c))}
+              >
+                + {c}
+              </Button>
             ))}
+            <label className="ml-auto flex items-center gap-1.5 text-xs text-muted-foreground">
+              Columns
+              <select
+                className="h-8 rounded-md border border-input bg-background px-2 text-sm text-foreground"
+                aria-label="columns"
+                value={builder.config.columns ?? 1}
+                onChange={(e) => builder.setColumns(Number(e.target.value) as FormConfig['columns'])}
+              >
+                {[1, 2, 3, 4].map((n) => <option key={n} value={n}>{n}</option>)}
+              </select>
+            </label>
           </div>
-        </SortableContext>
-      </DndContext>
 
-      <div data-testid="config-form-preview" className="rounded-md border border-input p-4">
-        <ConfigForm
-          key={JSON.stringify(builder.config)}
-          config={builder.config}
-          locale={locale}
-          onSubmit={() => {}}
-        />
-      </div>
+          <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={onDragEnd}>
+            <SortableContext items={ids} strategy={verticalListSortingStrategy}>
+              <div className="flex flex-col gap-2">
+                {builder.config.fields.map((field) => (
+                  <FieldRow
+                    key={field.key}
+                    field={field}
+                    onUpdate={(patch) => builder.update(field.key, patch)}
+                    onRemove={() => builder.remove(field.key)}
+                  />
+                ))}
+              </div>
+            </SortableContext>
+          </DndContext>
+
+          <div data-testid="config-form-preview" className="rounded-md border border-input p-4">
+            <ConfigForm
+              key={JSON.stringify(builder.config)}
+              config={builder.config}
+              locale={locale}
+              onSubmit={() => {}}
+            />
+          </div>
+        </>
+      ) : (
+        <div>
+          <textarea
+            aria-label="config json"
+            className="h-64 w-full rounded-md border border-input bg-background p-3 font-mono text-xs"
+            defaultValue={JSON.stringify(builder.config, null, 2)}
+            onChange={(e) => onJsonChange(e.target.value)}
+          />
+          {jsonError ? <p className="mt-1 text-xs text-destructive">Invalid config: {jsonError}</p> : null}
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/form-builder-ui/src/config-form-builder.tsx
+++ b/packages/form-builder-ui/src/config-form-builder.tsx
@@ -25,9 +25,10 @@ export interface ConfigFormBuilderProps {
   initialConfig?: FormConfig;
   onChange?: (config: FormConfig) => void;
   locale?: string;
+  locales?: string[];
 }
 
-export function ConfigFormBuilder({ initialConfig = EMPTY, onChange, locale = 'en' }: ConfigFormBuilderProps) {
+export function ConfigFormBuilder({ initialConfig = EMPTY, onChange, locale = 'en', locales = ['en'] }: ConfigFormBuilderProps) {
   const builder = useConfigBuilder(initialConfig, onChange);
   const sensors = useSensors(useSensor(PointerSensor));
   const ids = builder.config.fields.map((f) => f.key);
@@ -110,6 +111,7 @@ export function ConfigFormBuilder({ initialConfig = EMPTY, onChange, locale = 'e
                   <FieldRow
                     key={field.key}
                     field={field}
+                    locales={locales}
                     onUpdate={(patch) => builder.update(field.key, patch)}
                     onRemove={() => builder.remove(field.key)}
                   />

--- a/packages/form-builder-ui/src/field-row.spec.tsx
+++ b/packages/form-builder-ui/src/field-row.spec.tsx
@@ -49,6 +49,14 @@ describe('FieldRow', () => {
     fireEvent.click(screen.getByRole('button', { name: /remove field/i }));
     expect(onRemove).toHaveBeenCalled();
   });
+  it('commits a key change on blur', () => {
+    const { onUpdate } = renderRow(base);
+    const keyInput = screen.getByLabelText('key for name');
+    fireEvent.change(keyInput, { target: { value: 'full_name' } });
+    expect(onUpdate).not.toHaveBeenCalled(); // not on each keystroke
+    fireEvent.blur(keyInput);
+    expect(onUpdate).toHaveBeenCalledWith({ key: 'full_name' });
+  });
 });
 
 const selectField: FieldConfig = { key: 'role', label: 'Role', component: 'Select', dataType: 'string', options: [{ label: 'Admin', value: 'admin' }] };

--- a/packages/form-builder-ui/src/field-row.spec.tsx
+++ b/packages/form-builder-ui/src/field-row.spec.tsx
@@ -83,6 +83,26 @@ describe('OptionsEditor', () => {
   });
 });
 
+describe('multi-locale label editing', () => {
+  it('edits a per-locale label when multiple locales', () => {
+    const onUpdate = vi.fn();
+    render(
+      <DndContext>
+        <SortableContext items={['name']}>
+          <FieldRow
+            field={{ key: 'name', label: 'Name', component: 'Input', dataType: 'string' }}
+            locales={['en', 'zh-TW']}
+            onUpdate={onUpdate}
+            onRemove={() => {}}
+          />
+        </SortableContext>
+      </DndContext>,
+    );
+    fireEvent.change(screen.getByLabelText('label (zh-TW) for name'), { target: { value: '姓名' } });
+    expect(onUpdate).toHaveBeenCalledWith({ label: { en: 'Name', 'zh-TW': '姓名' } });
+  });
+});
+
 describe('makeField', () => {
   it('creates a defaulted field for a component with a unique-ish key', () => {
     const f = makeField('Select');

--- a/packages/form-builder-ui/src/field-row.tsx
+++ b/packages/form-builder-ui/src/field-row.tsx
@@ -92,6 +92,8 @@ export interface FieldRowProps {
 export function FieldRow({ field, onUpdate, onRemove }: FieldRowProps) {
   const { attributes, listeners, setNodeRef, transform, transition } = useSortable({ id: field.key });
   const [open, setOpen] = React.useState(true);
+  const [keyDraft, setKeyDraft] = React.useState(field.key);
+  React.useEffect(() => setKeyDraft(field.key), [field.key]);
   const style: React.CSSProperties = { transform: CSS.Transform.toString(transform), transition };
 
   function changeComponent(component: FieldComponent) {
@@ -145,6 +147,16 @@ export function FieldRow({ field, onUpdate, onRemove }: FieldRowProps) {
                 </option>
               ))}
             </select>
+          </label>
+          <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+            Key
+            <Input
+              className="h-8 font-mono"
+              aria-label={`key for ${field.key}`}
+              value={keyDraft}
+              onChange={(e) => setKeyDraft(e.target.value)}
+              onBlur={() => { if (keyDraft && keyDraft !== field.key) onUpdate({ key: keyDraft }); }}
+            />
           </label>
           <label className="flex flex-col gap-1 text-xs text-muted-foreground">
             Label

--- a/packages/form-builder-ui/src/field-row.tsx
+++ b/packages/form-builder-ui/src/field-row.tsx
@@ -83,13 +83,25 @@ function OptionsEditor({ field, onUpdate }: { field: FieldConfig; onUpdate: (pat
   );
 }
 
+function localeText(label: FieldConfig['label'], loc: string, fallback: string): string {
+  if (typeof label === 'string') return loc === fallback ? label : '';
+  return label[loc] ?? '';
+}
+
+function setLocaleLabel(label: FieldConfig['label'], loc: string, value: string, locales: string[]): FieldConfig['label'] {
+  const base: Record<string, string> = typeof label === 'string' ? { [locales[0] ?? 'en']: label } : { ...label };
+  base[loc] = value;
+  return base;
+}
+
 export interface FieldRowProps {
   field: FieldConfig;
   onUpdate: (patch: Partial<FieldConfig>) => void;
   onRemove: () => void;
+  locales?: string[];
 }
 
-export function FieldRow({ field, onUpdate, onRemove }: FieldRowProps) {
+export function FieldRow({ field, onUpdate, onRemove, locales = ['en'] }: FieldRowProps) {
   const { attributes, listeners, setNodeRef, transform, transition } = useSortable({ id: field.key });
   const [open, setOpen] = React.useState(true);
   const [keyDraft, setKeyDraft] = React.useState(field.key);
@@ -158,15 +170,29 @@ export function FieldRow({ field, onUpdate, onRemove }: FieldRowProps) {
               onBlur={() => { if (keyDraft && keyDraft !== field.key) onUpdate({ key: keyDraft }); }}
             />
           </label>
-          <label className="flex flex-col gap-1 text-xs text-muted-foreground">
-            Label
-            <Input
-              className="h-8"
-              aria-label={`label for ${field.key}`}
-              value={labelOf(field.label)}
-              onChange={(e) => onUpdate({ label: e.target.value })}
-            />
-          </label>
+          {locales.length <= 1 ? (
+            <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+              Label
+              <Input
+                className="h-8"
+                aria-label={`label for ${field.key}`}
+                value={labelOf(field.label)}
+                onChange={(e) => onUpdate({ label: e.target.value })}
+              />
+            </label>
+          ) : (
+            locales.map((loc) => (
+              <label key={loc} className="flex flex-col gap-1 text-xs text-muted-foreground">
+                Label ({loc})
+                <Input
+                  className="h-8"
+                  aria-label={`label (${loc}) for ${field.key}`}
+                  value={localeText(field.label, loc, locales[0] ?? 'en')}
+                  onChange={(e) => onUpdate({ label: setLocaleLabel(field.label, loc, e.target.value, locales) })}
+                />
+              </label>
+            ))
+          )}
           <label className="flex flex-col gap-1 text-xs text-muted-foreground">
             Width
             <select

--- a/packages/web-core/src/registry/packages.ts
+++ b/packages/web-core/src/registry/packages.ts
@@ -111,6 +111,14 @@ export const packageRegistry: PackageDefinition[] = [
     relatedTools: ['object-flatten', 'object-transformer'],
   },
   {
+    name: '@rfjs/form-builder',
+    status: 'preview',
+    href: '/packages/form-builder',
+    github: GITHUB,
+    tags: ['form', 'builder', 'config'],
+    relatedTools: ['form-builder'],
+  },
+  {
     name: '@rfjs/pg-toolkit',
     status: 'ready',
     href: '/packages/pg-toolkit',

--- a/packages/web-core/src/registry/tools.ts
+++ b/packages/web-core/src/registry/tools.ts
@@ -106,6 +106,14 @@ export const toolRegistry: ToolDefinition[] = [
     tags: ['builder', 'playground'],
   },
   {
+    id: 'form-builder',
+    category: 'generator',
+    surface: 'web',
+    status: 'preview',
+    relatedPackages: ['@rfjs/form-builder', '@rfjs/form-builder-ui'],
+    tags: ['form', 'builder', 'config'],
+  },
+  {
     id: 'object-transformer',
     category: 'transform',
     surface: 'workbench',

--- a/packages/web-core/src/registry/tools.ts
+++ b/packages/web-core/src/registry/tools.ts
@@ -110,7 +110,7 @@ export const toolRegistry: ToolDefinition[] = [
     category: 'generator',
     surface: 'web',
     status: 'preview',
-    relatedPackages: ['@rfjs/form-builder', '@rfjs/form-builder-ui'],
+    relatedPackages: ['@rfjs/form-builder'],
     tags: ['form', 'builder', 'config'],
   },
   {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -208,6 +208,12 @@ importers:
       '@rfjs/filter-builder-ui':
         specifier: workspace:*
         version: link:../../packages/filter-builder-ui
+      '@rfjs/form-builder':
+        specifier: workspace:*
+        version: link:../../packages/form-builder
+      '@rfjs/form-builder-ui':
+        specifier: workspace:*
+        version: link:../../packages/form-builder-ui
       '@rfjs/jsonb-query':
         specifier: workspace:*
         version: link:../../packages/jsonb-query


### PR DESCRIPTION
## What

**Phase 3c + 4** — **finishes and ships** the visual `<ConfigFormBuilder>`. Completes the editor and surfaces it as a tool in `apps/web`.

**P3c — finish the builder (`@rfjs/form-builder-ui`):**
- **Columns control** — set the form's grid columns (1-4) from the toolbar.
- **Config(JSON) round-trip tab** — Builder / JSON tabs; editing the JSON parses via `parseFormConfig` → `builder.replace`, with an inline error on invalid input. (The ref-based `useConfigBuilder.replace` from P3b makes this safe.)
- **Key editing** — edit a field's `key`, committed **on blur** (a per-keystroke commit would remount the dnd/React-keyed row).
- **Per-locale label editing** — `<ConfigFormBuilder locales={[...]}>`; with >1 locale the editor shows one label input per locale and `label` becomes a `Record<locale,string>` (single-locale path unchanged; `resolveLabel` renders both).

**P4 — ship (`apps/web` + `@rfjs/web-core`):**
- New `form-builder` tool (`tools/form-builder/{index,ui,messages}`) rendering `<ConfigFormBuilder locales={['en','zh-TW']}>`, registered in `toolModules` + `toolRegistry` (category `generator`) + `packageRegistry`, with en/zh-TW i18n, `transpilePackages`, and workspace deps.

## This completes the ConfigFormBuilder feature

P1 grid → P2 list-ops/i18n → P3a visual core → P3b collapsible fields + options → **P3c+P4 columns / JSON round-trip / key / per-locale + live on the site**. The only remaining piece is the separate **shadcn registry distribution** plan (the original "installable via `npx shadcn add`" goal).

**Deferred (noted in the plan):** panel-level "collapse all".

## Testing

- `@rfjs/form-builder-ui`: all spec files green — columns control, JSON round-trip (apply + invalid-error), key-on-blur, per-locale label seeding, plus prior ConfigForm/ConfigFormBuilder/FieldRow/hook tests.
- `apps/web`: **73/73** (registry↔components consistency incl. `form-builder`, nav, i18n-content) after `pnpm build:packages`. `check-types` clean.
- Built TDD, task-by-task, with per-task spec+quality review and a final whole-branch review (ready-to-merge; the one finding — a private `-ui` package listed in `relatedPackages` — fixed by trimming to the publishable `@rfjs/form-builder`, matching the filter-builder tools' convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
