### PR TITLE
feat(form-builder): v2-A polish — reactive preview, shadcn controls, seeded first-run

### DIFF
--- a/.superpowers/sdd/task-3-report.md
+++ b/.superpowers/sdd/task-3-report.md
@@ -1,0 +1,38 @@
+# Task 3 Report: seeded/framed first-run and empty state
+
+## Changes
+
+### 1. Empty state — `packages/form-builder-ui/src/config-form-builder.tsx`
+- When `builder.config.fields.length === 0`, the field-list area renders a `<p data-testid="empty-state-hint">` with "No fields yet — add one from the palette above" instead of an empty DnD list.
+- The preview panel (`data-testid="config-form-preview"`) also shows a muted placeholder ("Preview will appear here once you add fields") and suppresses the `<ConfigForm>` (and therefore its Submit button) when empty.
+
+### 2. Framing/polish — `packages/form-builder-ui/src/config-form-builder.tsx`
+- Field-list area wrapped in `rounded-lg border bg-card p-4`.
+- Preview panel border upgraded from `rounded-md border-input` to `rounded-lg border bg-card p-4`.
+- No new deps added; all existing `data-testid`/`aria-label`/`role` hooks preserved.
+
+### 3. Seed sample — `apps/web/src/tools/form-builder/ui.tsx`
+- `SAMPLE_CONFIG` constant: Name (Input, string, required), Email (Input, string), Role (Select, string, options Admin/User).
+- Passed as `initialConfig` to `<ConfigFormBuilder>`. `locales={["en","zh-TW"]}` retained.
+
+## TDD evidence
+- 3 new tests in `config-form-builder.spec.tsx`:
+  - `shows the empty-state hint when there are no fields` — asserts `data-testid="empty-state-hint"` and `/no fields yet/i`.
+  - `does not show the empty-state hint when fields are present` — asserts hint is absent.
+  - `preview panel has a placeholder and no Submit when fields are empty` — asserts preview text and no Submit button.
+
+## Test results
+- `pnpm -F @rfjs/form-builder-ui vitest:run`: **39 passed, 0 failed** (5 test files)
+- `pnpm -F web vitest:run`: **73 passed, 0 failed** (23 test files) — registry/nav/i18n tests unaffected; the MISSING_MESSAGE IntlError on `Operators` is a pre-existing noise from `_filter-builder` tests, not caused by this task.
+
+## Check-types
+- `pnpm -F @rfjs/form-builder-ui check-types`: clean
+- `pnpm -F web check-types`: clean
+
+## Files modified
+- `packages/form-builder-ui/src/config-form-builder.tsx` — empty state + framing
+- `packages/form-builder-ui/src/config-form-builder.spec.tsx` — 3 new TDD tests
+- `apps/web/src/tools/form-builder/ui.tsx` — seed config
+
+## Concerns
+None. The web's pre-existing IntlError for `Operators` is not introduced by this task.

--- a/apps/web/src/tools/form-builder/ui.tsx
+++ b/apps/web/src/tools/form-builder/ui.tsx
@@ -1,11 +1,30 @@
 "use client";
 
+import type { FormConfig } from "@rfjs/form-builder";
 import { ConfigFormBuilder } from "@rfjs/form-builder-ui";
+
+const SAMPLE_CONFIG: FormConfig = {
+  version: 1,
+  fields: [
+    { key: "name", label: "Name", component: "Input", dataType: "string", required: true },
+    { key: "email", label: "Email", component: "Input", dataType: "string" },
+    {
+      key: "role",
+      label: "Role",
+      component: "Select",
+      dataType: "string",
+      options: [
+        { label: "Admin", value: "admin" },
+        { label: "User", value: "user" },
+      ],
+    },
+  ],
+};
 
 export function FormBuilderTool() {
   return (
     <div className="flex flex-col gap-5">
-      <ConfigFormBuilder locales={["en", "zh-TW"]} />
+      <ConfigFormBuilder initialConfig={SAMPLE_CONFIG} locales={["en", "zh-TW"]} />
     </div>
   );
 }

--- a/docs/superpowers/plans/2026-06-26-form-builder-v2a-polish.md
+++ b/docs/superpowers/plans/2026-06-26-form-builder-v2a-polish.md
@@ -1,0 +1,67 @@
+# Form Builder v2-A (polish + shadcn controls) Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Fix the rough edges that made v1 feel unfinished — kill the live-preview flicker, replace the builder's native `<select>` controls with shadcn `Select`, and give the tool a seeded/framed first-run instead of a barren empty box.
+
+**Architecture:** Touches `@rfjs/form-builder-ui` (`ConfigForm` preview-reactivity, `FieldRow`/`ConfigFormBuilder` shadcn controls + framing/empty-state) and `apps/web/src/tools/form-builder/ui.tsx` (seed a sample config). No engine/model change (v2-A is polish only; the item-kind model lands later).
+
+**Tech Stack:** React 19, react-hook-form, @dnd-kit, @rfjs/web-ui (shadcn Select), vitest jsdom, @testing-library/react.
+
+## Global Constraints
+
+- v2-A is **polish only** — no config-model changes (no items/sections/validation yet).
+- All existing tests must stay green (or be deliberately adapted where a native control becomes a shadcn one — documented in the task).
+- shadcn `Select` (radix) replaces native `<select>` for type / width / columns. radix Select is hard to drive in jsdom — **test the value rendering + the `onValueChange` handler wiring, not the radix popover open/click**.
+- Co-locate `*.spec.tsx`. Conventional Commits; pre-commit passes (no `--no-verify`). Fresh worktree → `pnpm install`.
+
+---
+
+### Task 1: Live preview without remount flicker
+
+**Problem:** the builder preview is `<ConfigForm key={JSON.stringify(builder.config)} …>` — it remounts on every keystroke → flicker. `ConfigForm` reads `config` once at mount (react-hook-form doesn't re-init from a changed resolver), which is why the key hack exists.
+
+**Files:** `packages/form-builder-ui/src/config-form.tsx`, `config-form.spec.tsx`; `config-form-builder.tsx` (drop the `key`).
+
+- [ ] **Step 1:** `pnpm install`.
+- [ ] **Step 2 — make `ConfigForm` reactive to `config`.** Add an effect that re-initialises the form when `config` changes, and recompute the resolver, so the preview updates in place (no remount):
+  - Keep `resolver = useMemo(() => zodResolver(configToZod(config)), [config])`.
+  - Use `const form = useForm({ resolver, defaultValues })`.
+  - Add `React.useEffect(() => { form.reset(defaultValues ?? {}); }, [config]);` so changing `config` resets fields cleanly (RHF picks up the new field set on the next render; the resolver memo already tracks `config`).
+  - Verify validation still reflects the latest `config` (zodResolver is read per-submit by RHF v7 via the resolver reference held at mount — if validation does NOT track the new resolver, fall back to keying ConfigForm on a **structure signature** instead of full JSON: `key={config.fields.map(f=>f.key+f.component+(f.width??'')).join('|')+':'+(config.columns??1)}` so label keystrokes don't remount but structural edits do). Pick whichever the tests prove correct; document the choice.
+- [ ] **Step 3 — drop the JSON key in the builder.** In `config-form-builder.tsx`, change `<ConfigForm key={JSON.stringify(builder.config)} …>` to no key (or the structure-signature key from Step 2 fallback).
+- [ ] **Step 4 — test.** Add a `config-form.spec.tsx` test: render `<ConfigForm>`, rerender with a changed `config` (added field), assert the new field's label appears WITHOUT a full remount losing identity — e.g. assert the new field renders and an existing field's input node is the same element across rerender (`rerender()` from testing-library; compare `getByLabelText` node identity, or simply assert the updated field set renders). Keep existing ConfigForm tests green.
+- [ ] **Step 5:** `pnpm -F @rfjs/form-builder-ui vitest:run` + `check-types` clean. Commit: `fix(form-builder-ui): make ConfigForm preview reactive (no remount flicker)`.
+
+---
+
+### Task 2: shadcn `Select` for builder controls
+
+**Files:** `packages/form-builder-ui/src/field-row.tsx` (type, width), `config-form-builder.tsx` (columns), their specs.
+
+- [ ] **Step 1 — swap controls.** Replace the native `<select>` for **type** and **width** in `FieldRow`, and **columns** in `ConfigFormBuilder`, with `@rfjs/web-ui` `Select` (`Select`, `SelectTrigger`, `SelectValue`, `SelectContent`, `SelectItem`). Keep an accessible name on the trigger (e.g. `aria-label={\`type for ${field.key}\`}` on `SelectTrigger`) and the same `onValueChange → onUpdate({...})` / `setColumns` wiring + remap logic (`changeComponent` unchanged).
+- [ ] **Step 2 — adapt the tests.** The old tests used `fireEvent.change(getByLabelText('type for name'), {value:'Select'})` against a native select — that won't work on radix. Replace those assertions with: (a) the trigger renders the current value (`getByLabelText('type for name')` shows "Select"/"Input"); and (b) the change wiring is exercised by calling the rendered `SelectItem`'s path is NOT reliable in jsdom — instead, extract the change logic so it's unit-testable, OR assert via a thin handler. Concretely: assert the trigger shows the right current value and that `SelectContent` lists the options; do NOT assert a radix open+click. Keep `label`/`required`/`remove`/`key`/per-locale tests (those controls are unchanged) green.
+- [ ] **Step 3 — guard radix in jsdom.** Add a minimal jsdom shim in the spec setup if radix Select needs it (`Element.prototype.hasPointerCapture`, `scrollIntoView`) so rendering the trigger doesn't throw; keep the shim test-only.
+- [ ] **Step 4:** tests green; `check-types` clean. Commit: `feat(form-builder-ui): use shadcn Select for builder controls (type/width/columns)`.
+
+---
+
+### Task 3: seeded, framed first-run + empty state
+
+**Files:** `config-form-builder.tsx` + spec; `apps/web/src/tools/form-builder/ui.tsx`.
+
+- [ ] **Step 1 — empty state.** In `ConfigFormBuilder`, when `builder.config.fields.length === 0`, render an empty-state hint inside the list area ("No fields yet — add one from the palette above") instead of an empty preview with a lone Submit. Hide/condense the preview's submit row when there are no fields.
+- [ ] **Step 2 — framing/polish.** Wrap the field-list + preview each in a clearer panel (`rounded-lg border bg-card p-…`), tighten spacing, give the toolbar a clear grouping. Keep it minimal (no new deps).
+- [ ] **Step 3 — seed sample in the web tool.** In `apps/web/src/tools/form-builder/ui.tsx`, pass an `initialConfig` with a small sample (e.g. Name/Email/Role) so the tool is alive on load rather than empty. Keep `locales={['en','zh-TW']}`.
+- [ ] **Step 4 — test.** `config-form-builder.spec.tsx`: with an empty config, the empty-state hint renders; with fields, it does not. Existing add/remove/preview tests green.
+- [ ] **Step 5:** `pnpm -F @rfjs/form-builder-ui vitest:run` + `pnpm -F web vitest:run` (build packages first) + `check-types` clean. Commit: `feat(form-builder-ui): seeded/framed first-run and empty state`.
+
+---
+
+## Self-Review
+
+**Spec coverage:** v2-A (spec §5 + §4.5) = preview-flicker fix (T1), shadcn controls (T2), seeded/framed/empty-state (T3). No model change — validation/conditional/sections/blocks/dataSource are later phases.
+
+**Placeholder scan:** T1 and T2 carry explicit fallback strategies (structure-signature key; value+wiring assertions) because RHF-reactivity and radix-in-jsdom are genuinely environment-dependent — the implementer picks the approach the tests prove and documents it. These are bounded decisions, not open TODOs.
+
+**Risk notes:** (1) RHF resolver reactivity — if `form.reset` + memo'd resolver doesn't make validation track new config, use the structure-signature key (still kills per-keystroke flicker). (2) radix Select testing — assert trigger value + option list, not popover interaction; shim pointer APIs test-only. Both are flagged for the implementer.

--- a/docs/superpowers/specs/2026-06-26-form-builder-v2-design.md
+++ b/docs/superpowers/specs/2026-06-26-form-builder-v2-design.md
@@ -1,0 +1,104 @@
+# Form Builder v2 — 設計規格
+
+**日期：** 2026-06-26
+**狀態：** 草稿（待審查）
+**分支：** `worktree-feat-form-builder-v2`
+
+## 1. 摘要
+
+把已上線的 ConfigFormBuilder（v1：P1–P3c/P4）升級為 v2 —— 從「欄位清單」進化為**項目(item)化、可分組編排**的視覺表單建構器：item 有多種 kind（輸入欄位 / 內容 / 版面 / AI 備註），支援 **section + 列式編排器**、**驗證**、**條件顯示**、**多語 label**、**外部 API 取值**，UI 一律用 **shadcn** 元件。目標是把現況「功能可用但外觀/互動/功能不夠」的 builder 做到精緻、好用、夠力。
+
+mockup（已對齊，本機）：`form-builder-v2-mockup.html`、`form-builder-layout-options.html`。
+
+## 2. 背景
+
+v1 已交付並合併（PR #191/194/195/196/197/198）：`@rfjs/form-builder` 引擎（types/schema/configToZod/list-ops/LocalizedLabel）+ `@rfjs/form-builder-ui`（`<ConfigForm>`、`<ConfigFormBuilder>`、`FieldRow`）+ `apps/web` 的 `form-builder` 工具。使用者回饋：**外觀不夠好、互動不順、功能不足**（方向 OK）。v2 即針對這三面改善並擴充。
+
+## 3. 核心模型升級：item 有 kind
+
+表單從 `fields[]` 升級為 **`items[]`**，每個 item 有 `kind`：
+
+- **`field`（輸入）**：收資料。`component`（Input/Textarea/Select/Checkbox/Date/Number/Radio/Switch/Email…）、`dataType`、`width`、`label`(LocalizedLabel)、`required`、`options`、`validation`、`conditional`、`aiNote`、`dataSource`。
+- **`content`（內容）**：固定文字/說明（markdown）。`text`(LocalizedLabel-like)、`locked`（preset 不可編輯）、`conditional`、`dataSource`（可顯示外部取值）。無資料。
+- **`divider` / `spacer`（版面）**：分隔線 / 空白（`spacer.size`）。無資料。
+- **`ai-note`（AI 備註）**：`text`（給 AI 的 prompt/說明）。**不渲染給填表者**，只存在 config 供 AI/匯出使用。
+
+巢狀結構：**section → rows → items**（列式編排器，見 §6）。`configToZod` **只對 `field` item 產資料驗證**；其餘 kind 不產資料。`conditional` 同時適用 `field` 與 `content`。向後相容：v1 的扁平 `fields[]` 視為「單一隱性 section、每欄一列、kind=field」。
+
+## 4. 功能設計（逐項）
+
+### 4.1 驗證規則（v2-B）
+`FieldConfig.validation`：`{ min?, max?, minLength?, maxLength?, pattern?, message? }`。`configToZod` 依此產出 zod（數值 min/max、字串 length/regex、自訂 message）。builder 屬性編輯器加 Validation sub-block；渲染端顯示錯誤訊息。
+
+### 4.2 條件顯示（v2-C）
+`item.conditional`：一個 **`@rfjs/data-filter` 的 filter tree**（重用既有引擎）。`<ConfigForm>` 在執行期對「目前表單值物件」評估該 tree → show/hide 該 item。builder 用條件編輯器（可重用 filter-builder-ui 概念）。適用 field 與 content。
+
+### 4.3 多語 label（v1 已具，v2 強化）
+`label` / content `text` 為 `LocalizedLabel`；builder 依 `locales` 顯示逐語言輸入；`resolveLabel` 渲染。
+
+### 4.4 內容 / 版面 / AI 備註區塊（v2-F）
+- `content`：markdown 文字、`locked`（preset）、可條件顯示、可掛 `dataSource` 顯示外部值。
+- `divider` / `spacer`：純版面。
+- `ai-note`：AI-only block；**且每個 `field` 可附 `aiNote`**（per-field AI 說明）。皆不渲染給填表者；config/匯出可見。
+
+### 4.5 shadcn UI（v2-A 起，全程）
+builder 控制元件（型別/寬度/必填…）一律用 **shadcn `Select`/`Checkbox`** 等，**不用原生 HTML 控制元件**。（「原生/shadcn 可選」為 nice-to-have，預設 shadcn。）radix Select 在 jsdom 較難測 → 測 handler 邏輯為主。
+
+### 4.6 shadcn 日期選擇器（v2-E）
+`Date` 欄位升級為 **shadcn DatePicker**（需先補 `@rfjs/web-ui` 的 `Calendar`，用 `react-day-picker` + 既有 `Popover`）。
+
+### 4.7 更多輸入型別（v2-E）
+Number / Radio / Switch / Email …（部分需先補 web-ui `Switch`、`RadioGroup`、`Calendar`）。
+
+### 4.8 外部 API 取值 / 資料來源（v2-G）
+`item.dataSource`：
+```
+{ request: { url, method, headers?, body? },
+  extract: { dialect: 'path' | 'jsonpath' | 'jsonata', expr },
+  fallback: '無' }
+```
+- 用途：(a) 動態 Select/Radio **選項**（撈清單 → map {label,value}，label 可用 `@rfjs/data-label`）；(b) `content` **顯示值**（唯讀）；(可選) 欄位**預設值**。
+- 取值**可插拔**：`path`→`@rfjs/object-utils`、`jsonpath`→jsonpath lib、`jsonata`→`@rfjs/data-expr`。
+- **執行期 fetch**：runtime 取資料，需 loading / empty / error 狀態 + `fallback`（取不到顯示「無」）。
+- **可插拔 fetcher**：實際 fetch 由 consumer 注入（散佈成 shadcn registry 元件時，auth/CORS/安全由使用者掌控，元件不寫死網路行為）。
+
+## 5. 外觀 / 互動打磨（v2-A）
+- 載入時帶**種子範例**（不空白）；真空時顯示**空狀態引導**。
+- 編輯區**框架化**（面板）、欄位卡打磨（摘要 pill）。
+- **修預覽 remount 閃爍**：現況 `<ConfigForm key={JSON.stringify(config)}>` 每次改動都 remount → 改成 ConfigForm 對 config 反應式（或穩定 keying）。
+- 修「空預覽裡孤兒 Submit」；Submit 配色/位置調整。
+- builder 控制改 shadcn（§4.5）。
+
+## 6. 版面：列式編排器（v2-D；2D 畫布為未來 v2-?）
+**section → rows → items**：拖一個 item 到另一個旁邊 → 同列並排；拖到列間插入線 → 新列；`@dnd-kit` 多容器 sortable。RWD 時每列疊單欄。每段可設 columns（影響列內均分）。**自由 2D 畫布**（座標式、跨欄跨列、resize）威力最大但對表單過頭，列為**未來加強**，疊在列式編排器之上。
+
+## 7. 套件落點
+- `@rfjs/form-builder`（引擎）：item/section/rows 型別、schema、`configToZod`（驗證）、conditional 評估（包 data-filter）、dataSource 取值（resolver，包 object-utils/data-expr/data-label）、list/tree-ops。
+- `@rfjs/form-builder-ui`：`<ConfigForm>`（渲染：sections/rows/conditional/dataSource/validation/更多型別/shadcn）、`<ConfigFormBuilder>`（編輯：列式編排器、item 屬性編輯、各 sub-block）。
+- `@rfjs/web-ui`：補 `Calendar`、`Switch`、`RadioGroup` 等 shadcn 元件。
+- `apps/web`：`form-builder` 工具（已存在）改帶種子 config + locales。
+
+## 8. 分階段（各一個 PR；TDD + 逐任務審查）
+| 階段 | 內容 |
+|---|---|
+| **v2-A** | 外觀/互動打磨 + 控制元件改 shadcn（種子/空狀態、框架化、修預覽閃爍、Submit、shadcn Select 取代原生） |
+| **v2-B** | 驗證規則（schema/configToZod + 編輯器 + 渲染訊息） |
+| **v2-C** | 條件顯示（重用 data-filter；field + content） |
+| **v2-D** | section + 列式編排器（item-kind 模型 + 巢狀 + @dnd-kit 多容器） |
+| **v2-E** | 更多輸入型別 + shadcn DatePicker（補 web-ui Calendar/Switch/Radio） |
+| **v2-F** | 內容/分隔線/空白/AI-note 區塊 + 每欄 AI 說明 |
+| **v2-G** | 外部 API 取值 / dataSource（可插拔 fetcher + 取值 dialect） |
+| *(future)* | 自由 2D 畫布；registry 散佈（A，原始目標，獨立計畫） |
+
+各階段向後相容、可獨立 merge；模型擴充（items/section/rows）會在最早需要它的階段引入（v2-D 引入巢狀；v2-F 引入非 field kind；驗證/條件為 field 欄位擴充，可早於巢狀）。
+
+## 9. 非目標 / 取捨
+- 自由 2D 畫布 —— 未來再說（列式編排器先）。
+- registry 散佈 —— 獨立計畫。
+- dataSource 不在元件內寫死網路/auth —— 用注入 fetcher。
+- 「原生/shadcn 可選」開關 —— 預設 shadcn，開關列為 nice-to-have。
+
+## 10. 開放決策（實作時定奪）
+1. dataSource 取值 dialect 預設：建議 `path`（object-utils）為預設、`jsonata`（data-expr）為進階；`jsonpath` 視需要。
+2. section 巢狀引入時機：v2-D；在那之前 v2-B/C 以扁平 field 擴充進行（向後相容）。
+3. 條件編輯器 UI：重用 `@rfjs/filter-builder-ui` 概念或做精簡版（v2-C 定）。

--- a/packages/form-builder-ui/src/config-form-builder.spec.tsx
+++ b/packages/form-builder-ui/src/config-form-builder.spec.tsx
@@ -26,7 +26,28 @@ import { render, screen, fireEvent, within } from '@testing-library/react';
 import { ConfigFormBuilder } from './config-form-builder';
 import type { FormConfig } from '@rfjs/form-builder';
 
+const empty: FormConfig = { version: 1, fields: [] };
 const initial: FormConfig = { version: 1, fields: [{ key: 'name', label: 'Name', component: 'Input', dataType: 'string' }] };
+
+describe('ConfigFormBuilder empty state', () => {
+  it('shows the empty-state hint when there are no fields', () => {
+    render(<ConfigFormBuilder initialConfig={empty} />);
+    expect(screen.getByTestId('empty-state-hint')).toBeTruthy();
+    expect(screen.getByText(/no fields yet/i)).toBeTruthy();
+  });
+
+  it('does not show the empty-state hint when fields are present', () => {
+    render(<ConfigFormBuilder initialConfig={initial} />);
+    expect(screen.queryByTestId('empty-state-hint')).toBeNull();
+  });
+
+  it('preview panel has a placeholder and no Submit when fields are empty', () => {
+    render(<ConfigFormBuilder initialConfig={empty} />);
+    const preview = screen.getByTestId('config-form-preview');
+    expect(preview.textContent).toMatch(/preview will appear/i);
+    expect(within(preview).queryByRole('button', { name: /submit/i })).toBeNull();
+  });
+});
 
 describe('ConfigFormBuilder', () => {
   it('adds a field from the palette', () => {

--- a/packages/form-builder-ui/src/config-form-builder.spec.tsx
+++ b/packages/form-builder-ui/src/config-form-builder.spec.tsx
@@ -1,3 +1,26 @@
+// jsdom shim: radix-ui Select uses pointer capture and scrollIntoView APIs not available in jsdom
+if (typeof Element !== 'undefined') {
+  if (!Element.prototype.hasPointerCapture) {
+    Element.prototype.hasPointerCapture = () => false;
+  }
+  if (!Element.prototype.setPointerCapture) {
+    Element.prototype.setPointerCapture = () => {};
+  }
+  if (!Element.prototype.releasePointerCapture) {
+    Element.prototype.releasePointerCapture = () => {};
+  }
+  if (!Element.prototype.scrollIntoView) {
+    Element.prototype.scrollIntoView = () => {};
+  }
+}
+if (typeof window !== 'undefined' && !window.ResizeObserver) {
+  window.ResizeObserver = class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+}
+
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent, within } from '@testing-library/react';
 import { ConfigFormBuilder } from './config-form-builder';
@@ -26,11 +49,12 @@ describe('ConfigFormBuilder', () => {
     expect(screen.queryByLabelText('label for name')).toBeNull();
   });
 
-  it('sets form columns from the columns control', () => {
-    const onChange = vi.fn();
-    render(<ConfigFormBuilder initialConfig={initial} onChange={onChange} />);
-    fireEvent.change(screen.getByLabelText(/columns/i), { target: { value: '2' } });
-    expect(onChange).toHaveBeenLastCalledWith(expect.objectContaining({ columns: 2 }));
+  it('columns trigger renders the current columns value', () => {
+    // Radix Select cannot be driven by fireEvent.change; assert the trigger shows current value.
+    // The popover open+click interaction is unreliable in jsdom, so we assert trigger text only.
+    render(<ConfigFormBuilder initialConfig={initial} />);
+    const trigger = screen.getByLabelText(/columns/i);
+    expect(trigger.textContent).toContain('1');
   });
 
   it('shows the config as JSON and applies edits back (round-trip)', () => {

--- a/packages/form-builder-ui/src/config-form-builder.tsx
+++ b/packages/form-builder-ui/src/config-form-builder.tsx
@@ -13,6 +13,7 @@ import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable'
 import type { FieldComponent, FormConfig } from '@rfjs/form-builder';
 import { parseFormConfig } from '@rfjs/form-builder';
 import { Button } from '@rfjs/web-ui/components/button';
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@rfjs/web-ui/components/select';
 
 import { useConfigBuilder } from './use-config-builder';
 import { FieldRow, makeField } from './field-row';
@@ -91,17 +92,20 @@ export function ConfigFormBuilder({ initialConfig = EMPTY, onChange, locale = 'e
                 + {c}
               </Button>
             ))}
-            <label className="ml-auto flex items-center gap-1.5 text-xs text-muted-foreground">
+            <span className="ml-auto flex items-center gap-1.5 text-xs text-muted-foreground">
               Columns
-              <select
-                className="h-8 rounded-md border border-input bg-background px-2 text-sm text-foreground"
-                aria-label="columns"
-                value={builder.config.columns ?? 1}
-                onChange={(e) => builder.setColumns(Number(e.target.value) as FormConfig['columns'])}
+              <Select
+                value={String(builder.config.columns ?? 1)}
+                onValueChange={(v) => builder.setColumns(Number(v) as FormConfig['columns'])}
               >
-                {[1, 2, 3, 4].map((n) => <option key={n} value={n}>{n}</option>)}
-              </select>
-            </label>
+                <SelectTrigger className="h-8" aria-label="columns">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {[1, 2, 3, 4].map((n) => <SelectItem key={n} value={String(n)}>{n}</SelectItem>)}
+                </SelectContent>
+              </Select>
+            </span>
           </div>
 
           <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={onDragEnd}>

--- a/packages/form-builder-ui/src/config-form-builder.tsx
+++ b/packages/form-builder-ui/src/config-form-builder.tsx
@@ -122,7 +122,6 @@ export function ConfigFormBuilder({ initialConfig = EMPTY, onChange, locale = 'e
 
           <div data-testid="config-form-preview" className="rounded-md border border-input p-4">
             <ConfigForm
-              key={JSON.stringify(builder.config)}
               config={builder.config}
               locale={locale}
               onSubmit={() => {}}

--- a/packages/form-builder-ui/src/config-form-builder.tsx
+++ b/packages/form-builder-ui/src/config-form-builder.tsx
@@ -108,28 +108,43 @@ export function ConfigFormBuilder({ initialConfig = EMPTY, onChange, locale = 'e
             </span>
           </div>
 
-          <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={onDragEnd}>
-            <SortableContext items={ids} strategy={verticalListSortingStrategy}>
-              <div className="flex flex-col gap-2">
-                {builder.config.fields.map((field) => (
-                  <FieldRow
-                    key={field.key}
-                    field={field}
-                    locales={locales}
-                    onUpdate={(patch) => builder.update(field.key, patch)}
-                    onRemove={() => builder.remove(field.key)}
-                  />
-                ))}
-              </div>
-            </SortableContext>
-          </DndContext>
+          <div className="rounded-lg border bg-card p-4">
+            <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={onDragEnd}>
+              <SortableContext items={ids} strategy={verticalListSortingStrategy}>
+                <div className="flex flex-col gap-2">
+                  {builder.config.fields.length === 0 ? (
+                    <p
+                      data-testid="empty-state-hint"
+                      className="py-8 text-center text-sm text-muted-foreground"
+                    >
+                      No fields yet — add one from the palette above
+                    </p>
+                  ) : (
+                    builder.config.fields.map((field) => (
+                      <FieldRow
+                        key={field.key}
+                        field={field}
+                        locales={locales}
+                        onUpdate={(patch) => builder.update(field.key, patch)}
+                        onRemove={() => builder.remove(field.key)}
+                      />
+                    ))
+                  )}
+                </div>
+              </SortableContext>
+            </DndContext>
+          </div>
 
-          <div data-testid="config-form-preview" className="rounded-md border border-input p-4">
-            <ConfigForm
-              config={builder.config}
-              locale={locale}
-              onSubmit={() => {}}
-            />
+          <div data-testid="config-form-preview" className="rounded-lg border bg-card p-4">
+            {builder.config.fields.length === 0 ? (
+              <p className="py-4 text-center text-sm text-muted-foreground">Preview will appear here once you add fields</p>
+            ) : (
+              <ConfigForm
+                config={builder.config}
+                locale={locale}
+                onSubmit={() => {}}
+              />
+            )}
           </div>
         </>
       ) : (

--- a/packages/form-builder-ui/src/config-form.spec.tsx
+++ b/packages/form-builder-ui/src/config-form.spec.tsx
@@ -3,6 +3,11 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { ConfigForm } from './config-form';
 import type { FormConfig } from '@rfjs/form-builder';
 
+const baseConfig: FormConfig = {
+  version: 1,
+  fields: [{ key: 'name', label: 'Name', component: 'Input', dataType: 'string' }],
+};
+
 const config: FormConfig = {
   version: 1,
   fields: [
@@ -46,6 +51,63 @@ describe('localized labels', () => {
   it('defaults to the en label', () => {
     render(<ConfigForm config={cfg} onSubmit={() => {}} />);
     expect(screen.getByText('Name')).toBeTruthy();
+  });
+});
+
+describe('config reactivity', () => {
+  it('renders the new field set after config changes without remounting existing inputs', () => {
+    const extendedConfig: FormConfig = {
+      version: 1,
+      fields: [
+        { key: 'name', label: 'Name', component: 'Input', dataType: 'string' },
+        { key: 'email', label: 'Email', component: 'Input', dataType: 'string' },
+      ],
+    };
+
+    const { rerender } = render(<ConfigForm config={baseConfig} onSubmit={() => {}} />);
+
+    // Record the input node for the existing 'name' field before rerender
+    const nameInputBefore = screen.getByRole('textbox', { name: 'Name' });
+
+    // Only 'Name' field should be present initially
+    expect(screen.queryByText('Email')).toBeNull();
+
+    // Rerender with an extended config that adds 'email' field
+    rerender(<ConfigForm config={extendedConfig} onSubmit={() => {}} />);
+
+    // The new 'Email' field should appear
+    expect(screen.getByText('Email')).toBeTruthy();
+
+    // The existing 'name' input node must be the SAME DOM element — no remount
+    const nameInputAfter = screen.getByRole('textbox', { name: 'Name' });
+    expect(nameInputAfter).toBe(nameInputBefore);
+  });
+
+  it('accepts a config change that removes the required constraint on a field', async () => {
+    // Start with a required 'name' field
+    const requiredConfig: FormConfig = {
+      version: 1,
+      fields: [{ key: 'name', label: 'Name', component: 'Input', dataType: 'string', required: true }],
+    };
+    // Change to the same field but optional
+    const optionalConfig: FormConfig = {
+      version: 1,
+      fields: [{ key: 'name', label: 'Name', component: 'Input', dataType: 'string', required: false }],
+    };
+
+    const onSubmit = vi.fn();
+    const { rerender } = render(<ConfigForm config={requiredConfig} onSubmit={onSubmit} />);
+
+    // Submitting with empty 'name' should be blocked (required)
+    fireEvent.click(screen.getByRole('button', { name: /submit/i }));
+    await waitFor(() => expect(onSubmit).not.toHaveBeenCalled());
+
+    // Now change config to remove the required constraint
+    rerender(<ConfigForm config={optionalConfig} onSubmit={onSubmit} />);
+
+    // Submitting with empty 'name' should now succeed (field is optional)
+    fireEvent.click(screen.getByRole('button', { name: /submit/i }));
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledOnce());
   });
 });
 

--- a/packages/form-builder-ui/src/config-form.tsx
+++ b/packages/form-builder-ui/src/config-form.tsx
@@ -11,8 +11,9 @@ import { FieldControl } from './field-control';
 
 export interface ConfigFormProps {
   /**
-   * `config` is read once at mount (react-hook-form does not re-initialise from a changed resolver);
-   * remount with a React `key` to swap configs at runtime.
+   * `config` drives the form reactively: changing it re-renders the field list and resets
+   * the form state (clears stale values for removed/changed fields) without unmounting.
+   * The zod resolver is recomputed per `config` so validation tracks the latest schema.
    */
   config: FormConfig;
   defaultValues?: Record<string, unknown>;
@@ -24,7 +25,14 @@ export interface ConfigFormProps {
 
 export function ConfigForm({ config, defaultValues, onSubmit, submitLabel = 'Submit', locale = 'en' }: ConfigFormProps) {
   const resolver = React.useMemo(() => zodResolver(configToZod(config)), [config]);
-  const { control, handleSubmit } = useForm({ resolver, defaultValues });
+  const { control, handleSubmit, reset } = useForm({ resolver, defaultValues });
+
+  // Re-initialise form state when `config` changes so stale field values are cleared.
+  // RHF v7 already picks up the new resolver reference on each validation call via _options,
+  // so only a reset of values is needed (not a full remount).
+  React.useEffect(() => {
+    reset(defaultValues ?? {});
+  }, [config]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const columns = config.columns ?? 1;
 

--- a/packages/form-builder-ui/src/field-row.spec.tsx
+++ b/packages/form-builder-ui/src/field-row.spec.tsx
@@ -1,3 +1,26 @@
+// jsdom shim: radix-ui Select uses pointer capture and scrollIntoView APIs not available in jsdom
+if (typeof Element !== 'undefined') {
+  if (!Element.prototype.hasPointerCapture) {
+    Element.prototype.hasPointerCapture = () => false;
+  }
+  if (!Element.prototype.setPointerCapture) {
+    Element.prototype.setPointerCapture = () => {};
+  }
+  if (!Element.prototype.releasePointerCapture) {
+    Element.prototype.releasePointerCapture = () => {};
+  }
+  if (!Element.prototype.scrollIntoView) {
+    Element.prototype.scrollIntoView = () => {};
+  }
+}
+if (typeof window !== 'undefined' && !window.ResizeObserver) {
+  window.ResizeObserver = class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+}
+
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { DndContext } from '@dnd-kit/core';
@@ -29,15 +52,22 @@ describe('FieldRow', () => {
     fireEvent.change(screen.getByLabelText('label for name'), { target: { value: 'Full name' } });
     expect(onUpdate).toHaveBeenCalledWith({ label: 'Full name' });
   });
-  it('changes width', () => {
-    const { onUpdate } = renderRow(base);
-    fireEvent.change(screen.getByLabelText('width for name'), { target: { value: 'half' } });
-    expect(onUpdate).toHaveBeenCalledWith({ width: 'half' });
+  it('type trigger renders the current component value', () => {
+    // Radix Select cannot be driven by fireEvent.change; assert the trigger shows current value
+    renderRow(base);
+    const trigger = screen.getByLabelText('type for name');
+    expect(trigger.textContent).toContain('Input');
   });
-  it('changes type and remaps dataType/options', () => {
-    const { onUpdate } = renderRow(base);
-    fireEvent.change(screen.getByLabelText('type for name'), { target: { value: 'Select' } });
-    expect(onUpdate).toHaveBeenCalledWith({ component: 'Select', dataType: 'string', options: [] });
+  it('width trigger renders the current width value', () => {
+    // Radix Select cannot be driven by fireEvent.change; assert the trigger shows current value
+    renderRow(base);
+    const trigger = screen.getByLabelText('width for name');
+    expect(trigger.textContent).toContain('Full');
+  });
+  it('width trigger shows Half when field.width is half', () => {
+    renderRow({ ...base, width: 'half' });
+    const trigger = screen.getByLabelText('width for name');
+    expect(trigger.textContent).toContain('Half');
   });
   it('toggles required', () => {
     const { onUpdate } = renderRow(base);

--- a/packages/form-builder-ui/src/field-row.tsx
+++ b/packages/form-builder-ui/src/field-row.tsx
@@ -145,7 +145,7 @@ export function FieldRow({ field, onUpdate, onRemove, locales = ['en'] }: FieldR
       </div>
       {open ? (
         <div className="grid grid-cols-[repeat(auto-fit,minmax(150px,1fr))] gap-3 border-t border-input p-3">
-          <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+          <span className="flex flex-col gap-1 text-xs text-muted-foreground">
             Type
             <Select value={field.component} onValueChange={(v) => changeComponent(v as FieldComponent)}>
               <SelectTrigger className="h-8" aria-label={`type for ${field.key}`}>
@@ -157,7 +157,7 @@ export function FieldRow({ field, onUpdate, onRemove, locales = ['en'] }: FieldR
                 ))}
               </SelectContent>
             </Select>
-          </label>
+          </span>
           <label className="flex flex-col gap-1 text-xs text-muted-foreground">
             Key
             <Input
@@ -191,7 +191,7 @@ export function FieldRow({ field, onUpdate, onRemove, locales = ['en'] }: FieldR
               </label>
             ))
           )}
-          <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+          <span className="flex flex-col gap-1 text-xs text-muted-foreground">
             Width
             <Select value={field.width ?? 'full'} onValueChange={(v) => onUpdate({ width: v as FieldWidth })}>
               <SelectTrigger className="h-8" aria-label={`width for ${field.key}`}>
@@ -202,7 +202,7 @@ export function FieldRow({ field, onUpdate, onRemove, locales = ['en'] }: FieldR
                 <SelectItem value="half">Half</SelectItem>
               </SelectContent>
             </Select>
-          </label>
+          </span>
           <label className="flex items-center gap-1.5 self-end text-xs text-muted-foreground">
             <Checkbox
               checked={Boolean(field.required)}

--- a/packages/form-builder-ui/src/field-row.tsx
+++ b/packages/form-builder-ui/src/field-row.tsx
@@ -8,6 +8,7 @@ import type { FieldComponent, FieldConfig, FieldOption, FieldWidth } from '@rfjs
 import { Input } from '@rfjs/web-ui/components/input';
 import { Checkbox } from '@rfjs/web-ui/components/checkbox';
 import { Button } from '@rfjs/web-ui/components/button';
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@rfjs/web-ui/components/select';
 
 const DATATYPE_BY_COMPONENT: Record<FieldComponent, FieldConfig['dataType']> = {
   Input: 'string',
@@ -18,7 +19,6 @@ const DATATYPE_BY_COMPONENT: Record<FieldComponent, FieldConfig['dataType']> = {
 };
 
 const COMPONENTS: FieldComponent[] = ['Input', 'Textarea', 'Select', 'Checkbox', 'Date'];
-const SELECT_CLASS = 'h-8 rounded-md border border-input bg-background px-2 text-sm text-foreground';
 
 function labelOf(label: FieldConfig['label']): string {
   return typeof label === 'string' ? label : (Object.values(label)[0] ?? '');
@@ -147,18 +147,16 @@ export function FieldRow({ field, onUpdate, onRemove, locales = ['en'] }: FieldR
         <div className="grid grid-cols-[repeat(auto-fit,minmax(150px,1fr))] gap-3 border-t border-input p-3">
           <label className="flex flex-col gap-1 text-xs text-muted-foreground">
             Type
-            <select
-              className={SELECT_CLASS}
-              aria-label={`type for ${field.key}`}
-              value={field.component}
-              onChange={(e) => changeComponent(e.target.value as FieldComponent)}
-            >
-              {COMPONENTS.map((c) => (
-                <option key={c} value={c}>
-                  {c}
-                </option>
-              ))}
-            </select>
+            <Select value={field.component} onValueChange={(v) => changeComponent(v as FieldComponent)}>
+              <SelectTrigger className="h-8" aria-label={`type for ${field.key}`}>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {COMPONENTS.map((c) => (
+                  <SelectItem key={c} value={c}>{c}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
           </label>
           <label className="flex flex-col gap-1 text-xs text-muted-foreground">
             Key
@@ -195,15 +193,15 @@ export function FieldRow({ field, onUpdate, onRemove, locales = ['en'] }: FieldR
           )}
           <label className="flex flex-col gap-1 text-xs text-muted-foreground">
             Width
-            <select
-              className={SELECT_CLASS}
-              aria-label={`width for ${field.key}`}
-              value={field.width ?? 'full'}
-              onChange={(e) => onUpdate({ width: e.target.value as FieldWidth })}
-            >
-              <option value="full">Full</option>
-              <option value="half">Half</option>
-            </select>
+            <Select value={field.width ?? 'full'} onValueChange={(v) => onUpdate({ width: v as FieldWidth })}>
+              <SelectTrigger className="h-8" aria-label={`width for ${field.key}`}>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="full">Full</SelectItem>
+                <SelectItem value="half">Half</SelectItem>
+              </SelectContent>
+            </Select>
           </label>
           <label className="flex items-center gap-1.5 self-end text-xs text-muted-foreground">
             <Checkbox


### PR DESCRIPTION
## What

**v2-A** — the first phase of the **Form Builder v2** overhaul, addressing the "looks/feels unfinished" feedback. Polish only, no config-model change.

- **Reactive live preview (no flicker)** — `<ConfigForm>` now re-initialises on `config` change (memoized resolver read live by RHF v7 + `useEffect(reset, [config])`), so the builder dropped its `key={JSON.stringify(config)}` remount hack. Editing no longer flickers the preview.
- **shadcn `Select` for builder controls** — type / width (FieldRow) and columns (ConfigFormBuilder) now use `@rfjs/web-ui`'s `Select` instead of native `<select>`. (Builder UI is now shadcn throughout.)
- **Seeded / framed first-run + empty state** — the `apps/web` form-builder tool loads with a sample config (Name/Email/Role) instead of blank; an empty config shows a "no fields yet" hint instead of a lone Submit in an empty preview; the editor + preview are framed panels.

This PR also lands the **v2 design spec** and the **v2-A plan** under `docs/superpowers/`.

## v2 roadmap (follow-on PRs)

v2-A (this) → **v2-B** validation rules → **v2-C** conditional display (reuses `@rfjs/data-filter`) → **v2-D** sections + row arranger → **v2-E** more field types + shadcn DatePicker → **v2-F** content/divider/spacer/AI-note items + per-field AI notes → **v2-G** external `dataSource` (API-sourced values). (Free 2D canvas + shadcn-registry distribution are later.)

## Testing

- `@rfjs/form-builder-ui`: **39** tests across 5 files — incl. new reactivity tests (DOM-identity proves no remount; validation tracks the new config), shadcn-Select trigger-value assertions, and empty-state tests. Existing ConfigForm/FieldRow/ConfigFormBuilder tests green.
- `apps/web`: **73/73** (registry↔components / nav / i18n) after `pnpm build:packages`. `check-types` clean.
- TDD, per-task spec+quality review + a final whole-branch review (ready-to-merge; the one a11y finding — `<label>` wrapping the radix `Select` button → `<span>` — fixed).

### Known follow-ups (non-blocking, recorded)
`ConfigForm` `defaultValues` is excluded from the reset-effect deps (public-API note; preview path unaffected) · width/columns `onValueChange` lack unit coverage (radix popover isn't driveable in jsdom; e2e/manual covers) · radix jsdom shim duplicated across two specs (could move to a shared setup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
