### PR TITLE
feat(form-builder): field validation rules (v2-B)

### DIFF
--- a/docs/superpowers/plans/2026-06-26-form-builder-v2bc-rules.md
+++ b/docs/superpowers/plans/2026-06-26-form-builder-v2bc-rules.md
@@ -1,0 +1,85 @@
+# Form Builder v2 Group 1 (rules: validation + conditional) Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Add field-level **validation rules** and **conditional display** to the config-driven form — engine + renderer + builder editors. These are field-level config extensions (no section/item-kind restructure — that's Group 2).
+
+**Architecture:** `@rfjs/form-builder` gains `FieldConfig.validation` (→ `configToZod`) and `FieldConfig.conditional` (a `@rfjs/data-filter` filter group, evaluated via `compileMatchQuery`). `<ConfigForm>` displays validation messages and show/hides fields by conditional (watching form values). `FieldRow` gains Validation + Conditional sub-blocks.
+
+**Tech Stack:** TypeScript, zod v4, react-hook-form, `@rfjs/data-filter`, @rfjs/web-ui, vitest jsdom.
+
+## Global Constraints
+
+- Field-level only — no `items[]`/section/rows restructure (Group 2). `FieldConfig` extends; `FormConfig.fields` stays.
+- Validation maps to zod in `configToZod`: `min`/`max` (numeric), `minLength`/`maxLength` (string), `pattern` (regex on string), `message` (custom error). Applied on top of the existing base/required/optional logic — must not break the empty→undefined optional handling.
+- Conditional = a `@rfjs/data-filter` filter group over the current form values; evaluate with `compileMatchQuery` (verify its exact signature/predicate shape in the package). Absent conditional → always shown.
+- `<ConfigForm>` must keep its reactive-preview behaviour (no remount). Show/hide must not break field registration/validation for hidden fields (hidden fields should not block submit — exclude their validation when hidden).
+- shadcn controls (Group v2-A standard). Co-locate `*.spec`. Conventional Commits; pre-commit passes. Fresh worktree → `pnpm install`.
+
+---
+
+### Task 1: Engine — `FieldConfig.validation` + `configToZod`
+**Files:** `packages/form-builder/src/types.ts`, `config-schema.ts`, `config-to-zod.ts`, `config-to-zod.spec.ts`, `config-schema.spec.ts`.
+- [ ] `pnpm install`.
+- [ ] Add `FieldValidation` type + `FieldConfig.validation?: FieldValidation`:
+```ts
+export interface FieldValidation {
+  min?: number; max?: number;        // numeric
+  minLength?: number; maxLength?: number;  // string
+  pattern?: string;                  // regex source, string fields
+  message?: string;                  // custom error message
+}
+```
+- [ ] Schema: validate `validation` (all optional; numbers; `pattern` string).
+- [ ] `config-to-zod.ts`: apply validation to the per-field base BEFORE the required/optional wrap. For numeric: `.min(v.min, msg)` / `.max(v.max, msg)`. For string: `.min(v.minLength, msg)` / `.max(v.maxLength, msg)` / `.regex(new RegExp(v.pattern), msg)`. Keep `message` as the zod error message where given. Preserve the existing empty→undefined optional handling (apply validation to the base, then wrap).
+- [ ] TDD: tests — numeric min/max reject out-of-range; string minLength/maxLength/pattern reject; `message` surfaces; an optional field with validation still omits on empty.
+- [ ] `build` engine; `vitest:run` green; commit `feat(form-builder): add FieldConfig.validation and apply in configToZod`.
+
+---
+
+### Task 2: Renderer — show validation messages in `<ConfigForm>`
+**Files:** `packages/form-builder-ui/src/config-form.tsx`, `config-form.spec.tsx`.
+- [ ] Render `formState.errors[field.key]?.message` under each field (a `<p className="text-xs text-destructive">`). Use RHF's `formState` from `useForm`.
+- [ ] TDD: a config with a required/min-length field → submit invalid → the error message renders; valid → no message. Keep existing tests green.
+- [ ] `check-types`; commit `feat(form-builder-ui): render field validation messages`.
+
+---
+
+### Task 3: Builder — Validation sub-block in `FieldRow`
+**Files:** `packages/form-builder-ui/src/field-row.tsx`, `field-row.spec.tsx`.
+- [ ] In the expanded property editor, add a **Validation** sub-block: inputs for the fields relevant to the field's `dataType` (numeric → min/max; string/date → minLength/maxLength/pattern) + a `message` input. Each updates `onUpdate({ validation: { ...field.validation, [k]: v } })` (numbers parsed; empty clears the key). Use shadcn `Input`.
+- [ ] TDD: editing a validation input calls `onUpdate` with the merged `validation`. Existing FieldRow tests green.
+- [ ] `check-types`; commit `feat(form-builder-ui): add validation editor to FieldRow`.
+
+---
+
+### Task 4: Engine — `FieldConfig.conditional` + `evaluateConditional`
+**Files:** `packages/form-builder/src/types.ts`, `config-schema.ts`, new `conditional.ts`, `conditional.spec.ts`, barrel.
+- [ ] Add `conditional?: ConditionalRule` to `FieldConfig`, where `ConditionalRule` is a `@rfjs/data-filter` filter group (import its `FilterGroup`/query type; alias it). Schema validates it as the data-filter group shape (use a permissive object schema if data-filter exposes no zod — validate structurally: `{ logic, filters }`).
+- [ ] `conditional.ts`: `export function evaluateConditional(rule: ConditionalRule | undefined, values: Record<string, unknown>): boolean` — `if (!rule) return true;` else use `@rfjs/data-filter`'s `compileMatchQuery(rule)` (VERIFY exact signature — it returns a predicate `(item)=>boolean` or similar) → `predicate(values)`. Add `@rfjs/data-filter` to `@rfjs/form-builder` deps (workspace).
+- [ ] TDD: `evaluateConditional(undefined, {})===true`; a rule `{logic:'and',filters:[{field:'role',operator:'eq',value:'admin'}]}` returns true for `{role:'admin'}`, false otherwise. (Match the actual data-filter group/condition shape — read its types.)
+- [ ] `build`; `vitest:run`; commit `feat(form-builder): add conditional rule + evaluateConditional (data-filter)`.
+
+---
+
+### Task 5: Renderer — conditional show/hide in `<ConfigForm>`
+**Files:** `packages/form-builder-ui/src/config-form.tsx`, `config-form.spec.tsx`.
+- [ ] Use RHF `watch()` to get current values; for each field with `conditional`, render only when `evaluateConditional(field.conditional, values)` is true. Hidden fields must NOT block submit — when building the resolver, exclude hidden fields' validation (e.g. `configToZod` over only-visible fields, recomputed from watched values) OR mark hidden fields optional. Simplest robust approach: compute visible fields from watched values and pass a `{ ...config, fields: visibleFields }` to a memoized resolver + render only visible.
+- [ ] TDD: a field with `conditional` shows/hides as a controlling field's value changes; a hidden required field does not block submit.
+- [ ] `check-types`; commit `feat(form-builder-ui): conditional field show/hide in ConfigForm`.
+
+---
+
+### Task 6: Builder — Conditional sub-block in `FieldRow` (simplified editor)
+**Files:** `packages/form-builder-ui/src/field-row.tsx`, `field-row.spec.tsx`.
+- [ ] Add a **Conditional display** sub-block: a mode toggle (shadcn) "Always" | "When…"; when "When…", a small list of condition rows `[field-select(other fields) · operator-select · value-input]` (shadcn) building a `{ logic: 'and', filters: [{field, operator, value}, …] }` data-filter group → `onUpdate({ conditional })`. "Always" → `onUpdate({ conditional: undefined })`. `FieldRow` needs the list of other field keys — pass `siblingFields` (key + label) from `ConfigFormBuilder`.
+- [ ] TDD: switching to "When…" + setting a condition calls `onUpdate` with the expected group; "Always" clears it. Use shadcn-trigger-value assertions (radix not driven in jsdom) + the test-only radix shim already present.
+- [ ] In `config-form-builder.tsx`: pass `siblingFields={builder.config.fields.filter(f=>f.key!==field.key).map(f=>({key:f.key,label:f.label}))}` to each `FieldRow`.
+- [ ] `check-types`; commit `feat(form-builder-ui): add conditional editor to FieldRow`.
+
+---
+
+## Self-Review
+**Spec coverage:** Group 1 = v2-B validation (T1 engine, T2 render, T3 editor) + v2-C conditional (T4 engine, T5 render, T6 editor). No item-kind/section restructure (Group 2). dataSource/more-types (Group 3) excluded.
+**Placeholder scan:** engine tasks have concrete zod/eval code; the conditional editor + `compileMatchQuery` signature are flagged "verify exact data-filter shape" (real API to confirm at impl, not open TODOs).
+**Risk notes:** (1) hidden-field-must-not-block-submit — Task 5 recomputes resolver over visible fields. (2) `compileMatchQuery` exact API — Task 4 verifies. (3) radix editors — trigger-value assertions + existing shim. (4) validation must not break the empty→undefined optional handling in configToZod — Task 1 applies validation to the base before the optional wrap.

--- a/packages/form-builder-ui/src/config-form.spec.tsx
+++ b/packages/form-builder-ui/src/config-form.spec.tsx
@@ -111,6 +111,44 @@ describe('config reactivity', () => {
   });
 });
 
+describe('field validation messages', () => {
+  const minLenConfig: FormConfig = {
+    version: 1,
+    fields: [
+      {
+        key: 'username',
+        label: 'Username',
+        component: 'Input',
+        dataType: 'string',
+        validation: { minLength: 3, message: 'At least 3 characters' },
+      },
+    ],
+  };
+
+  it('shows the validation message after submitting an invalid value', async () => {
+    render(<ConfigForm config={minLenConfig} onSubmit={() => {}} />);
+    fireEvent.change(screen.getByRole('textbox', { name: 'Username' }), { target: { value: 'ab' } });
+    fireEvent.click(screen.getByRole('button', { name: /submit/i }));
+    await waitFor(() => expect(screen.getByText('At least 3 characters')).toBeTruthy());
+  });
+
+  it('does not show a validation message when the value is valid', async () => {
+    const onSubmit = vi.fn();
+    render(<ConfigForm config={minLenConfig} onSubmit={onSubmit} />);
+    fireEvent.change(screen.getByRole('textbox', { name: 'Username' }), { target: { value: 'ada' } });
+    fireEvent.click(screen.getByRole('button', { name: /submit/i }));
+    await waitFor(() => expect(onSubmit).toHaveBeenCalled());
+    expect(screen.queryByText('At least 3 characters')).toBeNull();
+  });
+
+  it('shows a minLength message when the value is too short after typing', async () => {
+    render(<ConfigForm config={minLenConfig} onSubmit={() => {}} />);
+    fireEvent.change(screen.getByRole('textbox', { name: 'Username' }), { target: { value: 'x' } });
+    fireEvent.click(screen.getByRole('button', { name: /submit/i }));
+    await waitFor(() => expect(screen.getByText('At least 3 characters')).toBeTruthy());
+  });
+});
+
 describe('grid layout', () => {
   const gridConfig: FormConfig = {
     version: 1,

--- a/packages/form-builder-ui/src/config-form.tsx
+++ b/packages/form-builder-ui/src/config-form.tsx
@@ -25,7 +25,7 @@ export interface ConfigFormProps {
 
 export function ConfigForm({ config, defaultValues, onSubmit, submitLabel = 'Submit', locale = 'en' }: ConfigFormProps) {
   const resolver = React.useMemo(() => zodResolver(configToZod(config)), [config]);
-  const { control, handleSubmit, reset } = useForm({ resolver, defaultValues });
+  const { control, handleSubmit, reset, formState: { errors } } = useForm({ resolver, defaultValues });
 
   // Re-initialise form state when `config` changes so stale field values are cleared.
   // RHF v7 already picks up the new resolver reference on each validation call via _options,
@@ -60,6 +60,9 @@ export function ConfigForm({ config, defaultValues, onSubmit, submitLabel = 'Sub
                 <FieldControl field={field} value={rhf.value} onChange={rhf.onChange} />
               )}
             />
+            {errors[field.key]?.message && (
+              <p className="text-xs text-destructive">{String(errors[field.key]?.message)}</p>
+            )}
           </div>
         );
       })}

--- a/packages/form-builder-ui/src/field-row.spec.tsx
+++ b/packages/form-builder-ui/src/field-row.spec.tsx
@@ -142,3 +142,76 @@ describe('makeField', () => {
     expect(typeof f.label).toBe('string');
   });
 });
+
+const numericField: FieldConfig = { key: 'age', label: 'Age', component: 'Input', dataType: 'numeric' };
+const stringField: FieldConfig = { key: 'bio', label: 'Bio', component: 'Textarea', dataType: 'string' };
+
+describe('ValidationEditor', () => {
+  it('shows min and max inputs for a numeric field', () => {
+    renderRow(numericField);
+    expect(screen.getByLabelText('validation min')).toBeTruthy();
+    expect(screen.getByLabelText('validation max')).toBeTruthy();
+    expect(screen.queryByLabelText('validation minLength')).toBeNull();
+    expect(screen.queryByLabelText('validation pattern')).toBeNull();
+  });
+
+  it('shows minLength, maxLength, pattern inputs for a string field', () => {
+    renderRow(stringField);
+    expect(screen.getByLabelText('validation minLength')).toBeTruthy();
+    expect(screen.getByLabelText('validation maxLength')).toBeTruthy();
+    expect(screen.getByLabelText('validation pattern')).toBeTruthy();
+    expect(screen.queryByLabelText('validation min')).toBeNull();
+    expect(screen.queryByLabelText('validation max')).toBeNull();
+  });
+
+  it('shows message input for all field types', () => {
+    renderRow(numericField);
+    expect(screen.getByLabelText('validation message')).toBeTruthy();
+  });
+
+  it('updates min on numeric field merging existing validation', () => {
+    const field: FieldConfig = { ...numericField, validation: { max: 100 } };
+    const { onUpdate } = renderRow(field);
+    fireEvent.change(screen.getByLabelText('validation min'), { target: { value: '5' } });
+    expect(onUpdate).toHaveBeenCalledWith({ validation: { max: 100, min: 5 } });
+  });
+
+  it('updates max on numeric field', () => {
+    const { onUpdate } = renderRow(numericField);
+    fireEvent.change(screen.getByLabelText('validation max'), { target: { value: '99' } });
+    expect(onUpdate).toHaveBeenCalledWith({ validation: { max: 99 } });
+  });
+
+  it('updates minLength on string field', () => {
+    const { onUpdate } = renderRow(stringField);
+    fireEvent.change(screen.getByLabelText('validation minLength'), { target: { value: '3' } });
+    expect(onUpdate).toHaveBeenCalledWith({ validation: { minLength: 3 } });
+  });
+
+  it('updates pattern on string field', () => {
+    const { onUpdate } = renderRow(stringField);
+    fireEvent.change(screen.getByLabelText('validation pattern'), { target: { value: '^[a-z]+$' } });
+    expect(onUpdate).toHaveBeenCalledWith({ validation: { pattern: '^[a-z]+$' } });
+  });
+
+  it('updates message on any field', () => {
+    const { onUpdate } = renderRow(numericField);
+    fireEvent.change(screen.getByLabelText('validation message'), { target: { value: 'Invalid value' } });
+    expect(onUpdate).toHaveBeenCalledWith({ validation: { message: 'Invalid value' } });
+  });
+
+  it('clears a numeric key when input is emptied', () => {
+    const field: FieldConfig = { ...numericField, validation: { min: 5, max: 100 } };
+    const { onUpdate } = renderRow(field);
+    fireEvent.change(screen.getByLabelText('validation min'), { target: { value: '' } });
+    expect(onUpdate).toHaveBeenCalledWith({ validation: { max: 100 } });
+  });
+
+  it('shows only message for a boolean field', () => {
+    const boolField: FieldConfig = { key: 'active', label: 'Active', component: 'Checkbox', dataType: 'boolean' };
+    renderRow(boolField);
+    expect(screen.getByLabelText('validation message')).toBeTruthy();
+    expect(screen.queryByLabelText('validation min')).toBeNull();
+    expect(screen.queryByLabelText('validation minLength')).toBeNull();
+  });
+});

--- a/packages/form-builder-ui/src/field-row.spec.tsx
+++ b/packages/form-builder-ui/src/field-row.spec.tsx
@@ -25,7 +25,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { DndContext } from '@dnd-kit/core';
 import { SortableContext } from '@dnd-kit/sortable';
-import { FieldRow, makeField } from './field-row';
+import { FieldRow, makeField, mergeValidation } from './field-row';
 import type { FieldConfig } from '@rfjs/form-builder';
 
 function renderRow(field: FieldConfig, onUpdate = vi.fn(), onRemove = vi.fn()) {
@@ -164,9 +164,26 @@ describe('ValidationEditor', () => {
     expect(screen.queryByLabelText('validation max')).toBeNull();
   });
 
-  it('shows message input for all field types', () => {
+  it('shows message input when a constraint block is shown', () => {
     renderRow(numericField);
     expect(screen.getByLabelText('validation message')).toBeTruthy();
+  });
+
+  it('shows no validation inputs (incl. message) for a Select field with options', () => {
+    renderRow(selectField);
+    expect(screen.queryByLabelText('validation min')).toBeNull();
+    expect(screen.queryByLabelText('validation max')).toBeNull();
+    expect(screen.queryByLabelText('validation minLength')).toBeNull();
+    expect(screen.queryByLabelText('validation maxLength')).toBeNull();
+    expect(screen.queryByLabelText('validation pattern')).toBeNull();
+    expect(screen.queryByLabelText('validation message')).toBeNull();
+  });
+
+  it('clears a numeric key when input is emptied via the component', () => {
+    const field: FieldConfig = { ...numericField, validation: { min: 5, max: 100 } };
+    const { onUpdate } = renderRow(field);
+    fireEvent.change(screen.getByLabelText('validation min'), { target: { value: '' } });
+    expect(onUpdate).toHaveBeenCalledWith({ validation: { max: 100 } });
   });
 
   it('updates min on numeric field merging existing validation', () => {
@@ -194,24 +211,33 @@ describe('ValidationEditor', () => {
     expect(onUpdate).toHaveBeenCalledWith({ validation: { pattern: '^[a-z]+$' } });
   });
 
-  it('updates message on any field', () => {
+  it('updates message on a field that shows a constraint block', () => {
     const { onUpdate } = renderRow(numericField);
     fireEvent.change(screen.getByLabelText('validation message'), { target: { value: 'Invalid value' } });
     expect(onUpdate).toHaveBeenCalledWith({ validation: { message: 'Invalid value' } });
   });
 
-  it('clears a numeric key when input is emptied', () => {
-    const field: FieldConfig = { ...numericField, validation: { min: 5, max: 100 } };
-    const { onUpdate } = renderRow(field);
-    fireEvent.change(screen.getByLabelText('validation min'), { target: { value: '' } });
-    expect(onUpdate).toHaveBeenCalledWith({ validation: { max: 100 } });
-  });
-
-  it('shows only message for a boolean field', () => {
+  it('shows no validation inputs for a boolean field', () => {
     const boolField: FieldConfig = { key: 'active', label: 'Active', component: 'Checkbox', dataType: 'boolean' };
     renderRow(boolField);
-    expect(screen.getByLabelText('validation message')).toBeTruthy();
+    expect(screen.queryByLabelText('validation message')).toBeNull();
     expect(screen.queryByLabelText('validation min')).toBeNull();
     expect(screen.queryByLabelText('validation minLength')).toBeNull();
+  });
+});
+
+describe('mergeValidation', () => {
+  it('stores a parsed number for a numeric key', () => {
+    expect(mergeValidation({ max: 100 }, 'min', '5', true)).toEqual({ max: 100, min: 5 });
+  });
+  it('clears a numeric key on empty input', () => {
+    expect(mergeValidation({ min: 5, max: 100 }, 'min', '', true)).toEqual({ max: 100 });
+  });
+  it('clears a numeric key (does NOT store NaN) on a non-numeric value', () => {
+    expect(mergeValidation({ min: 5, max: 100 }, 'min', 'abc', true)).toEqual({ max: 100 });
+  });
+  it('stores a string for a string key and clears it on empty', () => {
+    expect(mergeValidation(undefined, 'pattern', '^x$', false)).toEqual({ pattern: '^x$' });
+    expect(mergeValidation({ pattern: '^x$' }, 'pattern', '', false)).toEqual({});
   });
 });

--- a/packages/form-builder-ui/src/field-row.tsx
+++ b/packages/form-builder-ui/src/field-row.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { ChevronDown, ChevronRight, GripVertical, Trash2 } from 'lucide-react';
-import type { FieldComponent, FieldConfig, FieldOption, FieldWidth } from '@rfjs/form-builder';
+import type { FieldComponent, FieldConfig, FieldOption, FieldValidation, FieldWidth } from '@rfjs/form-builder';
 import { Input } from '@rfjs/web-ui/components/input';
 import { Checkbox } from '@rfjs/web-ui/components/checkbox';
 import { Button } from '@rfjs/web-ui/components/button';
@@ -79,6 +79,106 @@ function OptionsEditor({ field, onUpdate }: { field: FieldConfig; onUpdate: (pat
       >
         + Add option
       </Button>
+    </div>
+  );
+}
+
+function ValidationEditor({ field, onUpdate }: { field: FieldConfig; onUpdate: (patch: Partial<FieldConfig>) => void }) {
+  const v = field.validation ?? {};
+
+  function patchValidation(key: keyof FieldValidation, raw: string, numeric: boolean) {
+    const next: FieldValidation = { ...v };
+    if (numeric) {
+      const n = raw === '' ? undefined : Number(raw);
+      if (n === undefined) {
+        delete next[key];
+      } else {
+        (next as Record<string, unknown>)[key] = n;
+      }
+    } else {
+      if (raw === '') {
+        delete next[key];
+      } else {
+        (next as Record<string, unknown>)[key] = raw;
+      }
+    }
+    onUpdate({ validation: next });
+  }
+
+  const isNumeric = field.dataType === 'numeric';
+  const isStringOrDate = field.dataType === 'string' || field.dataType === 'date';
+
+  return (
+    <div className="col-span-full flex flex-col gap-2">
+      <span className="text-xs font-medium text-muted-foreground">Validation</span>
+      <div className="grid grid-cols-[repeat(auto-fit,minmax(120px,1fr))] gap-2">
+        {isNumeric ? (
+          <>
+            <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+              Min
+              <Input
+                className="h-8"
+                type="number"
+                aria-label="validation min"
+                value={v.min ?? ''}
+                onChange={(e) => patchValidation('min', e.target.value, true)}
+              />
+            </label>
+            <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+              Max
+              <Input
+                className="h-8"
+                type="number"
+                aria-label="validation max"
+                value={v.max ?? ''}
+                onChange={(e) => patchValidation('max', e.target.value, true)}
+              />
+            </label>
+          </>
+        ) : null}
+        {isStringOrDate ? (
+          <>
+            <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+              Min length
+              <Input
+                className="h-8"
+                type="number"
+                aria-label="validation minLength"
+                value={v.minLength ?? ''}
+                onChange={(e) => patchValidation('minLength', e.target.value, true)}
+              />
+            </label>
+            <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+              Max length
+              <Input
+                className="h-8"
+                type="number"
+                aria-label="validation maxLength"
+                value={v.maxLength ?? ''}
+                onChange={(e) => patchValidation('maxLength', e.target.value, true)}
+              />
+            </label>
+            <label className="flex flex-col gap-1 text-xs text-muted-foreground col-span-2">
+              Pattern
+              <Input
+                className="h-8"
+                aria-label="validation pattern"
+                value={v.pattern ?? ''}
+                onChange={(e) => patchValidation('pattern', e.target.value, false)}
+              />
+            </label>
+          </>
+        ) : null}
+        <label className="flex flex-col gap-1 text-xs text-muted-foreground col-span-full">
+          Message
+          <Input
+            className="h-8"
+            aria-label="validation message"
+            value={v.message ?? ''}
+            onChange={(e) => patchValidation('message', e.target.value, false)}
+          />
+        </label>
+      </div>
     </div>
   );
 }
@@ -211,6 +311,7 @@ export function FieldRow({ field, onUpdate, onRemove, locales = ['en'] }: FieldR
             required
           </label>
           {field.component === 'Select' ? <OptionsEditor field={field} onUpdate={onUpdate} /> : null}
+          <ValidationEditor field={field} onUpdate={onUpdate} />
         </div>
       ) : null}
     </div>

--- a/packages/form-builder-ui/src/field-row.tsx
+++ b/packages/form-builder-ui/src/field-row.tsx
@@ -83,30 +83,48 @@ function OptionsEditor({ field, onUpdate }: { field: FieldConfig; onUpdate: (pat
   );
 }
 
+/**
+ * Merge a single validation field into the existing validation object.
+ * For numeric keys an empty/`NaN` parse CLEARS the key (never stores `NaN`);
+ * for string keys an empty value CLEARS the key.
+ */
+export function mergeValidation(
+  current: FieldValidation | undefined,
+  key: keyof FieldValidation,
+  raw: string,
+  numeric: boolean,
+): FieldValidation {
+  const next: FieldValidation = { ...current };
+  if (numeric) {
+    const n = raw === '' ? undefined : Number(raw);
+    if (n === undefined || Number.isNaN(n)) {
+      delete next[key];
+    } else {
+      (next as Record<string, unknown>)[key] = n;
+    }
+  } else if (raw === '') {
+    delete next[key];
+  } else {
+    (next as Record<string, unknown>)[key] = raw;
+  }
+  return next;
+}
+
 function ValidationEditor({ field, onUpdate }: { field: FieldConfig; onUpdate: (patch: Partial<FieldConfig>) => void }) {
   const v = field.validation ?? {};
 
   function patchValidation(key: keyof FieldValidation, raw: string, numeric: boolean) {
-    const next: FieldValidation = { ...v };
-    if (numeric) {
-      const n = raw === '' ? undefined : Number(raw);
-      if (n === undefined) {
-        delete next[key];
-      } else {
-        (next as Record<string, unknown>)[key] = n;
-      }
-    } else {
-      if (raw === '') {
-        delete next[key];
-      } else {
-        (next as Record<string, unknown>)[key] = raw;
-      }
-    }
-    onUpdate({ validation: next });
+    onUpdate({ validation: mergeValidation(v, key, raw, numeric) });
   }
 
-  const isNumeric = field.dataType === 'numeric';
-  const isStringOrDate = field.dataType === 'string' || field.dataType === 'date';
+  // Fields with `options` (enum/Select) ignore numeric/length/pattern bounds in the
+  // engine's applyValidation, so don't offer dead controls for them.
+  const hasOptions = Boolean(field.options?.length);
+  const isNumeric = field.dataType === 'numeric' && !hasOptions;
+  const isStringOrDate = (field.dataType === 'string' || field.dataType === 'date') && !hasOptions;
+
+  // The `message` input only matters when at least one constraint block applies.
+  if (!isNumeric && !isStringOrDate) return null;
 
   return (
     <div className="col-span-full flex flex-col gap-2">

--- a/packages/form-builder/src/config-schema.spec.ts
+++ b/packages/form-builder/src/config-schema.spec.ts
@@ -141,4 +141,36 @@ describe('FieldValidation schema', () => {
     const cfg = { version: 1, fields: [{ ...baseField }] };
     expect(FormConfigSchema.safeParse(cfg).success).toBe(true);
   });
+
+  it('rejects a field with an invalid regex pattern', () => {
+    const cfg = {
+      version: 1,
+      fields: [
+        {
+          key: 'test',
+          label: 'Test',
+          component: 'Input',
+          dataType: 'string',
+          validation: { pattern: '[unclosed' },
+        },
+      ],
+    };
+    expect(FormConfigSchema.safeParse(cfg).success).toBe(false);
+  });
+
+  it('accepts a field with a valid regex pattern', () => {
+    const cfg = {
+      version: 1,
+      fields: [
+        {
+          key: 'test',
+          label: 'Test',
+          component: 'Input',
+          dataType: 'string',
+          validation: { pattern: '^[a-z]+$' },
+        },
+      ],
+    };
+    expect(FormConfigSchema.safeParse(cfg).success).toBe(true);
+  });
 });

--- a/packages/form-builder/src/config-schema.spec.ts
+++ b/packages/form-builder/src/config-schema.spec.ts
@@ -82,3 +82,63 @@ describe('grid layout fields', () => {
     expect(FormConfigSchema.safeParse({ version: 1, fields: [{ key: 'a', label: 'A', component: 'Input', dataType: 'string' }] }).success).toBe(true);
   });
 });
+
+describe('FieldValidation schema', () => {
+  const baseField = { key: 'x', label: 'X', component: 'Input', dataType: 'numeric' };
+
+  it('accepts a field with numeric min/max', () => {
+    const cfg = { version: 1, fields: [{ ...baseField, validation: { min: 0, max: 100 } }] };
+    expect(FormConfigSchema.safeParse(cfg).success).toBe(true);
+  });
+
+  it('accepts a field with string minLength/maxLength/pattern/message', () => {
+    const cfg = {
+      version: 1,
+      fields: [
+        {
+          key: 'zip',
+          label: 'Zip',
+          component: 'Input',
+          dataType: 'string',
+          validation: { minLength: 5, maxLength: 10, pattern: '^\\d+$', message: 'Invalid' },
+        },
+      ],
+    };
+    expect(FormConfigSchema.safeParse(cfg).success).toBe(true);
+  });
+
+  it('rejects non-numeric min', () => {
+    const cfg = { version: 1, fields: [{ ...baseField, validation: { min: 'zero' } }] };
+    expect(FormConfigSchema.safeParse(cfg).success).toBe(false);
+  });
+
+  it('rejects non-numeric max', () => {
+    const cfg = { version: 1, fields: [{ ...baseField, validation: { max: true } }] };
+    expect(FormConfigSchema.safeParse(cfg).success).toBe(false);
+  });
+
+  it('rejects non-numeric minLength', () => {
+    const cfg = { version: 1, fields: [{ ...baseField, validation: { minLength: '3' } }] };
+    expect(FormConfigSchema.safeParse(cfg).success).toBe(false);
+  });
+
+  it('rejects non-numeric maxLength', () => {
+    const cfg = { version: 1, fields: [{ ...baseField, validation: { maxLength: null } }] };
+    expect(FormConfigSchema.safeParse(cfg).success).toBe(false);
+  });
+
+  it('rejects non-string pattern', () => {
+    const cfg = { version: 1, fields: [{ ...baseField, validation: { pattern: 123 } }] };
+    expect(FormConfigSchema.safeParse(cfg).success).toBe(false);
+  });
+
+  it('accepts validation with no fields (all optional)', () => {
+    const cfg = { version: 1, fields: [{ ...baseField, validation: {} }] };
+    expect(FormConfigSchema.safeParse(cfg).success).toBe(true);
+  });
+
+  it('accepts a field without validation (backward compatible)', () => {
+    const cfg = { version: 1, fields: [{ ...baseField }] };
+    expect(FormConfigSchema.safeParse(cfg).success).toBe(true);
+  });
+});

--- a/packages/form-builder/src/config-schema.ts
+++ b/packages/form-builder/src/config-schema.ts
@@ -8,6 +8,15 @@ const fieldOptionSchema = z.object({
   value: z.union([z.string(), z.number()]),
 });
 
+const fieldValidationSchema = z.object({
+  min: z.number().optional(),
+  max: z.number().optional(),
+  minLength: z.number().optional(),
+  maxLength: z.number().optional(),
+  pattern: z.string().optional(),
+  message: z.string().optional(),
+});
+
 const fieldConfigSchema = z.object({
   key: z.string().min(1),
   label: z.union([z.string(), z.record(z.string(), z.string())]),
@@ -18,6 +27,7 @@ const fieldConfigSchema = z.object({
   defaultValue: z.unknown().optional(),
   options: z.array(fieldOptionSchema).optional(),
   width: z.enum(['full', 'half']).optional(),
+  validation: fieldValidationSchema.optional(),
 });
 
 export const FormConfigSchema: ZodType<FormConfig> = z.object({

--- a/packages/form-builder/src/config-schema.ts
+++ b/packages/form-builder/src/config-schema.ts
@@ -13,7 +13,20 @@ const fieldValidationSchema = z.object({
   max: z.number().optional(),
   minLength: z.number().optional(),
   maxLength: z.number().optional(),
-  pattern: z.string().optional(),
+  pattern: z
+    .string()
+    .refine(
+      (s) => {
+        try {
+          new RegExp(s);
+          return true;
+        } catch {
+          return false;
+        }
+      },
+      'Invalid regex pattern'
+    )
+    .optional(),
   message: z.string().optional(),
 });
 

--- a/packages/form-builder/src/config-to-zod.spec.ts
+++ b/packages/form-builder/src/config-to-zod.spec.ts
@@ -242,4 +242,26 @@ describe('configToZod — validation rules', () => {
     expect(schema.safeParse({ age: -5 }).success).toBe(false);
     expect(schema.safeParse({ age: 25 }).success).toBe(true);
   });
+
+  it('does not throw when given a field with an invalid regex pattern (defensive try/catch)', () => {
+    // Construct config directly, bypassing schema validation
+    const cfg: FormConfig = {
+      version: 1,
+      fields: [
+        {
+          key: 'test',
+          label: 'Test',
+          component: 'Input',
+          dataType: 'string',
+          required: true,
+          validation: { pattern: '[unclosed' }, // malformed regex
+        },
+      ],
+    };
+    // Should not throw; invalid pattern is skipped silently
+    expect(() => configToZod(cfg)).not.toThrow();
+    // Schema is still usable (just without the regex constraint)
+    const schema = configToZod(cfg);
+    expect(schema.safeParse({ test: 'anything' }).success).toBe(true);
+  });
 });

--- a/packages/form-builder/src/config-to-zod.spec.ts
+++ b/packages/form-builder/src/config-to-zod.spec.ts
@@ -83,3 +83,163 @@ describe('configToZod', () => {
     expect(schema.safeParse({ name: 'Ada', agree: false, role: 'ghost' }).success).toBe(false);
   });
 });
+
+describe('configToZod — validation rules', () => {
+  it('rejects a numeric value below min', () => {
+    const cfg: FormConfig = {
+      version: 1,
+      fields: [
+        {
+          key: 'age',
+          label: 'Age',
+          component: 'Input',
+          dataType: 'numeric',
+          required: true,
+          validation: { min: 0 },
+        },
+      ],
+    };
+    const schema = configToZod(cfg);
+    expect(schema.safeParse({ age: -1 }).success).toBe(false);
+    expect(schema.safeParse({ age: 0 }).success).toBe(true);
+  });
+
+  it('rejects a numeric value above max', () => {
+    const cfg: FormConfig = {
+      version: 1,
+      fields: [
+        {
+          key: 'score',
+          label: 'Score',
+          component: 'Input',
+          dataType: 'numeric',
+          required: true,
+          validation: { max: 100 },
+        },
+      ],
+    };
+    const schema = configToZod(cfg);
+    expect(schema.safeParse({ score: 101 }).success).toBe(false);
+    expect(schema.safeParse({ score: 100 }).success).toBe(true);
+  });
+
+  it('rejects a string shorter than minLength', () => {
+    const cfg: FormConfig = {
+      version: 1,
+      fields: [
+        {
+          key: 'name',
+          label: 'Name',
+          component: 'Input',
+          dataType: 'string',
+          required: true,
+          validation: { minLength: 3 },
+        },
+      ],
+    };
+    const schema = configToZod(cfg);
+    expect(schema.safeParse({ name: 'ab' }).success).toBe(false);
+    expect(schema.safeParse({ name: 'abc' }).success).toBe(true);
+  });
+
+  it('rejects a string longer than maxLength', () => {
+    const cfg: FormConfig = {
+      version: 1,
+      fields: [
+        {
+          key: 'code',
+          label: 'Code',
+          component: 'Input',
+          dataType: 'string',
+          required: true,
+          validation: { maxLength: 5 },
+        },
+      ],
+    };
+    const schema = configToZod(cfg);
+    expect(schema.safeParse({ code: 'toolong' }).success).toBe(false);
+    expect(schema.safeParse({ code: 'ok' }).success).toBe(true);
+  });
+
+  it('rejects a string not matching the pattern', () => {
+    const cfg: FormConfig = {
+      version: 1,
+      fields: [
+        {
+          key: 'zip',
+          label: 'Zip',
+          component: 'Input',
+          dataType: 'string',
+          required: true,
+          validation: { pattern: '^\\d{5}$' },
+        },
+      ],
+    };
+    const schema = configToZod(cfg);
+    expect(schema.safeParse({ zip: '1234' }).success).toBe(false);
+    expect(schema.safeParse({ zip: '12345' }).success).toBe(true);
+  });
+
+  it('surfaces a custom message when validation fails', () => {
+    const cfg: FormConfig = {
+      version: 1,
+      fields: [
+        {
+          key: 'age',
+          label: 'Age',
+          component: 'Input',
+          dataType: 'numeric',
+          required: true,
+          validation: { min: 18, message: 'Must be at least 18' },
+        },
+      ],
+    };
+    const schema = configToZod(cfg);
+    const result = schema.safeParse({ age: 10 });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const messages = result.error.issues.map((i) => i.message);
+      expect(messages.some((m) => m.includes('Must be at least 18'))).toBe(true);
+    }
+  });
+
+  it('optional field with validation still omits on empty string', () => {
+    const cfg: FormConfig = {
+      version: 1,
+      fields: [
+        {
+          key: 'age',
+          label: 'Age',
+          component: 'Input',
+          dataType: 'numeric',
+          validation: { min: 0, max: 120 },
+        },
+      ],
+    };
+    const schema = configToZod(cfg);
+    // empty string → undefined (omitted), not a validation failure
+    const result = schema.safeParse({ age: '' });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.age).toBeUndefined();
+    }
+  });
+
+  it('optional field with validation still validates present values', () => {
+    const cfg: FormConfig = {
+      version: 1,
+      fields: [
+        {
+          key: 'age',
+          label: 'Age',
+          component: 'Input',
+          dataType: 'numeric',
+          validation: { min: 0, max: 120 },
+        },
+      ],
+    };
+    const schema = configToZod(cfg);
+    expect(schema.safeParse({ age: -5 }).success).toBe(false);
+    expect(schema.safeParse({ age: 25 }).success).toBe(true);
+  });
+});

--- a/packages/form-builder/src/config-to-zod.ts
+++ b/packages/form-builder/src/config-to-zod.ts
@@ -45,7 +45,13 @@ function applyValidation(base: z.ZodTypeAny, field: FieldConfig): z.ZodTypeAny {
     let strBase = base as z.ZodString;
     if (v.minLength !== undefined) strBase = strBase.min(v.minLength, v.message);
     if (v.maxLength !== undefined) strBase = strBase.max(v.maxLength, v.message);
-    if (v.pattern !== undefined) strBase = strBase.regex(new RegExp(v.pattern), v.message);
+    if (v.pattern !== undefined) {
+      try {
+        strBase = strBase.regex(new RegExp(v.pattern), v.message);
+      } catch {
+        // invalid regex source — skip it silently rather than throwing
+      }
+    }
     return strBase;
   }
 

--- a/packages/form-builder/src/config-to-zod.ts
+++ b/packages/form-builder/src/config-to-zod.ts
@@ -27,8 +27,34 @@ function baseForField(field: FieldConfig): z.ZodTypeAny {
   }
 }
 
+/** Apply FieldValidation constraints to the base schema before required/optional wrap. */
+function applyValidation(base: z.ZodTypeAny, field: FieldConfig): z.ZodTypeAny {
+  const v = field.validation;
+  if (!v) return base;
+
+  // Numeric bounds — only for numeric fields with a numeric base (not options/enum)
+  if (field.dataType === 'numeric' && !field.options?.length) {
+    let numBase = base as z.ZodNumber;
+    if (v.min !== undefined) numBase = numBase.min(v.min, v.message);
+    if (v.max !== undefined) numBase = numBase.max(v.max, v.message);
+    return numBase;
+  }
+
+  // String length + pattern — only for string/date fields without options
+  if ((field.dataType === 'string' || field.dataType === 'date') && !field.options?.length) {
+    let strBase = base as z.ZodString;
+    if (v.minLength !== undefined) strBase = strBase.min(v.minLength, v.message);
+    if (v.maxLength !== undefined) strBase = strBase.max(v.maxLength, v.message);
+    if (v.pattern !== undefined) strBase = strBase.regex(new RegExp(v.pattern), v.message);
+    return strBase;
+  }
+
+  return base;
+}
+
 function fieldSchema(field: FieldConfig): z.ZodTypeAny {
-  const base = baseForField(field);
+  const rawBase = baseForField(field);
+  const base = applyValidation(rawBase, field);
   if (field.required) {
     // enum already rejects invalid values including ''
     if (field.options?.length) return base;

--- a/packages/form-builder/src/config-to-zod.ts
+++ b/packages/form-builder/src/config-to-zod.ts
@@ -65,7 +65,7 @@ function fieldSchema(field: FieldConfig): z.ZodTypeAny {
     // enum already rejects invalid values including ''
     if (field.options?.length) return base;
     if (field.dataType === 'string' || field.dataType === 'date')
-      return (base as z.ZodString).min(1);
+      return (base as z.ZodString).min(1, field.validation?.message);
     // '' -> undefined -> number rejects (required empty fails)
     if (field.dataType === 'numeric') return z.preprocess(emptyToUndefined, base);
     // boolean / object / array

--- a/packages/form-builder/src/types.ts
+++ b/packages/form-builder/src/types.ts
@@ -15,6 +15,17 @@ export interface FieldOption {
   value: string | number;
 }
 
+export interface FieldValidation {
+  min?: number;
+  max?: number;
+  minLength?: number;
+  maxLength?: number;
+  /** Regex source string — applied to string fields via `new RegExp(pattern)`. */
+  pattern?: string;
+  /** Custom error message passed to zod on validation failure. */
+  message?: string;
+}
+
 export interface FieldConfig {
   key: string;
   label: LocalizedLabel;
@@ -25,6 +36,7 @@ export interface FieldConfig {
   defaultValue?: unknown;
   options?: FieldOption[];
   width?: FieldWidth;
+  validation?: FieldValidation;
 }
 
 export interface FormConfig {


### PR DESCRIPTION
## What

**v2-B — field validation rules** for the config-driven form builder. This is the **validation half** of the planned "rules" group; **conditional display (v2-C, data-filter)** lands as a follow-up PR on a fresh branch.

- **Engine — `FieldConfig.validation`** (`@rfjs/form-builder`): new optional `FieldValidation { min, max, minLength, maxLength, pattern, message }`. `configToZod` applies these to each field's base schema *before* the required/optional wrap, so the existing empty→undefined optional handling is preserved:
  - numeric → `.min/.max` (only for numeric fields without `options`)
  - string / date → `.min/.max` (length) + `.regex(new RegExp(pattern))` (only without `options`)
  - `message` becomes the zod error message; threaded into the required `min(1)` guard too.
  - **Hardening:** an invalid `pattern` can't crash schema construction — the config schema `refine`s `pattern` to a valid regex, and `config-to-zod` wraps `new RegExp` in try/catch (skips a bad pattern rather than throwing, important for the JSON-config tab).
- **Renderer — validation messages** (`<ConfigForm>`): each field renders `errors[field.key]?.message` as `<p className="text-xs text-destructive">` on submit; reactive-preview behaviour from v2-A is unchanged.
- **Builder — Validation editor** (`<FieldRow>`): a Validation sub-block in the expanded property editor with `dataType`-aware inputs (numeric → min/max; string/date → minLength/maxLength/pattern; `message` shown only when a constraint block applies). Edits merge via `onUpdate({ validation: { ...field.validation, [k]: v } })`; empty/`NaN` input **clears** the key (never stores `NaN` or `''`). Fields with `options` (enum/Select) and boolean/object/array correctly show no bounds (the engine ignores them there).

## Testing

- `@rfjs/form-builder` (engine): **49** tests — `config-to-zod` validation (numeric/length/pattern reject, `message` surfaces, optional-with-validation still omits on empty, invalid-regex defensive) + `config-schema` validation-shape + regex refine. Build emits the new `FieldValidation` types cleanly.
- `@rfjs/form-builder-ui`: **57** tests — `ConfigForm` message rendering (invalid→shows, valid→none), `FieldRow` ValidationEditor (merge, clear, NaN-guard, options/dataType gating). `tsc --noEmit` clean.
- TDD throughout; each task got a per-task spec+quality review (T2 SHIP; T3 review found a `NaN`-write and an enum-gating gap, both fixed in `17a9223`).

## Scope / follow-ups

- **v2-C conditional display** (engine `evaluateConditional` via `@rfjs/data-filter`'s **sync** `matchQuery` + `<ConfigForm>` show/hide + `<FieldRow>` conditional editor) — next PR.
- No changeset added (consistent with the rest of the form-builder effort; release/versioning is a deferred decision; `@rfjs/form-builder-ui` is private).
- Minor a11y follow-up tracked: the error `<p>` isn't yet linked to its control via `aria-describedby` (out of scope here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
