### PR TITLE
feat(form-builder): conditional field display (v2-C)

### DIFF
--- a/packages/form-builder-ui/src/config-form-builder.tsx
+++ b/packages/form-builder-ui/src/config-form-builder.tsx
@@ -16,7 +16,7 @@ import { Button } from '@rfjs/web-ui/components/button';
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@rfjs/web-ui/components/select';
 
 import { useConfigBuilder } from './use-config-builder';
-import { FieldRow, makeField } from './field-row';
+import { FieldRow, makeField, labelOf } from './field-row';
 import { ConfigForm } from './config-form';
 
 const PALETTE: FieldComponent[] = ['Input', 'Textarea', 'Select', 'Checkbox', 'Date'];
@@ -127,6 +127,9 @@ export function ConfigFormBuilder({ initialConfig = EMPTY, onChange, locale = 'e
                         locales={locales}
                         onUpdate={(patch) => builder.update(field.key, patch)}
                         onRemove={() => builder.remove(field.key)}
+                        siblingFields={builder.config.fields
+                          .filter((f) => f.key !== field.key && ['string', 'numeric', 'date', 'boolean'].includes(f.dataType))
+                          .map((f) => ({ key: f.key, label: labelOf(f.label), dataType: f.dataType }))}
                       />
                     ))
                   )}

--- a/packages/form-builder-ui/src/config-form.spec.tsx
+++ b/packages/form-builder-ui/src/config-form.spec.tsx
@@ -149,6 +149,120 @@ describe('field validation messages', () => {
   });
 });
 
+describe('conditional show/hide', () => {
+  // Controlling field is a plain text Input so fireEvent.change works in jsdom
+  const conditionalConfig: FormConfig = {
+    version: 1,
+    fields: [
+      { key: 'role', label: 'Role', component: 'Input', dataType: 'string' },
+      {
+        key: 'adminCode',
+        label: 'Admin Code',
+        component: 'Input',
+        dataType: 'string',
+        conditional: {
+          logic: 'and',
+          filters: [{ field: 'role', dataType: 'string', operator: 'eq', value: 'admin' }],
+        },
+      },
+    ],
+  };
+
+  it('hides a conditional field when the controlling field does not satisfy the rule', () => {
+    render(<ConfigForm config={conditionalConfig} onSubmit={() => {}} />);
+    // role is empty → adminCode should not be in the DOM
+    expect(screen.queryByLabelText('Admin Code')).toBeNull();
+  });
+
+  it('shows the conditional field when the controlling field satisfies the rule', async () => {
+    render(<ConfigForm config={conditionalConfig} onSubmit={() => {}} />);
+    fireEvent.change(screen.getByRole('textbox', { name: 'Role' }), { target: { value: 'admin' } });
+    await waitFor(() => expect(screen.getByLabelText('Admin Code')).toBeTruthy());
+  });
+
+  it('hides the conditional field again when the controlling field changes away from the trigger value', async () => {
+    render(<ConfigForm config={conditionalConfig} onSubmit={() => {}} />);
+    const roleInput = screen.getByRole('textbox', { name: 'Role' });
+    fireEvent.change(roleInput, { target: { value: 'admin' } });
+    await waitFor(() => expect(screen.getByLabelText('Admin Code')).toBeTruthy());
+    fireEvent.change(roleInput, { target: { value: 'user' } });
+    await waitFor(() => expect(screen.queryByLabelText('Admin Code')).toBeNull());
+  });
+
+  it('does not block submit when a hidden required field is empty', async () => {
+    const requiredConditionalConfig: FormConfig = {
+      version: 1,
+      fields: [
+        { key: 'role', label: 'Role', component: 'Input', dataType: 'string' },
+        {
+          key: 'adminCode',
+          label: 'Admin Code',
+          component: 'Input',
+          dataType: 'string',
+          required: true,
+          conditional: {
+            logic: 'and',
+            filters: [{ field: 'role', dataType: 'string', operator: 'eq', value: 'admin' }],
+          },
+        },
+      ],
+    };
+    const onSubmit = vi.fn();
+    render(<ConfigForm config={requiredConditionalConfig} onSubmit={onSubmit} />);
+    // role !== 'admin' → adminCode hidden; even though it's required, submit should succeed
+    fireEvent.click(screen.getByRole('button', { name: /submit/i }));
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledOnce());
+  });
+
+  it('blocks submit when a visible required conditional field is empty', async () => {
+    const requiredConditionalConfig: FormConfig = {
+      version: 1,
+      fields: [
+        { key: 'role', label: 'Role', component: 'Input', dataType: 'string' },
+        {
+          key: 'adminCode',
+          label: 'Admin Code',
+          component: 'Input',
+          dataType: 'string',
+          required: true,
+          conditional: {
+            logic: 'and',
+            filters: [{ field: 'role', dataType: 'string', operator: 'eq', value: 'admin' }],
+          },
+        },
+      ],
+    };
+    const onSubmit = vi.fn();
+    render(<ConfigForm config={requiredConditionalConfig} onSubmit={onSubmit} />);
+    // Make adminCode visible by setting role = 'admin'
+    fireEvent.change(screen.getByRole('textbox', { name: 'Role' }), { target: { value: 'admin' } });
+    await waitFor(() => expect(screen.getByLabelText('Admin Code')).toBeTruthy());
+    // Submit without filling adminCode → should be blocked
+    fireEvent.click(screen.getByRole('button', { name: /submit/i }));
+    await waitFor(() => expect(onSubmit).not.toHaveBeenCalled());
+  });
+
+  it('strips hidden field values from the submit payload', async () => {
+    const onSubmit = vi.fn();
+    render(<ConfigForm config={conditionalConfig} onSubmit={onSubmit} />);
+    const roleInput = screen.getByRole('textbox', { name: 'Role' });
+    // Make adminCode visible and fill it
+    fireEvent.change(roleInput, { target: { value: 'admin' } });
+    await waitFor(() => expect(screen.getByLabelText('Admin Code')).toBeTruthy());
+    fireEvent.change(screen.getByRole('textbox', { name: 'Admin Code' }), { target: { value: 'secret' } });
+    // Now hide it by changing role
+    fireEvent.change(roleInput, { target: { value: 'user' } });
+    await waitFor(() => expect(screen.queryByLabelText('Admin Code')).toBeNull());
+    // Submit → payload should NOT contain adminCode
+    fireEvent.click(screen.getByRole('button', { name: /submit/i }));
+    await waitFor(() =>
+      expect(onSubmit).toHaveBeenCalledWith(
+        expect.not.objectContaining({ adminCode: expect.anything() }),
+      ),
+    );
+  });
+});
+
 describe('grid layout', () => {
   const gridConfig: FormConfig = {
     version: 1,

--- a/packages/form-builder-ui/src/config-form.tsx
+++ b/packages/form-builder-ui/src/config-form.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import * as React from 'react';
-import { Controller, useForm } from 'react-hook-form';
+import { Controller, useForm, type Resolver } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { configToZod, resolveLabel, type FormConfig } from '@rfjs/form-builder';
+import { configToZod, evaluateConditional, resolveLabel, type FormConfig } from '@rfjs/form-builder';
 import { Label } from '@rfjs/web-ui/components/label';
 import { Button } from '@rfjs/web-ui/components/button';
 
@@ -24,26 +24,46 @@ export interface ConfigFormProps {
 }
 
 export function ConfigForm({ config, defaultValues, onSubmit, submitLabel = 'Submit', locale = 'en' }: ConfigFormProps) {
-  const resolver = React.useMemo(() => zodResolver(configToZod(config)), [config]);
-  const { control, handleSubmit, reset, formState: { errors } } = useForm({ resolver, defaultValues });
+  // Keep the latest config reachable inside the stable resolver without re-creating it.
+  const configRef = React.useRef(config);
+  configRef.current = config;
+
+  // A single STABLE resolver passed once to useForm. RHF calls it at validation time with the
+  // current values; it builds the zod schema over ONLY the fields visible for those values, so
+  // hidden (e.g. required) fields never block submit. No private internals, no resolver swapping.
+  const resolver = React.useCallback<Resolver>((values, ctx, opts) => {
+    const cfg = configRef.current;
+    const visible = cfg.fields.filter((f) => evaluateConditional(f.conditional, values as Record<string, unknown>));
+    return zodResolver(configToZod({ ...cfg, fields: visible }))(values, ctx, opts);
+  }, []);
+
+  const { control, handleSubmit, reset, watch, formState: { errors } } = useForm({ resolver, defaultValues });
 
   // Re-initialise form state when `config` changes so stale field values are cleared.
-  // RHF v7 already picks up the new resolver reference on each validation call via _options,
-  // so only a reset of values is needed (not a full remount).
   React.useEffect(() => {
     reset(defaultValues ?? {});
   }, [config]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Subscribe to all form values to decide which fields to RENDER (live show/hide).
+  const values = watch();
+  const visibleFields = config.fields.filter((f) => evaluateConditional(f.conditional, values as Record<string, unknown>));
 
   const columns = config.columns ?? 1;
 
   return (
     <form
-      onSubmit={handleSubmit((values) => onSubmit(values as Record<string, unknown>))}
+      onSubmit={handleSubmit((all) => {
+        // Strip hidden fields' values from the submit payload.
+        const visible = config.fields.filter((f) => evaluateConditional(f.conditional, all as Record<string, unknown>));
+        const keys = new Set(visible.map((f) => f.key));
+        const out = Object.fromEntries(Object.entries(all).filter(([k]) => keys.has(k)));
+        onSubmit(out as Record<string, unknown>);
+      })}
       className="grid grid-cols-1 gap-4 md:[grid-template-columns:repeat(var(--form-cols),minmax(0,1fr))]"
       style={{ '--form-cols': String(columns) } as React.CSSProperties}
       data-columns={columns}
     >
-      {config.fields.map((field) => {
+      {visibleFields.map((field) => {
         const width = field.width ?? 'full';
         return (
           <div

--- a/packages/form-builder-ui/src/field-row.spec.tsx
+++ b/packages/form-builder-ui/src/field-row.spec.tsx
@@ -25,8 +25,21 @@ import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { DndContext } from '@dnd-kit/core';
 import { SortableContext } from '@dnd-kit/sortable';
-import { FieldRow, makeField, mergeValidation } from './field-row';
-import type { FieldConfig } from '@rfjs/form-builder';
+import {
+  FieldRow,
+  makeField,
+  mergeValidation,
+  operatorsFor,
+  coerceConditionValue,
+  defaultCondition,
+  addCondition,
+  removeCondition,
+  setConditionField,
+  setConditionOperator,
+  setConditionValue,
+  type SiblingField,
+} from './field-row';
+import type { FieldConfig, ConditionalRule } from '@rfjs/form-builder';
 
 function renderRow(field: FieldConfig, onUpdate = vi.fn(), onRemove = vi.fn()) {
   render(
@@ -71,7 +84,8 @@ describe('FieldRow', () => {
   });
   it('toggles required', () => {
     const { onUpdate } = renderRow(base);
-    fireEvent.click(screen.getByRole('checkbox'));
+    // Use the label text to target the correct checkbox now that there are two (required + conditional)
+    fireEvent.click(screen.getByRole('checkbox', { name: /required/i }));
     expect(onUpdate).toHaveBeenCalledWith({ required: true });
   });
   it('removes the field', () => {
@@ -239,5 +253,254 @@ describe('mergeValidation', () => {
   it('stores a string for a string key and clears it on empty', () => {
     expect(mergeValidation(undefined, 'pattern', '^x$', false)).toEqual({ pattern: '^x$' });
     expect(mergeValidation({ pattern: '^x$' }, 'pattern', '', false)).toEqual({});
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Conditional helpers — pure unit tests
+// ---------------------------------------------------------------------------
+
+const strSibling: SiblingField = { key: 'name', label: 'Name', dataType: 'string' };
+const numSibling: SiblingField = { key: 'age', label: 'Age', dataType: 'numeric' };
+const boolSibling: SiblingField = { key: 'active', label: 'Active', dataType: 'boolean' };
+const dateSibling: SiblingField = { key: 'dob', label: 'DOB', dataType: 'date' };
+
+describe('operatorsFor', () => {
+  it('returns string operators for string dataType', () => {
+    expect(operatorsFor('string')).toEqual(['eq', 'neq', 'contains', 'startswith', 'endswith']);
+  });
+  it('returns numeric operators for numeric dataType', () => {
+    expect(operatorsFor('numeric')).toEqual(['eq', 'neq', 'gt', 'gte', 'lt', 'lte']);
+  });
+  it('returns numeric operators for date dataType', () => {
+    expect(operatorsFor('date')).toEqual(['eq', 'neq', 'gt', 'gte', 'lt', 'lte']);
+  });
+  it('returns boolean operators for boolean dataType', () => {
+    expect(operatorsFor('boolean')).toEqual(['eq', 'neq']);
+  });
+});
+
+describe('coerceConditionValue', () => {
+  it('coerces a valid numeric string to number', () => {
+    expect(coerceConditionValue('42', 'numeric')).toBe(42);
+  });
+  it('returns empty string for empty numeric input', () => {
+    expect(coerceConditionValue('', 'numeric')).toBe('');
+  });
+  it('returns empty string for NaN-producing numeric input (does not store NaN)', () => {
+    expect(coerceConditionValue('abc', 'numeric')).toBe('');
+  });
+  it('coerces "true" string to boolean true', () => {
+    expect(coerceConditionValue('true', 'boolean')).toBe(true);
+  });
+  it('coerces anything else to boolean false for boolean dataType', () => {
+    expect(coerceConditionValue('false', 'boolean')).toBe(false);
+    expect(coerceConditionValue('yes', 'boolean')).toBe(false);
+  });
+  it('returns raw string for string dataType', () => {
+    expect(coerceConditionValue('hello', 'string')).toBe('hello');
+  });
+  it('returns raw string for date dataType', () => {
+    expect(coerceConditionValue('2024-01-01', 'date')).toBe('2024-01-01');
+  });
+});
+
+describe('defaultCondition', () => {
+  it('creates a condition with operator eq and empty value', () => {
+    expect(defaultCondition(strSibling)).toEqual({ field: 'name', dataType: 'string', operator: 'eq', value: '' });
+  });
+});
+
+describe('addCondition', () => {
+  it('creates a new group when called with undefined', () => {
+    const result = addCondition(undefined, strSibling);
+    expect(result.logic).toBe('and');
+    expect(result.filters).toHaveLength(1);
+  });
+  it('appends a condition to an existing group', () => {
+    const group: ConditionalRule = { logic: 'and', filters: [defaultCondition(strSibling) as never] };
+    const result = addCondition(group, numSibling);
+    expect(result.filters).toHaveLength(2);
+  });
+  it('preserves the logic of an existing group', () => {
+    const group: ConditionalRule = { logic: 'or', filters: [] };
+    expect(addCondition(group, strSibling).logic).toBe('or');
+  });
+});
+
+describe('removeCondition', () => {
+  it('removes a condition row at the given index', () => {
+    const group: ConditionalRule = {
+      logic: 'and',
+      filters: [defaultCondition(strSibling) as never, defaultCondition(numSibling) as never],
+    };
+    const result = removeCondition(group, 0);
+    expect(result.filters).toHaveLength(1);
+    expect((result.filters[0] as { field: string }).field).toBe('age');
+  });
+});
+
+describe('setConditionField', () => {
+  it('sets the field+dataType and resets operator to eq and clears value', () => {
+    const group: ConditionalRule = {
+      logic: 'and',
+      filters: [{ field: 'name', dataType: 'string', operator: 'contains', value: 'foo' } as never],
+    };
+    const result = setConditionField(group, 0, numSibling);
+    const row = result.filters[0] as { field: string; dataType: string; operator: string; value: string };
+    expect(row.field).toBe('age');
+    expect(row.dataType).toBe('numeric');
+    expect(row.operator).toBe('eq');
+    expect(row.value).toBe('');
+  });
+});
+
+describe('setConditionOperator', () => {
+  it('changes only the operator of the given row', () => {
+    const group: ConditionalRule = {
+      logic: 'and',
+      filters: [{ field: 'name', dataType: 'string', operator: 'eq', value: '' } as never],
+    };
+    const result = setConditionOperator(group, 0, 'contains');
+    expect((result.filters[0] as { operator: string }).operator).toBe('contains');
+  });
+});
+
+describe('setConditionValue', () => {
+  it('stores a numeric value as a number', () => {
+    const group: ConditionalRule = {
+      logic: 'and',
+      filters: [{ field: 'age', dataType: 'numeric', operator: 'gt', value: 0 } as never],
+    };
+    const result = setConditionValue(group, 0, '30', 'numeric');
+    expect((result.filters[0] as { value: number }).value).toBe(30);
+  });
+  it('stores empty string (not NaN) for a non-numeric raw value on numeric field', () => {
+    const group: ConditionalRule = {
+      logic: 'and',
+      filters: [{ field: 'age', dataType: 'numeric', operator: 'gt', value: 0 } as never],
+    };
+    const result = setConditionValue(group, 0, 'abc', 'numeric');
+    expect((result.filters[0] as { value: unknown }).value).toBe('');
+  });
+  it('stores a boolean value for boolean dataType', () => {
+    const group: ConditionalRule = {
+      logic: 'and',
+      filters: [{ field: 'active', dataType: 'boolean', operator: 'eq', value: false } as never],
+    };
+    const result = setConditionValue(group, 0, 'true', 'boolean');
+    expect((result.filters[0] as { value: boolean }).value).toBe(true);
+  });
+  it('stores raw string for string dataType', () => {
+    const group: ConditionalRule = {
+      logic: 'and',
+      filters: [{ field: 'name', dataType: 'string', operator: 'eq', value: '' } as never],
+    };
+    const result = setConditionValue(group, 0, 'Alice', 'string');
+    expect((result.filters[0] as { value: string }).value).toBe('Alice');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ConditionalEditor — component tests (driveable parts)
+// ---------------------------------------------------------------------------
+
+function renderRowWithSiblings(
+  field: FieldConfig,
+  siblingFields: SiblingField[],
+  onUpdate = vi.fn(),
+  onRemove = vi.fn(),
+) {
+  render(
+    <DndContext>
+      <SortableContext items={[field.key]}>
+        <FieldRow field={field} onUpdate={onUpdate} onRemove={onRemove} siblingFields={siblingFields} />
+      </SortableContext>
+    </DndContext>,
+  );
+  return { onUpdate, onRemove };
+}
+
+const siblings: SiblingField[] = [
+  { key: 'country', label: 'Country', dataType: 'string' },
+  { key: 'score', label: 'Score', dataType: 'numeric' },
+];
+
+describe('ConditionalEditor — Checkbox toggle', () => {
+  it('checking the checkbox calls onUpdate with an empty conditional group', () => {
+    const field: FieldConfig = { key: 'city', label: 'City', component: 'Input', dataType: 'string' };
+    const { onUpdate } = renderRowWithSiblings(field, siblings);
+    // "required" checkbox is first; "enable conditional display" is second
+    const conditionalCheckbox = screen.getByLabelText('enable conditional display');
+    fireEvent.click(conditionalCheckbox);
+    expect(onUpdate).toHaveBeenCalledWith({ conditional: { logic: 'and', filters: [] } });
+  });
+
+  it('unchecking the checkbox calls onUpdate with conditional: undefined', () => {
+    const field: FieldConfig = {
+      key: 'city', label: 'City', component: 'Input', dataType: 'string',
+      conditional: { logic: 'and', filters: [] },
+    };
+    const { onUpdate } = renderRowWithSiblings(field, siblings);
+    const conditionalCheckbox = screen.getByLabelText('enable conditional display');
+    fireEvent.click(conditionalCheckbox);
+    expect(onUpdate).toHaveBeenCalledWith({ conditional: undefined });
+  });
+});
+
+describe('ConditionalEditor — condition rows', () => {
+  const fieldWithCond: FieldConfig = {
+    key: 'city',
+    label: 'City',
+    component: 'Input',
+    dataType: 'string',
+    conditional: {
+      logic: 'and',
+      filters: [{ field: 'country', dataType: 'string', operator: 'eq', value: 'US' } as never],
+    },
+  };
+
+  it('renders the field select trigger with the current field value', () => {
+    renderRowWithSiblings(fieldWithCond, siblings);
+    const trigger = screen.getByLabelText('condition 0 field');
+    expect(trigger.textContent).toContain('Country');
+  });
+
+  it('renders the operator select trigger with the current operator', () => {
+    renderRowWithSiblings(fieldWithCond, siblings);
+    const trigger = screen.getByLabelText('condition 0 operator');
+    expect(trigger.textContent).toContain('eq');
+  });
+
+  it('editing the value input calls onUpdate with the updated group', () => {
+    const { onUpdate } = renderRowWithSiblings(fieldWithCond, siblings);
+    fireEvent.change(screen.getByLabelText('condition 0 value'), { target: { value: 'CA' } });
+    expect(onUpdate).toHaveBeenCalledWith({
+      conditional: {
+        logic: 'and',
+        filters: [{ field: 'country', dataType: 'string', operator: 'eq', value: 'CA' }],
+      },
+    });
+  });
+
+  it('clicking remove condition calls onUpdate with the condition removed', () => {
+    const { onUpdate } = renderRowWithSiblings(fieldWithCond, siblings);
+    fireEvent.click(screen.getByLabelText('remove condition 0'));
+    expect(onUpdate).toHaveBeenCalledWith({ conditional: { logic: 'and', filters: [] } });
+  });
+
+  it('clicking "+ Add condition" calls onUpdate appending a new condition', () => {
+    const field: FieldConfig = {
+      key: 'city', label: 'City', component: 'Input', dataType: 'string',
+      conditional: { logic: 'and', filters: [] },
+    };
+    const { onUpdate } = renderRowWithSiblings(field, siblings);
+    fireEvent.click(screen.getByRole('button', { name: /add condition/i }));
+    expect(onUpdate).toHaveBeenCalledWith({
+      conditional: {
+        logic: 'and',
+        filters: [{ field: 'country', dataType: 'string', operator: 'eq', value: '' }],
+      },
+    });
   });
 });

--- a/packages/form-builder-ui/src/field-row.tsx
+++ b/packages/form-builder-ui/src/field-row.tsx
@@ -519,6 +519,7 @@ export function FieldRow({ field, onUpdate, onRemove, locales = ['en'], siblingF
           </span>
           <label className="flex items-center gap-1.5 self-end text-xs text-muted-foreground">
             <Checkbox
+              aria-label="required"
               checked={Boolean(field.required)}
               onCheckedChange={(c) => onUpdate({ required: c === true })}
             />

--- a/packages/form-builder-ui/src/field-row.tsx
+++ b/packages/form-builder-ui/src/field-row.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { ChevronDown, ChevronRight, GripVertical, Trash2 } from 'lucide-react';
-import type { FieldComponent, FieldConfig, FieldOption, FieldValidation, FieldWidth } from '@rfjs/form-builder';
+import type { FieldComponent, FieldConfig, FieldOption, FieldValidation, FieldWidth, ConditionalRule } from '@rfjs/form-builder';
 import { Input } from '@rfjs/web-ui/components/input';
 import { Checkbox } from '@rfjs/web-ui/components/checkbox';
 import { Button } from '@rfjs/web-ui/components/button';
@@ -20,7 +20,7 @@ const DATATYPE_BY_COMPONENT: Record<FieldComponent, FieldConfig['dataType']> = {
 
 const COMPONENTS: FieldComponent[] = ['Input', 'Textarea', 'Select', 'Checkbox', 'Date'];
 
-function labelOf(label: FieldConfig['label']): string {
+export function labelOf(label: FieldConfig['label']): string {
   return typeof label === 'string' ? label : (Object.values(label)[0] ?? '');
 }
 
@@ -201,6 +201,201 @@ function ValidationEditor({ field, onUpdate }: { field: FieldConfig; onUpdate: (
   );
 }
 
+// ---------------------------------------------------------------------------
+// Conditional display — pure helpers (exported for direct unit-testing)
+// ---------------------------------------------------------------------------
+
+/** A sibling field descriptor used to populate the condition-row field select. */
+export type SiblingField = { key: string; label: string; dataType: FieldConfig['dataType'] };
+
+/** Operators available per scalar dataType. */
+export function operatorsFor(dataType: FieldConfig['dataType']): string[] {
+  if (dataType === 'numeric' || dataType === 'date') {
+    return ['eq', 'neq', 'gt', 'gte', 'lt', 'lte'];
+  }
+  if (dataType === 'boolean') {
+    return ['eq', 'neq'];
+  }
+  // string (default)
+  return ['eq', 'neq', 'contains', 'startswith', 'endswith'];
+}
+
+/**
+ * Coerce a raw string value from an <Input> to the correct JS type for the given dataType.
+ * numeric → Number (NaN → '' rather than storing NaN); boolean → `raw === 'true'`; string/date → raw.
+ */
+export function coerceConditionValue(raw: string, dataType: FieldConfig['dataType']): string | number | boolean {
+  if (dataType === 'numeric') {
+    if (raw === '') return '';
+    const n = Number(raw);
+    return Number.isNaN(n) ? '' : n;
+  }
+  if (dataType === 'boolean') {
+    return raw === 'true';
+  }
+  return raw;
+}
+
+/** Build a fresh condition row for a given sibling field. */
+export function defaultCondition(sibling: SiblingField): { field: string; dataType: FieldConfig['dataType']; operator: string; value: string | number | boolean } {
+  return { field: sibling.key, dataType: sibling.dataType, operator: 'eq', value: '' };
+}
+
+/** Append a new condition row for `sibling` to the group (or create the group). */
+export function addCondition(
+  group: ConditionalRule | undefined,
+  sibling: SiblingField,
+): ConditionalRule {
+  const base = group ?? { logic: 'and' as const, filters: [] };
+  return { ...base, filters: [...base.filters, defaultCondition(sibling) as never] };
+}
+
+/** Remove condition row at index `i`. */
+export function removeCondition(group: ConditionalRule, i: number): ConditionalRule {
+  return { ...group, filters: group.filters.filter((_, j) => j !== i) };
+}
+
+/** Change the field + dataType for condition row `i`; resets operator to `eq` and clears value. */
+export function setConditionField(group: ConditionalRule, i: number, sibling: SiblingField): ConditionalRule {
+  return {
+    ...group,
+    filters: group.filters.map((f, j) =>
+      j === i ? { field: sibling.key, dataType: sibling.dataType, operator: 'eq', value: '' } as never : f,
+    ),
+  };
+}
+
+/** Change the operator for condition row `i`. */
+export function setConditionOperator(group: ConditionalRule, i: number, op: string): ConditionalRule {
+  return {
+    ...group,
+    filters: group.filters.map((f, j) =>
+      j === i ? { ...(f as object), operator: op } as never : f,
+    ),
+  };
+}
+
+/** Change the value for condition row `i`, coercing by dataType. */
+export function setConditionValue(group: ConditionalRule, i: number, raw: string, dataType: FieldConfig['dataType']): ConditionalRule {
+  return {
+    ...group,
+    filters: group.filters.map((f, j) =>
+      j === i ? { ...(f as object), value: coerceConditionValue(raw, dataType) } as never : f,
+    ),
+  };
+}
+
+// A loose leaf shape used only inside this editor (not the full discriminated union).
+type ConditionRow = { field: string; dataType: FieldConfig['dataType']; operator: string; value: string | number | boolean };
+
+function ConditionalEditor({
+  field,
+  siblingFields,
+  onUpdate,
+}: {
+  field: FieldConfig;
+  siblingFields: SiblingField[];
+  onUpdate: (patch: Partial<FieldConfig>) => void;
+}) {
+  const enabled = Boolean(field.conditional);
+  const group = field.conditional;
+
+  function toggle(checked: boolean | 'indeterminate') {
+    if (checked === true) {
+      onUpdate({ conditional: { logic: 'and', filters: [] } });
+    } else {
+      onUpdate({ conditional: undefined });
+    }
+  }
+
+  const rows = (group?.filters ?? []) as ConditionRow[];
+
+  return (
+    <div className="col-span-full flex flex-col gap-2">
+      <label className="flex items-center gap-1.5 text-xs text-muted-foreground">
+        <Checkbox
+          aria-label="enable conditional display"
+          checked={enabled}
+          onCheckedChange={toggle}
+        />
+        Only show when conditions match
+      </label>
+      {enabled && group ? (
+        <div className="flex flex-col gap-2 pl-5">
+          {rows.map((row, i) => {
+            const ops = operatorsFor(row.dataType ?? 'string');
+            return (
+              <div key={i} className="flex flex-wrap items-center gap-2">
+                {/* Field select */}
+                <Select
+                  value={row.field}
+                  onValueChange={(v) => {
+                    const sib = siblingFields.find((s) => s.key === v);
+                    if (sib) onUpdate({ conditional: setConditionField(group, i, sib) });
+                  }}
+                >
+                  <SelectTrigger className="h-8 min-w-[120px]" aria-label={`condition ${i} field`}>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {siblingFields.map((s) => (
+                      <SelectItem key={s.key} value={s.key}>{s.label}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                {/* Operator select */}
+                <Select
+                  value={row.operator}
+                  onValueChange={(v) => onUpdate({ conditional: setConditionOperator(group, i, v) })}
+                >
+                  <SelectTrigger className="h-8 min-w-[100px]" aria-label={`condition ${i} operator`}>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {ops.map((op) => (
+                      <SelectItem key={op} value={op}>{op}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                {/* Value input */}
+                <Input
+                  className="h-8 min-w-[100px] flex-1"
+                  aria-label={`condition ${i} value`}
+                  value={String(row.value)}
+                  onChange={(e) => onUpdate({ conditional: setConditionValue(group, i, e.target.value, row.dataType ?? 'string') })}
+                />
+                {/* Remove button */}
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  aria-label={`remove condition ${i}`}
+                  onClick={() => onUpdate({ conditional: removeCondition(group, i) })}
+                >
+                  <Trash2 className="size-4" />
+                </Button>
+              </div>
+            );
+          })}
+          {siblingFields.length > 0 ? (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="self-start"
+              onClick={() => onUpdate({ conditional: addCondition(group, siblingFields[0]!) })}
+            >
+              + Add condition
+            </Button>
+          ) : (
+            <p className="text-xs text-muted-foreground">No other fields available to condition on.</p>
+          )}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
 function localeText(label: FieldConfig['label'], loc: string, fallback: string): string {
   if (typeof label === 'string') return loc === fallback ? label : '';
   return label[loc] ?? '';
@@ -217,9 +412,10 @@ export interface FieldRowProps {
   onUpdate: (patch: Partial<FieldConfig>) => void;
   onRemove: () => void;
   locales?: string[];
+  siblingFields?: SiblingField[];
 }
 
-export function FieldRow({ field, onUpdate, onRemove, locales = ['en'] }: FieldRowProps) {
+export function FieldRow({ field, onUpdate, onRemove, locales = ['en'], siblingFields = [] }: FieldRowProps) {
   const { attributes, listeners, setNodeRef, transform, transition } = useSortable({ id: field.key });
   const [open, setOpen] = React.useState(true);
   const [keyDraft, setKeyDraft] = React.useState(field.key);
@@ -330,6 +526,7 @@ export function FieldRow({ field, onUpdate, onRemove, locales = ['en'] }: FieldR
           </label>
           {field.component === 'Select' ? <OptionsEditor field={field} onUpdate={onUpdate} /> : null}
           <ValidationEditor field={field} onUpdate={onUpdate} />
+          <ConditionalEditor field={field} siblingFields={siblingFields} onUpdate={onUpdate} />
         </div>
       ) : null}
     </div>

--- a/packages/form-builder/package.json
+++ b/packages/form-builder/package.json
@@ -28,6 +28,7 @@
   "repository": { "type": "git", "url": "git+https://github.com/royfw/rfjs.git", "directory": "packages/form-builder" },
   "files": ["dist", "README.md"],
   "dependencies": {
+    "@rfjs/data-filter": "workspace:*",
     "zod": "^4.0.0"
   },
   "devDependencies": {

--- a/packages/form-builder/src/conditional.spec.ts
+++ b/packages/form-builder/src/conditional.spec.ts
@@ -59,5 +59,13 @@ describe('evaluateConditional', () => {
     it('returns false when age < 18', () => {
       expect(evaluateConditional(rule, { age: 17 })).toBe(false);
     });
+
+    // Regression guard: at runtime RHF numeric inputs yield STRING values (e.g. "30").
+    // Conditional show/hide relies on data-filter's NumericMatch coercing both sides —
+    // lock that in so a future refactor can't silently break numeric conditions.
+    it('matches a numeric condition when the form value is a string (real RHF output)', () => {
+      expect(evaluateConditional(rule, { age: '30' } as never)).toBe(true);
+      expect(evaluateConditional(rule, { age: '10' } as never)).toBe(false);
+    });
   });
 });

--- a/packages/form-builder/src/conditional.spec.ts
+++ b/packages/form-builder/src/conditional.spec.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { evaluateConditional } from './conditional';
+import type { ConditionalRule } from './conditional';
+
+describe('evaluateConditional', () => {
+  it('returns true when rule is undefined', () => {
+    expect(evaluateConditional(undefined, {})).toBe(true);
+  });
+
+  it('returns true for an empty and-group (always shown)', () => {
+    const rule: ConditionalRule = { logic: 'and', filters: [] };
+    expect(evaluateConditional(rule, {})).toBe(true);
+  });
+
+  // Empty-group semantics are asymmetric by logic — documents the contract before
+  // Task 6's editor picks a default logic. (and/nor → true, or/not → false.)
+  it('returns false for an empty or-group', () => {
+    expect(evaluateConditional({ logic: 'or', filters: [] }, {})).toBe(false);
+  });
+
+  it('returns true for an empty nor-group', () => {
+    expect(evaluateConditional({ logic: 'nor', filters: [] }, {})).toBe(true);
+  });
+
+  it('returns false for an empty not-group', () => {
+    expect(evaluateConditional({ logic: 'not', filters: [] }, {})).toBe(false);
+  });
+
+  describe('string condition (eq)', () => {
+    const rule: ConditionalRule = {
+      logic: 'and',
+      filters: [{ field: 'role', dataType: 'string', operator: 'eq', value: 'admin' }],
+    };
+
+    it('returns true when field matches', () => {
+      expect(evaluateConditional(rule, { role: 'admin' })).toBe(true);
+    });
+
+    it('returns false when field does not match', () => {
+      expect(evaluateConditional(rule, { role: 'user' })).toBe(false);
+    });
+
+    it('returns false when field is missing', () => {
+      expect(evaluateConditional(rule, {})).toBe(false);
+    });
+  });
+
+  describe('numeric condition (gte)', () => {
+    const rule: ConditionalRule = {
+      logic: 'and',
+      filters: [{ field: 'age', dataType: 'numeric', operator: 'gte', value: 18 }],
+    };
+
+    it('returns true when age >= 18', () => {
+      expect(evaluateConditional(rule, { age: 18 })).toBe(true);
+      expect(evaluateConditional(rule, { age: 30 })).toBe(true);
+    });
+
+    it('returns false when age < 18', () => {
+      expect(evaluateConditional(rule, { age: 17 })).toBe(false);
+    });
+  });
+});

--- a/packages/form-builder/src/conditional.ts
+++ b/packages/form-builder/src/conditional.ts
@@ -1,0 +1,22 @@
+import { matchQuery } from '@rfjs/data-filter';
+import type { FilterMatchQuery, ObjectData } from '@rfjs/data-filter';
+
+/** A filter-match rule that controls field visibility (alias of data-filter's group type). */
+export type ConditionalRule = FilterMatchQuery;
+
+/**
+ * Evaluates a conditional visibility rule against the current form values.
+ *
+ * Returns `true` (field shown) when:
+ * - `rule` is `undefined` (no condition — always visible), or
+ * - the rule's filter group matches `values`.
+ *
+ * Uses the SYNC `matchQuery` — safe for React render (no await).
+ */
+export function evaluateConditional(
+  rule: ConditionalRule | undefined,
+  values: Record<string, unknown>,
+): boolean {
+  if (!rule) return true;
+  return matchQuery(values as ObjectData, rule);
+}

--- a/packages/form-builder/src/config-schema.spec.ts
+++ b/packages/form-builder/src/config-schema.spec.ts
@@ -174,3 +174,62 @@ describe('FieldValidation schema', () => {
     expect(FormConfigSchema.safeParse(cfg).success).toBe(true);
   });
 });
+
+describe('conditional field visibility schema', () => {
+  const baseField = { key: 'x', label: 'X', component: 'Input', dataType: 'string' };
+
+  it('accepts a field with a valid conditional rule', () => {
+    const cfg = {
+      version: 1,
+      fields: [
+        {
+          ...baseField,
+          conditional: {
+            logic: 'and',
+            filters: [{ field: 'role', dataType: 'string', operator: 'eq', value: 'admin' }],
+          },
+        },
+      ],
+    };
+    expect(FormConfigSchema.safeParse(cfg).success).toBe(true);
+  });
+
+  it('accepts a field with an empty filters array', () => {
+    const cfg = {
+      version: 1,
+      fields: [{ ...baseField, conditional: { logic: 'and', filters: [] } }],
+    };
+    expect(FormConfigSchema.safeParse(cfg).success).toBe(true);
+  });
+
+  it('accepts a field without conditional (backward compatible)', () => {
+    const cfg = { version: 1, fields: [{ ...baseField }] };
+    expect(FormConfigSchema.safeParse(cfg).success).toBe(true);
+  });
+
+  it('rejects a conditional with an invalid logic value', () => {
+    const cfg = {
+      version: 1,
+      fields: [
+        {
+          ...baseField,
+          conditional: { logic: 'xyz', filters: [] },
+        },
+      ],
+    };
+    expect(FormConfigSchema.safeParse(cfg).success).toBe(false);
+  });
+
+  it('rejects a conditional missing the logic key', () => {
+    const cfg = {
+      version: 1,
+      fields: [
+        {
+          ...baseField,
+          conditional: { filters: [] },
+        },
+      ],
+    };
+    expect(FormConfigSchema.safeParse(cfg).success).toBe(false);
+  });
+});

--- a/packages/form-builder/src/config-schema.ts
+++ b/packages/form-builder/src/config-schema.ts
@@ -1,7 +1,25 @@
 import { z } from 'zod';
-import type { ZodType } from 'zod';
+import type { ZodType, ZodTypeAny } from 'zod';
 
 import type { FormConfig } from './types';
+
+// Permissive structural schema for ConditionalRule (FilterMatchQuery).
+// We validate shape (logic + filters array) without deep-validating every operator.
+const conditionSchema: ZodTypeAny = z.object({
+  field: z.string(),
+  dataType: z.string(),
+  operator: z.string(),
+  value: z.unknown().optional(),
+});
+
+// Recursive group schema: z.lazy defers the self-reference so the outer `conditionalSchema`
+// binding is resolved at evaluation time, not at declaration time.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const conditionalSchema: ZodTypeAny = z.object({
+  logic: z.enum(['and', 'or', 'nor', 'not']),
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  filters: z.array(z.union([conditionSchema, z.lazy(() => conditionalSchema as any)])),
+});
 
 const fieldOptionSchema = z.object({
   label: z.string(),
@@ -41,6 +59,7 @@ const fieldConfigSchema = z.object({
   options: z.array(fieldOptionSchema).optional(),
   width: z.enum(['full', 'half']).optional(),
   validation: fieldValidationSchema.optional(),
+  conditional: conditionalSchema.optional(),
 });
 
 export const FormConfigSchema: ZodType<FormConfig> = z.object({

--- a/packages/form-builder/src/index.ts
+++ b/packages/form-builder/src/index.ts
@@ -1,4 +1,5 @@
 export * from './types';
+export * from './conditional';
 export * from './config-schema';
 export * from './config-to-zod';
 export * from './list-ops';

--- a/packages/form-builder/src/types.ts
+++ b/packages/form-builder/src/types.ts
@@ -1,3 +1,5 @@
+import type { ConditionalRule } from './conditional';
+
 // Data-type vocabulary — identical to @rfjs/filter-builder's FieldType.
 export type ScalarType = 'string' | 'numeric' | 'date' | 'boolean';
 export type FieldType = ScalarType | 'object' | 'array';
@@ -37,6 +39,7 @@ export interface FieldConfig {
   options?: FieldOption[];
   width?: FieldWidth;
   validation?: FieldValidation;
+  conditional?: ConditionalRule;
 }
 
 export interface FormConfig {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -894,6 +894,9 @@ importers:
 
   packages/form-builder:
     dependencies:
+      '@rfjs/data-filter':
+        specifier: workspace:*
+        version: link:../data-filter
       zod:
         specifier: ^4.0.0
         version: 4.4.3


### PR DESCRIPTION
## What

**v2-C — conditional display** for the config-driven form builder. A field can declare a rule (a `@rfjs/data-filter` filter group over the other fields' values); the form shows/hides it live as those values change. This is the second half of the planned "rules" group (v2-B validation shipped in #200).

- **Engine** (`@rfjs/form-builder`): new `FieldConfig.conditional?: ConditionalRule` (= `@rfjs/data-filter`'s `FilterMatchQuery`) + `evaluateConditional(rule, values)`.
  - Evaluates with data-filter's **synchronous** `matchQuery` (not the async `compileMatchQuery`) — show/hide runs in React render and can't await.
  - `conditional` validated by a permissive, recursive structural zod schema (`{ logic, filters }`); absent rule → always shown; an empty `and` group → shown (the `or`/`nor`/`not` empty-group asymmetry is documented + tested).
  - Adds `@rfjs/data-filter` as a workspace dependency.
- **Renderer** (`<ConfigForm>`): a single **stable** `useCallback` resolver builds the zod schema over only the fields visible *for the values being validated*, so hidden (even `required`) fields never block submit; `watch()` drives live show/hide; the submit payload strips hidden fields' values. No reaching into RHF internals.
- **Builder** (`<FieldRow>`): a **Conditional display** sub-block — a Checkbox mode toggle + condition rows (sibling-field select · operator select · value input · add/remove). Logic is built into eight **pure, exported, unit-tested** helpers (`operatorsFor`, `coerceConditionValue`, `defaultCondition`, `add/remove/setConditionField/Operator/Value`); operator sets and value coercion are per `dataType`. `<ConfigFormBuilder>` passes `siblingFields` (other scalar fields).

## Testing

- `@rfjs/form-builder` (engine): **65** tests — `evaluateConditional` (undefined/empty-group `and`·`or`·`nor`·`not` semantics, string/numeric matches, **numeric-string runtime-shape guard**) + structural-schema accept/reject.
- `@rfjs/form-builder-ui`: **92** tests — `ConfigForm` show/hide, hidden-required-doesn't-block, visible-required-blocks, hidden-value-stripping; `FieldRow` conditional editor (8 helper unit tests + Checkbox/value-input/add/remove component tests; radix selects asserted by trigger value). `tsc --noEmit` clean.
- TDD throughout; per-task spec+quality reviews (T4: vitest-convention fix + empty-group tests; T5: replaced an RHF-private-`_options` hack with the stable resolver) + a final whole-branch review (verdict SHIP, no must-fix; the editor→engine round-trip and string/number coercion verified correct).

## Notes / follow-ups

- No changeset (consistent with the rest of the form-builder effort; release/versioning deferred; `@rfjs/form-builder-ui` is private).
- The editor only authors `and` groups (simplification); the engine supports `or`/`nor`/`not` from loaded JSON.
- Carried-over a11y item still open: the validation error `<p>` isn't linked to its control via `aria-describedby` (separate a11y pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
