### PR TITLE
feat(form-builder-ui): builder visual polish — collapsible kind-accented cards + section cards

### DIFF
--- a/apps/web/src/tools/form-builder/ui.tsx
+++ b/apps/web/src/tools/form-builder/ui.tsx
@@ -3,19 +3,99 @@
 import type { FormConfig } from "@rfjs/form-builder";
 import { ConfigFormBuilder } from "@rfjs/form-builder-ui";
 
+// A v2 sections config that showcases the item-kind model: named sections,
+// content / field / ai-note / divider kinds, plus validation, a conditional,
+// and a per-field AI note.
 const SAMPLE_CONFIG: FormConfig = {
   version: 1,
-  fields: [
-    { key: "name", label: "Name", component: "Input", dataType: "string", required: true },
-    { key: "email", label: "Email", component: "Input", dataType: "string" },
+  sections: [
     {
-      key: "role",
-      label: "Role",
-      component: "Select",
-      dataType: "string",
-      options: [
-        { label: "Admin", value: "admin" },
-        { label: "User", value: "user" },
+      id: "sec_account",
+      title: { en: "Account", "zh-TW": "帳號" },
+      rows: [
+        {
+          id: "r_welcome",
+          items: [
+            {
+              id: "i_welcome",
+              kind: "content",
+              text: { en: "Fill in your account details below.", "zh-TW": "請填寫以下帳號資訊。" },
+              locked: true,
+            },
+          ],
+        },
+        {
+          id: "r_name",
+          items: [
+            { id: "i_name", kind: "field", key: "name", label: { en: "Name", "zh-TW": "姓名" }, component: "Input", dataType: "string", required: true },
+          ],
+        },
+        {
+          id: "r_email",
+          items: [
+            {
+              id: "i_email",
+              kind: "field",
+              key: "email",
+              label: { en: "Email", "zh-TW": "電子郵件" },
+              component: "Input",
+              dataType: "string",
+              required: true,
+              validation: { pattern: "^[^@\\s]+@[^@\\s]+$", message: "Enter a valid email" },
+            },
+          ],
+        },
+        {
+          id: "r_role",
+          items: [
+            {
+              id: "i_role",
+              kind: "field",
+              key: "role",
+              label: { en: "Role", "zh-TW": "角色" },
+              component: "Select",
+              dataType: "string",
+              options: [
+                { label: "Admin", value: "admin" },
+                { label: "User", value: "user" },
+              ],
+              aiNote: "Pick 'admin' only for internal staff.",
+            },
+          ],
+        },
+        {
+          id: "r_guide",
+          items: [
+            { id: "i_guide", kind: "ai-note", text: "If the user is unsure of their role, default to 'user'." },
+          ],
+        },
+        {
+          id: "r_manager",
+          items: [
+            {
+              id: "i_manager",
+              kind: "field",
+              key: "manager",
+              label: { en: "Manager", "zh-TW": "主管" },
+              component: "Input",
+              dataType: "string",
+              conditional: { logic: "and", filters: [{ field: "role", dataType: "string", operator: "eq", value: "admin" }] },
+            },
+          ],
+        },
+      ],
+    },
+    {
+      id: "sec_profile",
+      title: { en: "Profile", "zh-TW": "個人資料" },
+      rows: [
+        {
+          id: "r_bio",
+          items: [
+            { id: "i_bio", kind: "field", key: "bio", label: { en: "Bio", "zh-TW": "簡介" }, component: "Textarea", dataType: "string" },
+          ],
+        },
+        { id: "r_div", items: [{ id: "i_div", kind: "divider" }] },
       ],
     },
   ],

--- a/packages/form-builder-ui/src/config-form-builder.spec.tsx
+++ b/packages/form-builder-ui/src/config-form-builder.spec.tsx
@@ -53,8 +53,9 @@ describe('ConfigFormBuilder', () => {
   it('adds a field from the palette', () => {
     render(<ConfigFormBuilder initialConfig={initial} />);
     fireEvent.click(screen.getByRole('button', { name: /\+ field/i }));
-    // two label inputs now exist in the editor (Name + the new Field)
-    expect(screen.getAllByLabelText(/^label for /).length).toBe(2);
+    // Items render as collapsed cards; two cards now exist (Name + the new Field).
+    // Each card exposes a remove button, so count those.
+    expect(screen.getAllByRole('button', { name: /remove item/i }).length).toBe(2);
   });
 
   it('adds a Content item from the palette and onChange receives a sections config', () => {

--- a/packages/form-builder-ui/src/config-form-builder.spec.tsx
+++ b/packages/form-builder-ui/src/config-form-builder.spec.tsx
@@ -123,8 +123,11 @@ describe('ConfigFormBuilder', () => {
 
   it('removes a field', () => {
     render(<ConfigFormBuilder initialConfig={initial} />);
+    expect(screen.getAllByRole('button', { name: /remove item/i }).length).toBe(1);
     fireEvent.click(screen.getByRole('button', { name: /remove item/i }));
-    expect(screen.queryByLabelText('label for name')).toBeNull();
+    // The only item is gone — no item cards (hence no remove buttons) remain.
+    // (Collapse-independent: the card body isn't mounted while collapsed.)
+    expect(screen.queryByRole('button', { name: /remove item/i })).toBeNull();
   });
 
   it('columns trigger renders the current columns value', () => {

--- a/packages/form-builder-ui/src/config-form.tsx
+++ b/packages/form-builder-ui/src/config-form.tsx
@@ -62,9 +62,12 @@ export function ConfigForm({ config, defaultValues, onSubmit, submitLabel = 'Sub
 
   const spacerHeights: Record<string, number> = { sm: 8, md: 16, lg: 32 };
 
-  // In a v2 flex row, items size themselves with flex-basis; in the v1 grid they use grid-column.
-  const flexBasis = (width: 'full' | 'half') =>
-    width === 'full' ? 'basis-full' : 'basis-[calc(50%-0.5rem)]';
+  // Width is applied via INLINE styles, not Tailwind `basis-*` / `col-span-full`
+  // utilities — those aren't reliably emitted for this package, which left preview
+  // fields collapsed to their intrinsic width ("not full-width"). Inline is guaranteed.
+  // v2 flex row → flex-basis; v1 grid → grid-column span.
+  const fullSpan = (flow: 'grid' | 'flex'): React.CSSProperties =>
+    flow === 'flex' ? { flexBasis: '100%', minWidth: 0 } : { gridColumn: '1 / -1' };
 
   function renderItem(item: FormItem, flow: 'grid' | 'flex') {
     const vals = values as Record<string, unknown>;
@@ -75,21 +78,19 @@ export function ConfigForm({ config, defaultValues, onSubmit, submitLabel = 'Sub
 
     if (item.kind === 'divider') {
       if (!evaluateConditional(item.conditional, vals)) return null;
-      const cls = flow === 'flex' ? 'basis-full border-input w-full' : 'col-span-full border-input w-full';
-      return <hr key={item.id} className={cls} />;
+      return <hr key={item.id} className="w-full border-input" style={fullSpan(flow)} />;
     }
 
     if (item.kind === 'spacer') {
       if (!evaluateConditional(item.conditional, vals)) return null;
       const height = spacerHeights[item.size ?? 'md'];
-      return <div key={item.id} className={flow === 'flex' ? 'basis-full' : undefined} style={{ height }} />;
+      return <div key={item.id} style={{ ...fullSpan(flow), height }} />;
     }
 
     if (item.kind === 'content') {
       if (!evaluateConditional(item.conditional, vals)) return null;
-      const cls = flow === 'flex' ? 'text-sm basis-full' : 'text-sm col-span-full';
       return (
-        <div key={item.id} className={cls}>
+        <div key={item.id} className="text-sm" style={fullSpan(flow)}>
           {resolveLabel(item.text, locale)}
         </div>
       );
@@ -98,13 +99,12 @@ export function ConfigForm({ config, defaultValues, onSubmit, submitLabel = 'Sub
     // kind === 'field'
     if (!evaluateConditional(item.conditional, vals)) return null;
     const width = item.width ?? 'full';
+    const fieldStyle: React.CSSProperties =
+      flow === 'flex'
+        ? { flexBasis: width === 'full' ? '100%' : 'calc(50% - 0.5rem)', minWidth: 0 }
+        : { gridColumn: width === 'full' ? '1 / -1' : undefined };
     return (
-      <div
-        key={item.key}
-        className={flow === 'flex' ? `flex flex-col gap-1.5 ${flexBasis(width)}` : 'flex flex-col gap-1.5'}
-        data-width={width}
-        style={flow === 'grid' && width === 'full' ? { gridColumn: '1 / -1' } : undefined}
-      >
+      <div key={item.key} className="flex min-w-0 flex-col gap-1.5" data-width={width} style={fieldStyle}>
         <Label htmlFor={item.key}>{resolveLabel(item.label, locale)}</Label>
         <Controller
           control={control}
@@ -145,13 +145,18 @@ export function ConfigForm({ config, defaultValues, onSubmit, submitLabel = 'Sub
       {sections.map((section) => (
         <React.Fragment key={section.id}>
           {section.title && (
-            <h3 className="col-span-full font-semibold text-sm">
+            <h3 className="font-semibold text-sm" style={{ gridColumn: '1 / -1' }}>
               {resolveLabel(section.title, locale)}
             </h3>
           )}
           {section.rows.map((row) =>
             isV2 ? (
-              <div key={row.id} data-testid="form-row" className="col-span-full flex flex-wrap gap-4">
+              <div
+                key={row.id}
+                data-testid="form-row"
+                className="flex flex-wrap gap-4"
+                style={{ gridColumn: '1 / -1' }}
+              >
                 {row.items.map((item) => renderItem(item, 'flex'))}
               </div>
             ) : (

--- a/packages/form-builder-ui/src/field-control.tsx
+++ b/packages/form-builder-ui/src/field-control.tsx
@@ -41,7 +41,7 @@ export function FieldControl({ field, value, onChange }: FieldControlProps) {
     case 'Select':
       return (
         <Select value={(value as string) ?? ''} onValueChange={onChange}>
-          <SelectTrigger id={field.key}>
+          <SelectTrigger id={field.key} className="w-full">
             <SelectValue placeholder={field.placeholder} />
           </SelectTrigger>
           <SelectContent>

--- a/packages/form-builder-ui/src/field-row.tsx
+++ b/packages/form-builder-ui/src/field-row.tsx
@@ -432,7 +432,10 @@ export function FieldItemEditor({ field, onUpdate, locales = ['en'], siblingFiel
   }
 
   return (
-    <div className="grid grid-cols-[repeat(auto-fit,minmax(150px,1fr))] gap-3 border-t border-input p-3">
+    <div
+      className="grid gap-3 border-t border-input p-3"
+      style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(150px, 1fr))' }}
+    >
       <span className="flex flex-col gap-1 text-xs text-muted-foreground">
         Type
         <Select value={field.component} onValueChange={(v) => changeComponent(v as FieldComponent)}>

--- a/packages/form-builder-ui/src/item-editor.spec.tsx
+++ b/packages/form-builder-ui/src/item-editor.spec.tsx
@@ -37,6 +37,7 @@ function renderEditor(
   onUpdate = vi.fn(),
   onRemove = vi.fn(),
   locales = ['en'],
+  defaultOpen = true, // body-interaction tests need the card expanded
 ) {
   render(
     <DndContext>
@@ -47,6 +48,7 @@ function renderEditor(
           locales={locales}
           onUpdate={onUpdate}
           onRemove={onRemove}
+          defaultOpen={defaultOpen}
         />
       </SortableContext>
     </DndContext>,
@@ -208,6 +210,36 @@ const fieldItem: FieldItem = {
   component: 'Input',
   dataType: 'string',
 };
+
+describe('ItemEditor — collapse behavior', () => {
+  it('is collapsed by default — the body is not mounted until expanded', () => {
+    render(
+      <DndContext>
+        <SortableContext items={[fieldItem.id]}>
+          <ItemEditor item={fieldItem} siblingFields={[]} onUpdate={vi.fn()} onRemove={vi.fn()} />
+        </SortableContext>
+      </DndContext>,
+    );
+    // header summary is visible...
+    expect(screen.getByText('Name')).toBeTruthy();
+    // ...but the body (e.g. the AI-note field) is not, until expanded
+    expect(screen.queryByLabelText('AI note for field')).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: /expand item/i }));
+    expect(screen.getByLabelText('AI note for field')).toBeTruthy();
+  });
+
+  it('shows the required pill in the collapsed header for a required field', () => {
+    const required: FieldItem = { ...fieldItem, required: true };
+    render(
+      <DndContext>
+        <SortableContext items={[required.id]}>
+          <ItemEditor item={required} siblingFields={[]} onUpdate={vi.fn()} onRemove={vi.fn()} />
+        </SortableContext>
+      </DndContext>,
+    );
+    expect(screen.getByText(/required/i)).toBeTruthy();
+  });
+});
 
 describe('ItemEditor — field kind (aiNote sub-block)', () => {
   it('renders the aiNote input for a field item', () => {

--- a/packages/form-builder-ui/src/item-editor.tsx
+++ b/packages/form-builder-ui/src/item-editor.tsx
@@ -1,16 +1,7 @@
 'use client';
 
 import * as React from 'react';
-import {
-  Trash2,
-  ChevronRight,
-  ChevronDown,
-  Type,
-  AlignLeft,
-  Minus,
-  MoveVertical,
-  Sparkles,
-} from 'lucide-react';
+import { Trash2, ChevronRight, Type, AlignLeft, Minus, MoveVertical, Sparkles } from 'lucide-react';
 import type { FieldItem, ContentItem, DividerItem, SpacerItem, AiNoteItem, FormItem, ItemKind, SpacerSize } from '@rfjs/form-builder';
 import { Input } from '@rfjs/web-ui/components/input';
 import { Textarea } from '@rfjs/web-ui/components/textarea';
@@ -187,7 +178,7 @@ export function ItemEditor({ item, siblingFields = [], locales = ['en'], onUpdat
     <div
       // Collapsed → a clean borderless row (the section card is the only box).
       // Expanded → a focused panel with a subtle surface + border.
-      className={`group/item rounded-md ${open ? 'border border-input bg-background/40' : ''}`}
+      className={`group/item rounded-md transition-shadow ${open ? 'border border-input bg-background/40 shadow-sm ring-1 ring-inset ring-white/[0.03]' : ''}`}
       data-kind={item.kind}
     >
       <div
@@ -206,11 +197,9 @@ export function ItemEditor({ item, siblingFields = [], locales = ['en'], onUpdat
           aria-expanded={open}
           onClick={() => setOpen((o) => !o)}
         >
-          {open ? (
-            <ChevronDown className="size-3.5 shrink-0 text-muted-foreground" />
-          ) : (
-            <ChevronRight className="size-3.5 shrink-0 text-muted-foreground" />
-          )}
+          <ChevronRight
+            className={`size-3.5 shrink-0 text-muted-foreground transition-transform duration-200 ${open ? 'rotate-90' : ''}`}
+          />
           <Icon className="size-4 shrink-0" style={{ color: meta.color }} aria-hidden />
           <span className="truncate text-sm font-medium text-foreground">{title}</span>
           {sub ? <span className="truncate font-mono text-[11px] text-muted-foreground/70">{sub}</span> : null}
@@ -232,7 +221,7 @@ export function ItemEditor({ item, siblingFields = [], locales = ['en'], onUpdat
         </div>
       </div>
       {open ? (
-        <div>
+        <div className="animate-in fade-in-0 slide-in-from-top-1 duration-150">
           {item.kind === 'field' ? (
             <FieldItemEditor field={item as FieldItem} onUpdate={onUpdate as (patch: Partial<FieldItem>) => void} locales={locales} siblingFields={siblingFields} />
           ) : item.kind === 'content' ? (

--- a/packages/form-builder-ui/src/item-editor.tsx
+++ b/packages/form-builder-ui/src/item-editor.tsx
@@ -189,28 +189,23 @@ export function ItemEditor({ item, siblingFields = [], locales = ['en'], onUpdat
     >
       <div className="flex items-center gap-2 p-2">
         {dragHandle}
+        {/* Single disclosure control: chevron + kind icon + summary all toggle the card. */}
         <button
           type="button"
-          className="text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:rounded"
+          className="flex min-w-0 flex-1 items-center gap-2 text-left text-muted-foreground hover:text-foreground focus-visible:rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           aria-label={open ? 'collapse item' : 'expand item'}
           aria-expanded={open}
           onClick={() => setOpen((o) => !o)}
         >
-          {open ? <ChevronDown className="size-4" /> : <ChevronRight className="size-4" />}
-        </button>
-        <span
-          className="flex size-6 shrink-0 items-center justify-center rounded"
-          style={{ backgroundColor: `${meta.color}22`, color: meta.color }}
-          aria-hidden
-        >
-          <Icon className="size-3.5" />
-        </span>
-        <button
-          type="button"
-          className="flex min-w-0 flex-1 items-baseline gap-2 text-left"
-          onClick={() => setOpen((o) => !o)}
-        >
-          <span className="truncate text-sm font-medium">{title}</span>
+          {open ? <ChevronDown className="size-4 shrink-0" /> : <ChevronRight className="size-4 shrink-0" />}
+          <span
+            className="flex size-6 shrink-0 items-center justify-center rounded"
+            style={{ backgroundColor: `${meta.color}22`, color: meta.color }}
+            aria-hidden
+          >
+            <Icon className="size-3.5" />
+          </span>
+          <span className="truncate text-sm font-medium text-foreground">{title}</span>
           {sub ? <span className="truncate font-mono text-[11px] text-muted-foreground">{sub}</span> : null}
         </button>
         <div className="flex shrink-0 items-center gap-1">

--- a/packages/form-builder-ui/src/item-editor.tsx
+++ b/packages/form-builder-ui/src/item-editor.tsx
@@ -1,18 +1,82 @@
 'use client';
 
 import * as React from 'react';
-import { Trash2 } from 'lucide-react';
-import type { FieldItem, ContentItem, DividerItem, SpacerItem, AiNoteItem, FormItem, SpacerSize } from '@rfjs/form-builder';
+import {
+  Trash2,
+  ChevronRight,
+  ChevronDown,
+  Type,
+  AlignLeft,
+  Minus,
+  MoveVertical,
+  Sparkles,
+} from 'lucide-react';
+import type { FieldItem, ContentItem, DividerItem, SpacerItem, AiNoteItem, FormItem, ItemKind, SpacerSize } from '@rfjs/form-builder';
 import { Input } from '@rfjs/web-ui/components/input';
 import { Textarea } from '@rfjs/web-ui/components/textarea';
 import { Checkbox } from '@rfjs/web-ui/components/checkbox';
 import { Button } from '@rfjs/web-ui/components/button';
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@rfjs/web-ui/components/select';
-import { FieldItemEditor } from './field-row';
+import { FieldItemEditor, labelOf } from './field-row';
 import type { SiblingField } from './field-row';
 
 // ---------------------------------------------------------------------------
-// Helpers — locale text for content items
+// Kind metadata — icon, label, and accent colors per item kind. The left
+// accent bar + icon chip give each kind an at-a-glance identity (matches mockup).
+// ---------------------------------------------------------------------------
+
+interface KindMeta {
+  label: string;
+  Icon: React.ComponentType<{ className?: string }>;
+  color: string; // kind accent color (inline — not dependent on the web-ui palette)
+}
+
+const KIND_META: Record<ItemKind, KindMeta> = {
+  field: { label: 'Field', Icon: Type, color: '#0ea5e9' }, // sky
+  content: { label: 'Content', Icon: AlignLeft, color: '#8b5cf6' }, // violet
+  'ai-note': { label: 'AI Note', Icon: Sparkles, color: '#d946ef' }, // fuchsia
+  divider: { label: 'Divider', Icon: Minus, color: '#71717a' }, // zinc
+  spacer: { label: 'Spacer', Icon: MoveVertical, color: '#71717a' },
+};
+
+const PILL_COLORS: Record<string, string> = {
+  danger: '#ef4444',
+  warn: '#f59e0b',
+  accent: '#8b5cf6',
+};
+
+function Pill({ tone = 'accent', children }: { tone?: 'danger' | 'warn' | 'accent'; children: React.ReactNode }) {
+  const c = PILL_COLORS[tone];
+  return (
+    <span
+      className="rounded px-1.5 py-0.5 text-[10px] font-medium leading-none"
+      style={{ backgroundColor: `${c}22`, color: c }}
+    >
+      {children}
+    </span>
+  );
+}
+
+/** One-line summary shown in the collapsed header for each kind. */
+function itemSummary(item: FormItem): { title: string; meta?: string } {
+  switch (item.kind) {
+    case 'field':
+      return { title: labelOf(item.label) || item.key, meta: `${item.key} · ${item.component}` };
+    case 'content':
+      return { title: labelOf(item.text) || 'Content block', meta: 'content' };
+    case 'ai-note':
+      return { title: item.text || 'AI note', meta: 'ai-only' };
+    case 'spacer':
+      return { title: 'Spacer', meta: item.size ?? 'md' };
+    case 'divider':
+      return { title: 'Divider', meta: undefined };
+    default:
+      return { title: '', meta: undefined };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Per-kind body components
 // ---------------------------------------------------------------------------
 
 function contentLocaleText(text: ContentItem['text'], loc: string, fallback: string): string {
@@ -20,31 +84,13 @@ function contentLocaleText(text: ContentItem['text'], loc: string, fallback: str
   return text[loc] ?? '';
 }
 
-function setContentLocaleText(
-  text: ContentItem['text'],
-  loc: string,
-  value: string,
-  locales: string[],
-): ContentItem['text'] {
-  const base: Record<string, string> =
-    typeof text === 'string' ? { [locales[0] ?? 'en']: text } : { ...text };
+function setContentLocaleText(text: ContentItem['text'], loc: string, value: string, locales: string[]): ContentItem['text'] {
+  const base: Record<string, string> = typeof text === 'string' ? { [locales[0] ?? 'en']: text } : { ...text };
   base[loc] = value;
   return base;
 }
 
-// ---------------------------------------------------------------------------
-// Per-kind body components
-// ---------------------------------------------------------------------------
-
-function ContentItemEditor({
-  item,
-  onUpdate,
-  locales = ['en'],
-}: {
-  item: ContentItem;
-  onUpdate: (patch: Partial<ContentItem>) => void;
-  locales?: string[];
-}) {
+function ContentItemEditor({ item, onUpdate, locales = ['en'] }: { item: ContentItem; onUpdate: (patch: Partial<ContentItem>) => void; locales?: string[] }) {
   const locked = Boolean(item.locked);
   return (
     <div className="flex flex-col gap-3 border-t border-input p-3">
@@ -57,40 +103,25 @@ function ContentItemEditor({
               aria-label={`content text (${loc})`}
               value={contentLocaleText(item.text, loc, locales[0] ?? 'en')}
               disabled={locked}
-              onChange={(e) =>
-                onUpdate({ text: setContentLocaleText(item.text, loc, e.target.value, locales) })
-              }
+              onChange={(e) => onUpdate({ text: setContentLocaleText(item.text, loc, e.target.value, locales) })}
             />
           </label>
         ))}
       </div>
       <label className="flex items-center gap-1.5 text-xs text-muted-foreground">
-        <Checkbox
-          aria-label="locked"
-          checked={locked}
-          onCheckedChange={(c) => onUpdate({ locked: c === true })}
-        />
-        locked
+        <Checkbox aria-label="locked" checked={locked} onCheckedChange={(c) => onUpdate({ locked: c === true })} />
+        locked (preset — not editable by the filler)
       </label>
     </div>
   );
 }
 
-function SpacerItemEditor({
-  item,
-  onUpdate,
-}: {
-  item: SpacerItem;
-  onUpdate: (patch: Partial<SpacerItem>) => void;
-}) {
+function SpacerItemEditor({ item, onUpdate }: { item: SpacerItem; onUpdate: (patch: Partial<SpacerItem>) => void }) {
   return (
     <div className="border-t border-input p-3">
       <span className="flex flex-col gap-1 text-xs text-muted-foreground">
         Size
-        <Select
-          value={item.size ?? 'md'}
-          onValueChange={(v) => onUpdate({ size: v as SpacerSize })}
-        >
+        <Select value={item.size ?? 'md'} onValueChange={(v) => onUpdate({ size: v as SpacerSize })}>
           <SelectTrigger className="h-8 w-[120px]" aria-label="spacer size">
             <SelectValue />
           </SelectTrigger>
@@ -105,23 +136,12 @@ function SpacerItemEditor({
   );
 }
 
-function AiNoteItemEditor({
-  item,
-  onUpdate,
-}: {
-  item: AiNoteItem;
-  onUpdate: (patch: Partial<AiNoteItem>) => void;
-}) {
+function AiNoteItemEditor({ item, onUpdate }: { item: AiNoteItem; onUpdate: (patch: Partial<AiNoteItem>) => void }) {
   return (
     <div className="border-t border-input p-3">
       <label className="flex flex-col gap-1 text-xs text-muted-foreground">
-        Text
-        <Textarea
-          aria-label="ai-note text"
-          value={item.text}
-          onChange={(e) => onUpdate({ text: e.target.value })}
-          rows={3}
-        />
+        Note for AI (not shown to the filler)
+        <Textarea aria-label="ai-note text" value={item.text} onChange={(e) => onUpdate({ text: e.target.value })} rows={3} />
       </label>
     </div>
   );
@@ -136,28 +156,7 @@ function DividerItemBody() {
 }
 
 // ---------------------------------------------------------------------------
-// Shared card header
-// ---------------------------------------------------------------------------
-
-function ItemEditorHeader({
-  kindLabel,
-  onRemove,
-}: {
-  kindLabel: string;
-  onRemove: () => void;
-}) {
-  return (
-    <div className="flex items-center gap-2 p-2">
-      <span className="flex-1 text-xs font-medium text-muted-foreground">{kindLabel}</span>
-      <Button type="button" variant="ghost" size="icon" aria-label="remove item" onClick={onRemove}>
-        <Trash2 className="size-4" />
-      </Button>
-    </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Public: ItemEditor
+// Public: ItemEditor — collapsible, kind-accented card
 // ---------------------------------------------------------------------------
 
 export interface ItemEditorProps {
@@ -166,45 +165,77 @@ export interface ItemEditorProps {
   locales?: string[];
   onUpdate: (patch: Partial<FormItem>) => void;
   onRemove: () => void;
+  /** Optional drag handle (rendered at the start of the header) supplied by the arranger. */
+  dragHandle?: React.ReactNode;
+  /** Start expanded (default collapsed — the builder shows scannable summary rows). */
+  defaultOpen?: boolean;
 }
 
-export function ItemEditor({
-  item,
-  siblingFields = [],
-  locales = ['en'],
-  onUpdate,
-  onRemove,
-}: ItemEditorProps) {
+export function ItemEditor({ item, siblingFields = [], locales = ['en'], onUpdate, onRemove, dragHandle, defaultOpen = false }: ItemEditorProps) {
+  const meta = KIND_META[item.kind];
+  const Icon = meta.Icon;
+  const { title, meta: sub } = itemSummary(item);
+  const [open, setOpen] = React.useState(defaultOpen);
+
+  const required = item.kind === 'field' && Boolean(item.required);
+  const hasConditional = (item.kind === 'field' || item.kind === 'content' || item.kind === 'divider' || item.kind === 'spacer') && Boolean((item as { conditional?: unknown }).conditional);
+  const locked = item.kind === 'content' && Boolean(item.locked);
+
   return (
-    <div className="rounded-md border border-input bg-background">
-      <ItemEditorHeader kindLabel={item.kind} onRemove={onRemove} />
-      {/* Each kind's body owns its own top border + padding (FieldItemEditor included),
-          so there is exactly one separator between header and body for every kind. */}
-      {item.kind === 'field' ? (
-        <FieldItemEditor
-          field={item as FieldItem}
-          onUpdate={onUpdate as (patch: Partial<FieldItem>) => void}
-          locales={locales}
-          siblingFields={siblingFields}
-        />
-      ) : item.kind === 'content' ? (
-        <ContentItemEditor
-          item={item as ContentItem}
-          onUpdate={onUpdate as (patch: Partial<ContentItem>) => void}
-          locales={locales}
-        />
-      ) : item.kind === 'spacer' ? (
-        <SpacerItemEditor
-          item={item as SpacerItem}
-          onUpdate={onUpdate as (patch: Partial<SpacerItem>) => void}
-        />
-      ) : item.kind === 'ai-note' ? (
-        <AiNoteItemEditor
-          item={item as AiNoteItem}
-          onUpdate={onUpdate as (patch: Partial<AiNoteItem>) => void}
-        />
-      ) : item.kind === 'divider' ? (
-        <DividerItemBody />
+    <div
+      className="overflow-hidden rounded-md border border-input bg-card"
+      style={{ borderLeftWidth: 3, borderLeftColor: meta.color }}
+      data-kind={item.kind}
+    >
+      <div className="flex items-center gap-2 p-2">
+        {dragHandle}
+        <button
+          type="button"
+          className="text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:rounded"
+          aria-label={open ? 'collapse item' : 'expand item'}
+          aria-expanded={open}
+          onClick={() => setOpen((o) => !o)}
+        >
+          {open ? <ChevronDown className="size-4" /> : <ChevronRight className="size-4" />}
+        </button>
+        <span
+          className="flex size-6 shrink-0 items-center justify-center rounded"
+          style={{ backgroundColor: `${meta.color}22`, color: meta.color }}
+          aria-hidden
+        >
+          <Icon className="size-3.5" />
+        </span>
+        <button
+          type="button"
+          className="flex min-w-0 flex-1 items-baseline gap-2 text-left"
+          onClick={() => setOpen((o) => !o)}
+        >
+          <span className="truncate text-sm font-medium">{title}</span>
+          {sub ? <span className="truncate font-mono text-[11px] text-muted-foreground">{sub}</span> : null}
+        </button>
+        <div className="flex shrink-0 items-center gap-1">
+          {required ? <Pill tone="danger">required</Pill> : null}
+          {hasConditional ? <Pill tone="warn">when…</Pill> : null}
+          {locked ? <Pill tone="accent">locked</Pill> : null}
+          <Button type="button" variant="ghost" size="icon" className="size-7" aria-label="remove item" onClick={onRemove}>
+            <Trash2 className="size-4" />
+          </Button>
+        </div>
+      </div>
+      {open ? (
+        <div>
+          {item.kind === 'field' ? (
+            <FieldItemEditor field={item as FieldItem} onUpdate={onUpdate as (patch: Partial<FieldItem>) => void} locales={locales} siblingFields={siblingFields} />
+          ) : item.kind === 'content' ? (
+            <ContentItemEditor item={item as ContentItem} onUpdate={onUpdate as (patch: Partial<ContentItem>) => void} locales={locales} />
+          ) : item.kind === 'spacer' ? (
+            <SpacerItemEditor item={item as SpacerItem} onUpdate={onUpdate as (patch: Partial<SpacerItem>) => void} />
+          ) : item.kind === 'ai-note' ? (
+            <AiNoteItemEditor item={item as AiNoteItem} onUpdate={onUpdate as (patch: Partial<AiNoteItem>) => void} />
+          ) : item.kind === 'divider' ? (
+            <DividerItemBody />
+          ) : null}
+        </div>
       ) : null}
     </div>
   );

--- a/packages/form-builder-ui/src/item-editor.tsx
+++ b/packages/form-builder-ui/src/item-editor.tsx
@@ -24,18 +24,20 @@ interface KindMeta {
 
 // A cohesive, cool, slightly-muted palette — field stays understated (it's the
 // common case); content/ai-note get gentle blue/violet; layout kinds are neutral.
+// Mid-tone, mid-saturation hues chosen to read on BOTH the dark and light surfaces
+// (the builder must look good in either theme).
 const KIND_META: Record<ItemKind, KindMeta> = {
-  field: { label: 'Field', Icon: Type, color: '#7c93b8' },
-  content: { label: 'Content', Icon: AlignLeft, color: '#7b9bf2' },
-  'ai-note': { label: 'AI Note', Icon: Sparkles, color: '#a78bfa' },
-  divider: { label: 'Divider', Icon: Minus, color: '#5a6678' },
-  spacer: { label: 'Spacer', Icon: MoveVertical, color: '#5a6678' },
+  field: { label: 'Field', Icon: Type, color: '#5b82c4' },
+  content: { label: 'Content', Icon: AlignLeft, color: '#6d7bf0' },
+  'ai-note': { label: 'AI Note', Icon: Sparkles, color: '#9168e8' },
+  divider: { label: 'Divider', Icon: Minus, color: '#7a8394' },
+  spacer: { label: 'Spacer', Icon: MoveVertical, color: '#7a8394' },
 };
 
 const PILL_COLORS: Record<string, string> = {
-  danger: '#e0857f',
-  warn: '#d3a35c',
-  accent: '#a78bfa',
+  danger: '#d65a55',
+  warn: '#bd842f',
+  accent: '#8b63dd',
 };
 
 function Pill({ tone = 'accent', children }: { tone?: 'danger' | 'warn' | 'accent'; children: React.ReactNode }) {
@@ -43,7 +45,7 @@ function Pill({ tone = 'accent', children }: { tone?: 'danger' | 'warn' | 'accen
   return (
     <span
       className="rounded px-1.5 py-px text-[10px] font-medium uppercase tracking-wide leading-none"
-      style={{ color: c, backgroundColor: `${c}1a` }}
+      style={{ color: c, backgroundColor: `${c}24` }}
     >
       {children}
     </span>
@@ -178,7 +180,7 @@ export function ItemEditor({ item, siblingFields = [], locales = ['en'], onUpdat
     <div
       // Collapsed → a clean borderless row (the section card is the only box).
       // Expanded → a focused panel with a subtle surface + border.
-      className={`group/item rounded-md transition-shadow ${open ? 'border border-input bg-background/40 shadow-sm ring-1 ring-inset ring-white/[0.03]' : ''}`}
+      className={`group/item rounded-md transition-shadow ${open ? 'border border-input bg-background/40 shadow-sm ring-1 ring-inset ring-foreground/[0.04]' : ''}`}
       data-kind={item.kind}
     >
       <div

--- a/packages/form-builder-ui/src/item-editor.tsx
+++ b/packages/form-builder-ui/src/item-editor.tsx
@@ -27,30 +27,32 @@ import type { SiblingField } from './field-row';
 
 interface KindMeta {
   label: string;
-  Icon: React.ComponentType<{ className?: string }>;
+  Icon: React.ComponentType<{ className?: string; style?: React.CSSProperties } & React.AriaAttributes>;
   color: string; // kind accent color (inline — not dependent on the web-ui palette)
 }
 
+// A cohesive, cool, slightly-muted palette — field stays understated (it's the
+// common case); content/ai-note get gentle blue/violet; layout kinds are neutral.
 const KIND_META: Record<ItemKind, KindMeta> = {
-  field: { label: 'Field', Icon: Type, color: '#0ea5e9' }, // sky
-  content: { label: 'Content', Icon: AlignLeft, color: '#8b5cf6' }, // violet
-  'ai-note': { label: 'AI Note', Icon: Sparkles, color: '#d946ef' }, // fuchsia
-  divider: { label: 'Divider', Icon: Minus, color: '#71717a' }, // zinc
-  spacer: { label: 'Spacer', Icon: MoveVertical, color: '#71717a' },
+  field: { label: 'Field', Icon: Type, color: '#7c93b8' },
+  content: { label: 'Content', Icon: AlignLeft, color: '#7b9bf2' },
+  'ai-note': { label: 'AI Note', Icon: Sparkles, color: '#a78bfa' },
+  divider: { label: 'Divider', Icon: Minus, color: '#5a6678' },
+  spacer: { label: 'Spacer', Icon: MoveVertical, color: '#5a6678' },
 };
 
 const PILL_COLORS: Record<string, string> = {
-  danger: '#ef4444',
-  warn: '#f59e0b',
-  accent: '#8b5cf6',
+  danger: '#e0857f',
+  warn: '#d3a35c',
+  accent: '#a78bfa',
 };
 
 function Pill({ tone = 'accent', children }: { tone?: 'danger' | 'warn' | 'accent'; children: React.ReactNode }) {
   const c = PILL_COLORS[tone];
   return (
     <span
-      className="rounded px-1.5 py-0.5 text-[10px] font-medium leading-none"
-      style={{ backgroundColor: `${c}22`, color: c }}
+      className="rounded px-1.5 py-px text-[10px] font-medium uppercase tracking-wide leading-none"
+      style={{ color: c, backgroundColor: `${c}1a` }}
     >
       {children}
     </span>
@@ -183,37 +185,49 @@ export function ItemEditor({ item, siblingFields = [], locales = ['en'], onUpdat
 
   return (
     <div
-      className="overflow-hidden rounded-md border border-input bg-card"
-      style={{ borderLeftWidth: 3, borderLeftColor: meta.color }}
+      // Collapsed → a clean borderless row (the section card is the only box).
+      // Expanded → a focused panel with a subtle surface + border.
+      className={`group/item rounded-md ${open ? 'border border-input bg-background/40' : ''}`}
       data-kind={item.kind}
     >
-      <div className="flex items-center gap-2 p-2">
-        {dragHandle}
+      <div
+        // Thin inset left accent (no layout shift, lighter than a full colored border).
+        className={`flex items-center gap-1.5 rounded-md py-1 pl-2.5 pr-1.5 ${open ? '' : 'transition-colors hover:bg-muted/40'}`}
+        style={{ boxShadow: `inset 2px 0 0 ${meta.color}` }}
+      >
+        <span className="shrink-0 opacity-40 transition-opacity group-hover/item:opacity-100">
+          {dragHandle}
+        </span>
         {/* Single disclosure control: chevron + kind icon + summary all toggle the card. */}
         <button
           type="button"
-          className="flex min-w-0 flex-1 items-center gap-2 text-left text-muted-foreground hover:text-foreground focus-visible:rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          className="flex min-w-0 flex-1 items-center gap-2 py-1 text-left focus-visible:rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           aria-label={open ? 'collapse item' : 'expand item'}
           aria-expanded={open}
           onClick={() => setOpen((o) => !o)}
         >
-          {open ? <ChevronDown className="size-4 shrink-0" /> : <ChevronRight className="size-4 shrink-0" />}
-          <span
-            className="flex size-6 shrink-0 items-center justify-center rounded"
-            style={{ backgroundColor: `${meta.color}22`, color: meta.color }}
-            aria-hidden
-          >
-            <Icon className="size-3.5" />
-          </span>
+          {open ? (
+            <ChevronDown className="size-3.5 shrink-0 text-muted-foreground" />
+          ) : (
+            <ChevronRight className="size-3.5 shrink-0 text-muted-foreground" />
+          )}
+          <Icon className="size-4 shrink-0" style={{ color: meta.color }} aria-hidden />
           <span className="truncate text-sm font-medium text-foreground">{title}</span>
-          {sub ? <span className="truncate font-mono text-[11px] text-muted-foreground">{sub}</span> : null}
+          {sub ? <span className="truncate font-mono text-[11px] text-muted-foreground/70">{sub}</span> : null}
         </button>
         <div className="flex shrink-0 items-center gap-1">
           {required ? <Pill tone="danger">required</Pill> : null}
-          {hasConditional ? <Pill tone="warn">when…</Pill> : null}
+          {hasConditional ? <Pill tone="warn">when</Pill> : null}
           {locked ? <Pill tone="accent">locked</Pill> : null}
-          <Button type="button" variant="ghost" size="icon" className="size-7" aria-label="remove item" onClick={onRemove}>
-            <Trash2 className="size-4" />
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="size-6 text-muted-foreground opacity-40 transition-opacity hover:text-destructive group-hover/item:opacity-100"
+            aria-label="remove item"
+            onClick={onRemove}
+          >
+            <Trash2 className="size-3.5" />
           </Button>
         </div>
       </div>

--- a/packages/form-builder-ui/src/section-arranger.tsx
+++ b/packages/form-builder-ui/src/section-arranger.tsx
@@ -49,32 +49,35 @@ interface SortableItemCardProps {
 }
 
 function SortableItemCard({ item, config, builder, locales }: SortableItemCardProps) {
-  const { attributes, listeners, setNodeRef, transform, transition } = useSortable({ id: item.id });
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: item.id });
   const style: React.CSSProperties = {
     transform: CSS.Transform.toString(transform),
     transition,
+    opacity: isDragging ? 0.5 : undefined,
   };
 
+  const handle = (
+    <button
+      type="button"
+      className="cursor-grab text-muted-foreground/70 hover:text-foreground"
+      aria-label="drag item"
+      {...attributes}
+      {...listeners}
+    >
+      <GripVertical className="size-4" />
+    </button>
+  );
+
   return (
-    <div ref={setNodeRef} style={style} className="flex items-start gap-1">
-      <button
-        type="button"
-        className="mt-2 cursor-grab text-muted-foreground"
-        aria-label="drag item"
-        {...attributes}
-        {...listeners}
-      >
-        <GripVertical className="size-4" />
-      </button>
-      <div className="flex-1">
-        <ItemEditor
-          item={item}
-          siblingFields={siblingFieldsFor(config, item.id)}
-          locales={locales}
-          onUpdate={(patch) => builder.updateItem(item.id, patch as Partial<FormItem>)}
-          onRemove={() => builder.removeItem(item.id)}
-        />
-      </div>
+    <div ref={setNodeRef} style={style}>
+      <ItemEditor
+        item={item}
+        siblingFields={siblingFieldsFor(config, item.id)}
+        locales={locales}
+        dragHandle={handle}
+        onUpdate={(patch) => builder.updateItem(item.id, patch as Partial<FormItem>)}
+        onRemove={() => builder.removeItem(item.id)}
+      />
     </div>
   );
 }
@@ -128,35 +131,45 @@ interface SectionViewProps {
 }
 
 function SectionView({ section, config, builder, locales }: SectionViewProps) {
+  const itemCount = section.rows.reduce((n, r) => n + r.items.length, 0);
+  const title = section.title ? labelOf(section.title) : 'Section';
   return (
-    <div className="flex flex-col gap-0">
-      <NewRowDropZone id={`newrow:${section.id}:0`} />
-      {section.rows.map((row, rowIndex) => {
-        const itemIds = row.items.map((i) => i.id);
-        return (
-          <React.Fragment key={row.id}>
-            <div className="rounded-md border border-dashed border-input/60 p-2">
-              <SortableContext items={itemIds} strategy={verticalListSortingStrategy}>
-                <div className="flex flex-col gap-2">
-                  {row.items.map((item) => (
-                    <SortableItemCard
-                      key={item.id}
-                      item={item}
-                      config={config}
-                      builder={builder}
-                      locales={locales}
-                    />
-                  ))}
-                </div>
-              </SortableContext>
-              {/* Append-to-row drop zone (`row:<rowId>`). */}
-              <RowDropZone rowId={row.id} />
-            </div>
-            <NewRowDropZone id={`newrow:${section.id}:${rowIndex + 1}`} />
-          </React.Fragment>
-        );
-      })}
-    </div>
+    <section className="rounded-lg border bg-card/40">
+      <header className="flex items-center gap-2 border-b border-input px-3 py-2">
+        <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">{title}</span>
+        <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
+          {itemCount} item{itemCount === 1 ? '' : 's'}
+        </span>
+      </header>
+      <div className="flex flex-col gap-0 p-2">
+        <NewRowDropZone id={`newrow:${section.id}:0`} />
+        {section.rows.map((row, rowIndex) => {
+          const itemIds = row.items.map((i) => i.id);
+          return (
+            <React.Fragment key={row.id}>
+              <div className="rounded-md p-1">
+                <SortableContext items={itemIds} strategy={verticalListSortingStrategy}>
+                  <div className="flex flex-col gap-2">
+                    {row.items.map((item) => (
+                      <SortableItemCard
+                        key={item.id}
+                        item={item}
+                        config={config}
+                        builder={builder}
+                        locales={locales}
+                      />
+                    ))}
+                  </div>
+                </SortableContext>
+                {/* Append-to-row drop zone (`row:<rowId>`). */}
+                <RowDropZone rowId={row.id} />
+              </div>
+              <NewRowDropZone id={`newrow:${section.id}:${rowIndex + 1}`} />
+            </React.Fragment>
+          );
+        })}
+      </div>
+    </section>
   );
 }
 
@@ -186,7 +199,7 @@ export function SectionArranger({ config, builder, locales = ['en'] }: SectionAr
   const allItemIds = sections.flatMap((s) => s.rows).flatMap((r) => r.items.map((i) => i.id));
 
   return (
-    <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={onDragEnd}>
+    <DndContext id="form-builder-arranger" sensors={sensors} collisionDetection={closestCenter} onDragEnd={onDragEnd}>
       {/* Flat SortableContext for all items — dnd-kit needs a single context covering all draggables */}
       <SortableContext items={allItemIds} strategy={verticalListSortingStrategy}>
         <div className="flex flex-col gap-6">

--- a/packages/form-builder-ui/src/section-arranger.tsx
+++ b/packages/form-builder-ui/src/section-arranger.tsx
@@ -134,36 +134,34 @@ function SectionView({ section, config, builder, locales }: SectionViewProps) {
   const itemCount = section.rows.reduce((n, r) => n + r.items.length, 0);
   const title = section.title ? labelOf(section.title) : 'Section';
   return (
-    <section className="rounded-lg border bg-card/40">
-      <header className="flex items-center gap-2 border-b border-input px-3 py-2">
-        <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">{title}</span>
-        <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
+    <section className="overflow-hidden rounded-lg border border-input/70 bg-card/30">
+      <header className="flex items-center gap-2 bg-muted/30 px-3 py-1.5">
+        <span className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">{title}</span>
+        <span className="text-[10px] text-muted-foreground/60">
           {itemCount} item{itemCount === 1 ? '' : 's'}
         </span>
       </header>
-      <div className="flex flex-col gap-0 p-2">
+      <div className="flex flex-col p-1.5">
         <NewRowDropZone id={`newrow:${section.id}:0`} />
         {section.rows.map((row, rowIndex) => {
           const itemIds = row.items.map((i) => i.id);
           return (
             <React.Fragment key={row.id}>
-              <div className="rounded-md p-1">
-                <SortableContext items={itemIds} strategy={verticalListSortingStrategy}>
-                  <div className="flex flex-col gap-2">
-                    {row.items.map((item) => (
-                      <SortableItemCard
-                        key={item.id}
-                        item={item}
-                        config={config}
-                        builder={builder}
-                        locales={locales}
-                      />
-                    ))}
-                  </div>
-                </SortableContext>
-                {/* Append-to-row drop zone (`row:<rowId>`). */}
-                <RowDropZone rowId={row.id} />
-              </div>
+              <SortableContext items={itemIds} strategy={verticalListSortingStrategy}>
+                <div className="flex flex-col gap-0.5">
+                  {row.items.map((item) => (
+                    <SortableItemCard
+                      key={item.id}
+                      item={item}
+                      config={config}
+                      builder={builder}
+                      locales={locales}
+                    />
+                  ))}
+                </div>
+              </SortableContext>
+              {/* Append-to-row drop zone (`row:<rowId>`). */}
+              <RowDropZone rowId={row.id} />
               <NewRowDropZone id={`newrow:${section.id}:${rowIndex + 1}`} />
             </React.Fragment>
           );
@@ -202,7 +200,7 @@ export function SectionArranger({ config, builder, locales = ['en'] }: SectionAr
     <DndContext id="form-builder-arranger" sensors={sensors} collisionDetection={closestCenter} onDragEnd={onDragEnd}>
       {/* Flat SortableContext for all items — dnd-kit needs a single context covering all draggables */}
       <SortableContext items={allItemIds} strategy={verticalListSortingStrategy}>
-        <div className="flex flex-col gap-6">
+        <div className="flex flex-col gap-3">
           {sections.map((section) => (
             <SectionView
               key={section.id}


### PR DESCRIPTION
## What

**Visual polish + UX fixes for the form-builder builder** to match the agreed v2 mockup. After v2 Groups 1–2 (#200–202) the builder was functionally complete but visually bare ("a wall of fully-expanded forms") and the live preview rendered fields at the wrong width. **UI-only — no engine/model change.**

### Builder craft (refined-minimalism)
- **Collapsible kind-accented item cards** → **airy borderless rows inside one section card** (no more box-in-box). Each row: a thin **inset** left color-bar by kind (field/content/divider/spacer/ai-note), kind icon, a one-line summary (`title · key · type`), and `required`/`when`/`locked` pills. Click to expand.
- **Expanded item = a focused panel** (subtle surface + border + shadow), with a **multi-column property grid** (the prior arbitrary `grid-cols-[…]` class was never emitted, so it had been single-column).
- **Motion + depth**: rotating chevron, content reveal on expand, hover-revealed drag/remove controls.
- **Cohesive cool palette tuned to read in BOTH light and dark** (theme-aware ring; mid-tone accents/pills).
- **Section cards** with a header (title + item count). Stable `DndContext id` fixes a known dnd-kit SSR hydration warning.

### Live-preview width fix
- `<ConfigForm>` preview fields rendered at their **intrinsic width** (not full-width) because `basis-full` / `col-span-full` weren't emitted by the app's Tailwind build for this package. Switched to **inline `flex-basis` / `grid-column` styles** (guaranteed), and gave the `Select` trigger `w-full`. Fields (Input/Select/Textarea, full + half) now size correctly.

### Demo seed → v2 sections
- The showcase config is now a v2 `sections` config (Account / Profile) exercising every kind + validation + a conditional + a per-field AI note, so the kinds/accents are visible out of the box.

Kind colors and the property grid use inline `style` (the web-ui preset doesn't emit those arbitrary palette/grid classes); values are static, SSR/hydration-safe.

## Testing
- `@rfjs/form-builder-ui` **145**, `@rfjs/form-builder` **116**, `apps/web` **73** — all green. All `@rfjs/*` build; UI + `apps/web` `tsc --noEmit` clean.
- Verified visually with local headless screenshots in **both light and dark** (collapsed, expanded, and the preview width fix). No changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
