### PR TITLE
feat(form-builder): external API dataSource (v2-G)

### DIFF
--- a/apps/web/src/tools/form-builder/ui.tsx
+++ b/apps/web/src/tools/form-builder/ui.tsx
@@ -1,7 +1,24 @@
 "use client";
 
-import type { FormConfig } from "@rfjs/form-builder";
+import type { FormConfig, DataSourceFetcher } from "@rfjs/form-builder";
 import { ConfigFormBuilder } from "@rfjs/form-builder-ui";
+
+// ---------------------------------------------------------------------------
+// Mock fetcher — no network. Returns canned data for known URLs.
+// Module-level const is a stable reference (no re-fetch loops).
+// ---------------------------------------------------------------------------
+const mockFetcher: DataSourceFetcher = async (req) => {
+  if (req.url === "/api/countries") {
+    return {
+      data: [
+        { code: "tw", name: "Taiwan" },
+        { code: "jp", name: "Japan" },
+        { code: "us", name: "United States" },
+      ],
+    };
+  }
+  return { data: [] };
+};
 
 // A v2 sections config showcasing the item-kind model (content / field / ai-note /
 // divider), validation, a conditional, a per-field AI note — and the v2-E field
@@ -116,6 +133,26 @@ const SAMPLE_CONFIG: FormConfig = {
           ],
         },
         {
+          id: "r_country",
+          items: [
+            {
+              id: "i_country",
+              kind: "field",
+              key: "country",
+              label: { en: "Country", "zh-TW": "國家" },
+              component: "Select",
+              dataType: "string",
+              dataSource: {
+                request: { url: "/api/countries" },
+                extract: { dialect: "path", expr: "data" },
+                optionLabel: "name",
+                optionValue: "code",
+                fallback: "無",
+              },
+            },
+          ],
+        },
+        {
           id: "r_newsletter",
           items: [
             { id: "i_newsletter", kind: "field", key: "newsletter", label: { en: "Subscribe to newsletter", "zh-TW": "訂閱電子報" }, component: "Switch", dataType: "boolean" },
@@ -130,7 +167,7 @@ const SAMPLE_CONFIG: FormConfig = {
 export function FormBuilderTool() {
   return (
     <div className="flex flex-col gap-5">
-      <ConfigFormBuilder initialConfig={SAMPLE_CONFIG} locales={["en", "zh-TW"]} />
+      <ConfigFormBuilder initialConfig={SAMPLE_CONFIG} locales={["en", "zh-TW"]} fetcher={mockFetcher} />
     </div>
   );
 }

--- a/docs/superpowers/plans/2026-06-28-form-builder-v2g-datasource.md
+++ b/docs/superpowers/plans/2026-06-28-form-builder-v2g-datasource.md
@@ -1,0 +1,134 @@
+# Form Builder v2-G (external API dataSource) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Let a field/content item pull values from an **external API** at runtime — to populate dynamic **Select/Radio options**, display a **content** value, or seed a **default** — with a **pluggable fetcher** (the component never hardcodes network/auth), value extraction via **`path` (object-utils)** or **`jsonata` (data-expr)**, and loading / empty / error / **fallback** states.
+
+**Architecture:** Engine `@rfjs/form-builder` gains a `DataSource` type + schema and pure helpers: `extractValue(dialect, expr, data)` (path→`getByPath`, jsonata→`compile().evaluate()`), `loadDataSource(ds, fetcher)`, and `toOptions(list, ds)`. The UI `@rfjs/form-builder-ui` gets a `useDataSource(ds, fetcher)` hook + a `fetcher` prop threaded through `<ConfigForm>`; `<FieldControl>` uses dynamic options for Select/Radio when a `dataSource` is present, content items show the fetched value, all with loading/error/fallback. The builder gets a DataSource editor sub-block.
+
+**Tech Stack:** TypeScript, zod v4, react-hook-form, `@rfjs/object-utils` (`getByPath`), `@rfjs/data-expr` (`compile`), `@rfjs/web-ui`, vitest jsdom.
+
+## Global Constraints
+
+- **Pluggable fetcher (non-negotiable):** the components NEVER call `fetch` directly. `fetcher: (req: DataSourceRequest) => Promise<unknown>` is injected by the consumer (via a `<ConfigForm fetcher={...}>` prop / passed down from the builder). When no `fetcher` is provided, dataSource features are inert (render the static control / fallback) — never throw.
+- **Back-compat:** items without `dataSource` behave exactly as today. New field is optional & additive.
+- Dialects: **`path`** (`@rfjs/object-utils` `getByPath`) and **`jsonata`** (`@rfjs/data-expr` `compile(expr).evaluate(data)`, async). `'jsonpath'` is reserved in the type union but NOT implemented here (throws a clear "unsupported dialect" — documented; avoids a new dep). 
+- Engine builds to dist; build it before UI tests in a fresh worktree. Co-locate `*.spec`. Conventional Commits (header ≤100 chars). pre-commit passes; no `--no-verify`; **no changeset**.
+- jsonata `evaluate` is async → `extractValue`/`loadDataSource` are async. The UI hook handles the promise + React state.
+
+## Engine type model (defined once)
+
+```ts
+// types.ts
+export interface DataSourceRequest {
+  url: string;
+  method?: 'GET' | 'POST' | 'PUT' | 'DELETE';
+  headers?: Record<string, string>;
+  body?: unknown;
+}
+export type DataSourceDialect = 'path' | 'jsonata' | 'jsonpath';
+export interface DataSourceExtract { dialect: DataSourceDialect; expr: string }
+export interface DataSource {
+  request: DataSourceRequest;
+  extract: DataSourceExtract;       // → the value (scalar for content/default; list for options)
+  fallback?: string;                // shown on empty/error; default '無'
+  optionLabel?: string;             // for options: path within each list item → label (default: the item)
+  optionValue?: string;             // for options: path within each list item → value (default: the item)
+}
+export type DataSourceFetcher = (req: DataSourceRequest) => Promise<unknown>;
+// add `dataSource?: DataSource` to FieldItem and ContentItem
+```
+
+---
+
+### Task 1: Engine — `DataSource` types + schema
+
+**Files:** `packages/form-builder/src/types.ts`, `config-schema.ts`, `config-schema.spec.ts`.
+
+- [ ] Add the types above to `types.ts`; add `dataSource?: DataSource` to `FieldItem` and `ContentItem` (and to `FieldConfig` so v1 fields can carry it too — put `dataSource?` on `FieldConfig`; `FieldItem extends FieldConfig` inherits it).
+- [ ] `config-schema.ts`: a structural `dataSourceSchema` (`request: { url: string, method?: enum, headers?: record, body?: unknown }`, `extract: { dialect: enum['path','jsonata','jsonpath'], expr: string }`, `fallback?: string`, `optionLabel?: string`, `optionValue?: string`), `.optional()` on `fieldConfigSchema` and `contentItemSchema`.
+- [ ] TDD: a config with a valid `dataSource` parses; a malformed one (missing `extract.expr`, bad `dialect`) is rejected. RED→GREEN.
+- [ ] Build engine; `vitest:run`; commit `feat(form-builder): add DataSource types + schema`.
+
+---
+
+### Task 2: Engine — `extractValue` / `loadDataSource` / `toOptions`
+
+**Files:** Create `packages/form-builder/src/data-source.ts`, `data-source.spec.ts`; export from `src/index.ts`. Add `@rfjs/object-utils` + `@rfjs/data-expr` as workspace deps of `@rfjs/form-builder`.
+
+**Interfaces:**
+- `extractValue(dialect, expr, data): Promise<unknown>` — `path`→`getByPath(data, expr)` (wrap sync in resolved promise); `jsonata`→`compile(expr).evaluate(data)`; `jsonpath`→`throw new Error('dataSource: jsonpath dialect not supported yet')`.
+- `loadDataSource(ds, fetcher): Promise<unknown>` — `extractValue(ds.extract.dialect, ds.extract.expr, await fetcher(ds.request))`.
+- `toOptions(extracted, ds): FieldOption[]` — if `extracted` isn't an array → `[]`; else map each item to `{ label: String(ds.optionLabel ? getByPath(item, ds.optionLabel) : item), value: ... ds.optionValue ... }`; if an item is already `{label,value}` and no optionLabel/Value given, pass through.
+
+- [ ] Add deps (`pnpm install`). TDD `data-source.spec.ts`:
+  - `extractValue('path', 'a.b', {a:{b:5}})` → 5; `extractValue('jsonata', 'items[0].name', {...})` → value; `jsonpath` → throws.
+  - `loadDataSource` with a fake fetcher returning `{items:[...]}` and `extract path 'items'` → the list.
+  - `toOptions([{id:1,name:'A'}], {optionLabel:'name', optionValue:'id'})` → `[{label:'A', value:1}]`; `toOptions(['x','y'], {})` → `[{label:'x',value:'x'},...]`; `toOptions('not-array', {})` → `[]`.
+  RED→GREEN.
+- [ ] Build; `vitest:run`; commit `feat(form-builder): dataSource extract/load/toOptions (path + jsonata)`.
+
+---
+
+### Task 3: UI — `useDataSource` hook
+
+**Files:** Create `packages/form-builder-ui/src/use-data-source.ts`, `use-data-source.spec.ts`; export from barrel.
+
+**Interfaces:** `useDataSource(ds: DataSource | undefined, fetcher?: DataSourceFetcher): { status: 'idle'|'loading'|'ready'|'error'; value: unknown; options: FieldOption[]; error?: string }`. On mount / when `ds`+`fetcher` identity changes: if both present → `loading` → `loadDataSource` → `ready` (set `value`; `options = toOptions(value, ds)`) or `error`. If `ds` or `fetcher` missing → `idle`. Guard against setState-after-unmount (an `active` flag in the effect).
+
+- [ ] TDD (`@testing-library/react` `renderHook` + `waitFor`): with a resolving fake fetcher → ends `ready` with options; with a rejecting fetcher → `error`; with no fetcher → `idle`. RED→GREEN.
+- [ ] Build engine; `vitest:run`; `check-types`; commit `feat(form-builder-ui): useDataSource hook`.
+
+---
+
+### Task 4: UI — dynamic options in `<ConfigForm>`/`<FieldControl>` (Select/Radio)
+
+**Files:** `packages/form-builder-ui/src/config-form.tsx` (thread `fetcher` prop), `field-control.tsx` (consume), specs.
+
+- [ ] `ConfigFormProps` gains `fetcher?: DataSourceFetcher`; pass it to each `<FieldControl fetcher={fetcher} .../>`. `FieldControlProps` gains `fetcher?`.
+- [ ] In `FieldControl`, for `Select`/`Radio` when `field.dataSource` is present: call `useDataSource(field.dataSource, fetcher)`. While `loading` → render the control disabled with a "Loading…" placeholder; on `ready` → use the fetched `options` (instead of `field.options`); on `error`/empty → render the `fallback` text (`field.dataSource.fallback ?? '無'`). When no `dataSource` → existing static `field.options` path unchanged.
+- [ ] TDD (`field-control.spec.tsx`): a `Select` with a `dataSource` + a resolving fake fetcher → after `waitFor`, the fetched options render (not the static ones); a rejecting fetcher → the fallback text shows. (radix Select popover isn't driven — assert the options exist in the DOM / the trigger/fallback text. For Radio the options are radios — assert count after load.) Keep existing FieldControl tests green.
+- [ ] Build engine; `vitest:run`; `check-types`; commit `feat(form-builder-ui): dynamic Select/Radio options via dataSource`.
+
+---
+
+### Task 5: UI — `content` item display value via dataSource
+
+**Files:** `packages/form-builder-ui/src/config-form.tsx`, `config-form.spec.tsx`.
+
+- [ ] In `renderItem` for `kind === 'content'`: if `item.dataSource` is present, render a small `<DataSourceContent ds fetcher fallback />` subcomponent that uses `useDataSource` → shows the resolved `value` (String) when `ready`, a muted "Loading…" while loading, and the `fallback` on error/empty. Without `dataSource`, render the static `resolveLabel(text)` exactly as today.
+- [ ] TDD: a content item with a `dataSource` + resolving fetcher → shows the fetched value; rejecting → shows fallback; no dataSource → shows the static text. Keep existing ConfigForm tests green.
+- [ ] Build engine; `vitest:run`; `check-types`; commit `feat(form-builder-ui): content item shows external dataSource value`.
+
+---
+
+### Task 6: Builder — DataSource editor sub-block in `FieldRow`
+
+**Files:** `packages/form-builder-ui/src/field-row.tsx`, `field-row.spec.tsx`.
+
+- [ ] In `FieldItemEditor`, add a **Data source** sub-block (Inputs): `url`, `method` (Select GET/POST/…), `dialect` (Select path/jsonata), `expr`, `fallback`, and (for Select/Radio) `optionLabel`/`optionValue`. Each updates `onUpdate({ dataSource: { ...field.dataSource, request: {...}, extract: {...}, ... } })`. Empty `url` clears `dataSource` (→ undefined). Extract pure mergers (mirror `mergeValidation`) so the merge logic is unit-tested.
+- [ ] TDD: editing the url sets `dataSource.request.url`; changing dialect sets `extract.dialect`; clearing url removes `dataSource`. (radix Select trigger-value assertions; the pure mergers unit-tested directly.) Keep existing FieldRow tests green.
+- [ ] Build engine; `vitest:run`; `check-types`; commit `feat(form-builder-ui): add dataSource editor to FieldRow`.
+
+---
+
+### Task 7: Demo — inject a mock fetcher in apps/web + a dataSource field in the seed
+
+**Files:** `apps/web/src/tools/form-builder/ui.tsx`.
+
+- [ ] Provide a small **mock** `fetcher` (no network — returns canned JSON for a known url, e.g. a list of countries) and pass it to `<ConfigFormBuilder fetcher={...}>` (thread `fetcher` through `ConfigFormBuilder` → `ConfigForm` preview). Add one seed field (e.g. a `Select` "country") with a `dataSource` pointing at the mock url + `extract: { dialect:'path', expr:'data' }` + `optionLabel/optionValue`. (Thread a `fetcher?` prop through `ConfigFormBuilderProps` → the preview `<ConfigForm fetcher>`.)
+- [ ] `check-types` for `apps/web`. Commit `feat(web): demo dataSource (mock fetcher) in the form-builder seed`.
+
+---
+
+## Self-Review
+
+**Spec coverage (§4.8):** dataSource shape (request/extract/fallback) → T1; extraction path+jsonata + options mapping → T2; runtime fetch + loading/error/fallback → T3; dynamic Select/Radio options → T4; content display value → T5; pluggable fetcher (injected, never hardcoded) → T3/T4/T7; builder authoring → T6; demo → T7.
+
+**Out of scope (documented):** `jsonpath` dialect (reserved, throws); dataSource-as-field-**default-value** (the spec's "可選" — deferred; options + content cover the main uses); the deferred visual/UX overhaul.
+
+**Placeholder scan:** engine tasks have concrete signatures + tests. UI tasks specify the hook contract + the loading/error/fallback behavior + which assertions (radix not driven). No open TODOs.
+
+**Type consistency:** `DataSource`/`DataSourceFetcher`/`FieldOption` names consistent across engine + UI. `extractValue`/`loadDataSource`/`toOptions` (T2) consumed by `useDataSource` (T3) consumed by FieldControl/ConfigForm (T4/T5). `fetcher` prop threaded `ConfigFormBuilder`→`ConfigForm`→`FieldControl`.
+
+**Risk notes:** (1) jsonata `evaluate` is async → all extraction async; the hook must guard setState-after-unmount. (2) No-fetcher path must be inert, never throw. (3) radix Select dynamic options aren't driveable in jsdom → assert option presence in DOM + fallback text + unit-test the pure helpers. (4) `getByPath` returns `undefined` for missing paths → `toOptions` treats non-array as `[]` (→ fallback). (5) `@rfjs/object-utils`/`@rfjs/data-expr` added as engine deps (workspace).

--- a/packages/form-builder-ui/src/config-form-builder.spec.tsx
+++ b/packages/form-builder-ui/src/config-form-builder.spec.tsx
@@ -22,9 +22,9 @@ if (typeof window !== 'undefined' && !window.ResizeObserver) {
 }
 
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent, within } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import { ConfigFormBuilder } from './config-form-builder';
-import type { FormConfig } from '@rfjs/form-builder';
+import type { FormConfig, DataSourceFetcher } from '@rfjs/form-builder';
 
 const empty: FormConfig = { version: 1, fields: [] };
 const initial: FormConfig = { version: 1, fields: [{ key: 'name', label: 'Name', component: 'Input', dataType: 'string' }] };
@@ -155,5 +155,71 @@ describe('ConfigFormBuilder', () => {
     fireEvent.change(screen.getByLabelText(/config json/i), { target: { value: '{ not json' } });
     expect(screen.getByText(/invalid/i)).toBeTruthy();
     expect(onChange).not.toHaveBeenCalled();
+  });
+});
+
+describe('ConfigFormBuilder fetcher threading', () => {
+  // A config with a dataSource Select field — the fetcher returns canned country options.
+  const withDataSource: FormConfig = {
+    version: 1,
+    sections: [
+      {
+        id: 'sec_1',
+        rows: [
+          {
+            id: 'row_1',
+            items: [
+              {
+                id: 'i_country',
+                kind: 'field',
+                key: 'country',
+                label: { en: 'Country' },
+                component: 'Select',
+                dataType: 'string',
+                dataSource: {
+                  request: { url: '/api/countries' },
+                  extract: { dialect: 'path', expr: 'data' },
+                  optionLabel: 'name',
+                  optionValue: 'code',
+                  fallback: '無',
+                },
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+
+  it('renders without error when fetcher + dataSource Select field are provided', async () => {
+    const fetcher: DataSourceFetcher = vi.fn().mockResolvedValue({
+      data: [
+        { code: 'tw', name: 'Taiwan' },
+        { code: 'jp', name: 'Japan' },
+      ],
+    });
+
+    render(<ConfigFormBuilder initialConfig={withDataSource} fetcher={fetcher} />);
+
+    // The preview panel is rendered (not the empty-state placeholder).
+    const preview = screen.getByTestId('config-form-preview');
+    expect(preview.textContent).not.toMatch(/preview will appear/i);
+
+    // The Country label is visible in the preview (field was threaded through).
+    await waitFor(() => {
+      expect(within(preview).getByText('Country')).toBeTruthy();
+    });
+
+    // The fetcher was called with the dataSource request (Select options were loaded).
+    expect(fetcher).toHaveBeenCalledWith(expect.objectContaining({ url: '/api/countries' }));
+  });
+
+  it('renders without error when no fetcher is provided (inert, shows fallback)', () => {
+    // No fetcher → idle state → fallback text rendered in the trigger area or control.
+    render(<ConfigFormBuilder initialConfig={withDataSource} />);
+    const preview = screen.getByTestId('config-form-preview');
+    expect(preview.textContent).not.toMatch(/preview will appear/i);
+    // Country label is still visible — the field renders in idle/fallback state.
+    expect(within(preview).getByText('Country')).toBeTruthy();
   });
 });

--- a/packages/form-builder-ui/src/config-form-builder.tsx
+++ b/packages/form-builder-ui/src/config-form-builder.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import * as React from 'react';
-import type { FormConfig, FormItem, ItemKind } from '@rfjs/form-builder';
+import type { FormConfig, FormItem, ItemKind, DataSourceFetcher } from '@rfjs/form-builder';
 import { parseFormConfig, normalizeToSections, makeItem } from '@rfjs/form-builder';
 import { Button } from '@rfjs/web-ui/components/button';
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@rfjs/web-ui/components/select';
@@ -35,9 +35,14 @@ export interface ConfigFormBuilderProps {
   onChange?: (config: FormConfig) => void;
   locale?: string;
   locales?: string[];
+  /**
+   * Pluggable fetcher for `dataSource` fields. Passed through to the live preview `<ConfigForm>`.
+   * Memoize with `useCallback` (or a module-level const) to avoid re-fetch loops.
+   */
+  fetcher?: DataSourceFetcher;
 }
 
-export function ConfigFormBuilder({ initialConfig = EMPTY, onChange, locale = 'en', locales = ['en'] }: ConfigFormBuilderProps) {
+export function ConfigFormBuilder({ initialConfig = EMPTY, onChange, locale = 'en', locales = ['en'], fetcher }: ConfigFormBuilderProps) {
   const builder = useConfigBuilder(initialConfig, onChange);
 
   // The form is "empty" only when no items exist at all (covers both v1 fields[] and v2 sections[]).
@@ -172,6 +177,7 @@ export function ConfigFormBuilder({ initialConfig = EMPTY, onChange, locale = 'e
               <ConfigForm
                 config={builder.config}
                 locale={locale}
+                fetcher={fetcher}
                 onSubmit={() => {}}
               />
             )}

--- a/packages/form-builder-ui/src/config-form.spec.tsx
+++ b/packages/form-builder-ui/src/config-form.spec.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { ConfigForm } from './config-form';
-import type { FormConfig } from '@rfjs/form-builder';
+import type { FormConfig, DataSource } from '@rfjs/form-builder';
 
 const baseConfig: FormConfig = {
   version: 1,
@@ -294,6 +294,55 @@ describe('grid layout', () => {
     expect(container.querySelector('form')!.getAttribute('data-columns')).toBe('1');
     // a field with no explicit width defaults to full → spans the single column
     expect((container.querySelector('[data-width="full"]') as HTMLElement).style.gridColumn).toBe('1 / -1');
+  });
+});
+
+describe('content item dataSource', () => {
+  const ds: DataSource = {
+    request: { url: 'https://example.com/api/value' },
+    extract: { dialect: 'path', expr: 'result' },
+    fallback: '—',
+  };
+
+  function makeCfg(dataSource?: DataSource): FormConfig {
+    return {
+      version: 1,
+      sections: [
+        {
+          id: 's1',
+          rows: [
+            {
+              id: 'r1',
+              items: [{ id: 'c1', kind: 'content', text: 'Static text', ...(dataSource ? { dataSource } : {}) }],
+            },
+          ],
+        },
+      ],
+    } as unknown as FormConfig;
+  }
+
+  it('shows the fetched value when dataSource resolves', async () => {
+    const fetcher = vi.fn().mockResolvedValue({ result: 'Fetched Value' });
+    render(<ConfigForm config={makeCfg(ds)} fetcher={fetcher} onSubmit={() => {}} />);
+    await waitFor(() => expect(screen.getByText('Fetched Value')).toBeTruthy());
+  });
+
+  it('shows the fallback when the fetcher rejects', async () => {
+    const fetcher = vi.fn().mockRejectedValue(new Error('Network error'));
+    render(<ConfigForm config={makeCfg(ds)} fetcher={fetcher} onSubmit={() => {}} />);
+    await waitFor(() => expect(screen.getByText('—')).toBeTruthy());
+  });
+
+  it('shows the default fallback (無) when ds has no fallback and fetcher rejects', async () => {
+    const dsNoFallback: DataSource = { request: { url: '/api' }, extract: { dialect: 'path', expr: 'v' } };
+    const fetcher = vi.fn().mockRejectedValue(new Error('fail'));
+    render(<ConfigForm config={makeCfg(dsNoFallback)} fetcher={fetcher} onSubmit={() => {}} />);
+    await waitFor(() => expect(screen.getByText('無')).toBeTruthy());
+  });
+
+  it('shows the static text when no dataSource is present', () => {
+    render(<ConfigForm config={makeCfg()} onSubmit={() => {}} />);
+    expect(screen.getByText('Static text')).toBeTruthy();
   });
 });
 

--- a/packages/form-builder-ui/src/config-form.tsx
+++ b/packages/form-builder-ui/src/config-form.tsx
@@ -12,6 +12,7 @@ import {
   isFieldItem,
   type FormConfig,
   type FormItem,
+  type DataSourceFetcher,
 } from '@rfjs/form-builder';
 import { Label } from '@rfjs/web-ui/components/label';
 import { Button } from '@rfjs/web-ui/components/button';
@@ -30,9 +31,14 @@ export interface ConfigFormProps {
   submitLabel?: string;
   /** BCP-47 locale used to resolve `LocalizedLabel` field labels. Defaults to `'en'`. */
   locale?: string;
+  /**
+   * Fetcher for `dataSource` fields (Select/Radio). Receives a `DataSourceRequest` and
+   * returns the raw response. Memoize with `useCallback` to avoid unnecessary refetches.
+   */
+  fetcher?: DataSourceFetcher;
 }
 
-export function ConfigForm({ config, defaultValues, onSubmit, submitLabel = 'Submit', locale = 'en' }: ConfigFormProps) {
+export function ConfigForm({ config, defaultValues, onSubmit, submitLabel = 'Submit', locale = 'en', fetcher }: ConfigFormProps) {
   // Keep the latest config reachable inside the stable resolver without re-creating it.
   const configRef = React.useRef(config);
   configRef.current = config;
@@ -110,7 +116,7 @@ export function ConfigForm({ config, defaultValues, onSubmit, submitLabel = 'Sub
           control={control}
           name={item.key}
           render={({ field: rhf }) => (
-            <FieldControl field={item} value={rhf.value} onChange={rhf.onChange} />
+            <FieldControl field={item} value={rhf.value} onChange={rhf.onChange} fetcher={fetcher} />
           )}
         />
         {errors[item.key]?.message && (

--- a/packages/form-builder-ui/src/config-form.tsx
+++ b/packages/form-builder-ui/src/config-form.tsx
@@ -12,12 +12,35 @@ import {
   isFieldItem,
   type FormConfig,
   type FormItem,
+  type DataSource,
   type DataSourceFetcher,
 } from '@rfjs/form-builder';
+import { useDataSource } from './use-data-source';
 import { Label } from '@rfjs/web-ui/components/label';
 import { Button } from '@rfjs/web-ui/components/button';
 
 import { FieldControl } from './field-control';
+
+interface DataSourceContentProps {
+  ds: DataSource;
+  fetcher?: DataSourceFetcher;
+}
+
+function DataSourceContent({ ds, fetcher }: DataSourceContentProps) {
+  const dsState = useDataSource(ds, fetcher);
+
+  if (dsState.status === 'loading') {
+    return <span className="text-muted-foreground">Loading…</span>;
+  }
+
+  if (dsState.status === 'ready') {
+    const display = dsState.value != null && dsState.value !== '' ? String(dsState.value) : (ds.fallback ?? '無');
+    return <span>{display}</span>;
+  }
+
+  // idle or error → fallback
+  return <span>{ds.fallback ?? '無'}</span>;
+}
 
 export interface ConfigFormProps {
   /**
@@ -97,7 +120,11 @@ export function ConfigForm({ config, defaultValues, onSubmit, submitLabel = 'Sub
       if (!evaluateConditional(item.conditional, vals)) return null;
       return (
         <div key={item.id} className="text-sm" style={fullSpan(flow)}>
-          {resolveLabel(item.text, locale)}
+          {item.dataSource ? (
+            <DataSourceContent ds={item.dataSource} fetcher={fetcher} />
+          ) : (
+            resolveLabel(item.text, locale)
+          )}
         </div>
       );
     }

--- a/packages/form-builder-ui/src/field-control.spec.tsx
+++ b/packages/form-builder-ui/src/field-control.spec.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeAll } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { FieldControl, dateToISO, isoToDate } from './field-control';
-import type { FieldConfig } from '@rfjs/form-builder';
+import type { FieldConfig, DataSource, DataSourceFetcher } from '@rfjs/form-builder';
 
 // jsdom shims for Radix UI components
 beforeAll(() => {
@@ -128,6 +128,72 @@ describe('FieldControl', () => {
     render(<FieldControl field={field} value="2024-03-15" onChange={() => {}} />);
     const btn = screen.getByRole('button');
     expect(btn.textContent).toContain('2024-03-15');
+  });
+});
+
+const ds: DataSource = {
+  request: { url: 'http://example.com/api' },
+  extract: { dialect: 'path', expr: 'items' },
+  optionLabel: 'name',
+  optionValue: 'id',
+};
+
+describe('FieldControl with dataSource', () => {
+  it('Radio + dataSource + resolving fetcher → renders fetched options as radios after load', async () => {
+    const fetcher: DataSourceFetcher = vi.fn().mockResolvedValue({
+      items: [{ id: 'a', name: 'Alpha' }, { id: 'b', name: 'Beta' }],
+    });
+    const field: FieldConfig = {
+      key: 'choice',
+      label: 'Choice',
+      component: 'Radio',
+      dataType: 'string',
+      dataSource: ds,
+    };
+    render(<FieldControl field={field} value="" onChange={() => {}} fetcher={fetcher} />);
+    await waitFor(() => expect(screen.getAllByRole('radio')).toHaveLength(2));
+    expect(screen.getByLabelText('Alpha')).toBeTruthy();
+    expect(screen.getByLabelText('Beta')).toBeTruthy();
+  });
+
+  it('Radio + dataSource + rejecting fetcher → shows fallback text', async () => {
+    const fetcher: DataSourceFetcher = vi.fn().mockRejectedValue(new Error('Network error'));
+    const field: FieldConfig = {
+      key: 'choice',
+      label: 'Choice',
+      component: 'Radio',
+      dataType: 'string',
+      dataSource: { ...ds, fallback: '無可選項' },
+    };
+    render(<FieldControl field={field} value="" onChange={() => {}} fetcher={fetcher} />);
+    await waitFor(() => expect(screen.getByText('無可選項')).toBeTruthy());
+  });
+
+  it('Radio + dataSource, ready but empty options → shows fallback', async () => {
+    const fetcher: DataSourceFetcher = vi.fn().mockResolvedValue({ items: [] });
+    const field: FieldConfig = {
+      key: 'choice',
+      label: 'Choice',
+      component: 'Radio',
+      dataType: 'string',
+      dataSource: { ...ds, fallback: 'N/A' },
+    };
+    render(<FieldControl field={field} value="" onChange={() => {}} fetcher={fetcher} />);
+    await waitFor(() => expect(screen.getByText('N/A')).toBeTruthy());
+  });
+
+  it('Radio without dataSource → static options unchanged', () => {
+    const field: FieldConfig = {
+      key: 'color',
+      label: 'Color',
+      component: 'Radio',
+      dataType: 'string',
+      options: [{ label: 'Red', value: 'red' }, { label: 'Blue', value: 'blue' }],
+    };
+    render(<FieldControl field={field} value="" onChange={() => {}} />);
+    expect(screen.getAllByRole('radio')).toHaveLength(2);
+    expect(screen.getByLabelText('Red')).toBeTruthy();
+    expect(screen.getByLabelText('Blue')).toBeTruthy();
   });
 });
 

--- a/packages/form-builder-ui/src/field-control.tsx
+++ b/packages/form-builder-ui/src/field-control.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import * as React from 'react';
-import type { FieldConfig } from '@rfjs/form-builder';
+import type { FieldConfig, DataSourceFetcher } from '@rfjs/form-builder';
 import { Input } from '@rfjs/web-ui/components/input';
 import { Textarea } from '@rfjs/web-ui/components/textarea';
 import { Checkbox } from '@rfjs/web-ui/components/checkbox';
@@ -18,11 +18,13 @@ import { Label } from '@rfjs/web-ui/components/label';
 import { Button } from '@rfjs/web-ui/components/button';
 import { Popover, PopoverContent, PopoverTrigger } from '@rfjs/web-ui/components/popover';
 import { Calendar } from '@rfjs/web-ui/components/calendar';
+import { useDataSource } from './use-data-source';
 
 export interface FieldControlProps {
   field: FieldConfig;
   value: unknown;
   onChange: (value: unknown) => void;
+  fetcher?: DataSourceFetcher;
 }
 
 /** Format a Date as a LOCAL `yyyy-mm-dd` ISO string (no UTC shift). */
@@ -41,7 +43,128 @@ export function isoToDate(s: string | undefined): Date | undefined {
   return new Date(y, m - 1, d);
 }
 
-export function FieldControl({ field, value, onChange }: FieldControlProps) {
+// --- Sub-components for controls that use hooks ---
+
+interface SelectControlProps {
+  field: FieldConfig;
+  value: unknown;
+  onChange: (value: unknown) => void;
+  fetcher?: DataSourceFetcher;
+}
+
+function SelectControl({ field, value, onChange, fetcher }: SelectControlProps) {
+  // Hook ALWAYS called unconditionally — returns idle when ds or fetcher is absent.
+  const dsState = useDataSource(field.dataSource, fetcher);
+
+  if (field.dataSource) {
+    if (dsState.status === 'loading') {
+      return (
+        <Select disabled>
+          <SelectTrigger id={field.key} className="w-full">
+            <SelectValue placeholder="Loading…" />
+          </SelectTrigger>
+          <SelectContent />
+        </Select>
+      );
+    }
+    if (dsState.status === 'ready' && dsState.options.length > 0) {
+      return (
+        <Select value={(value as string) ?? ''} onValueChange={onChange}>
+          <SelectTrigger id={field.key} className="w-full">
+            <SelectValue placeholder={field.placeholder} />
+          </SelectTrigger>
+          <SelectContent>
+            {dsState.options.map((opt) => (
+              <SelectItem key={String(opt.value)} value={String(opt.value)}>
+                {opt.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      );
+    }
+    // error, idle (no fetcher), or ready with empty options → fallback
+    return (
+      <span className="text-sm text-muted-foreground">
+        {field.dataSource.fallback ?? '無'}
+      </span>
+    );
+  }
+
+  // No dataSource → static options (unchanged behavior)
+  return (
+    <Select value={(value as string) ?? ''} onValueChange={onChange}>
+      <SelectTrigger id={field.key} className="w-full">
+        <SelectValue placeholder={field.placeholder} />
+      </SelectTrigger>
+      <SelectContent>
+        {(field.options ?? []).map((opt) => (
+          <SelectItem key={String(opt.value)} value={String(opt.value)}>
+            {opt.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}
+
+interface RadioControlProps {
+  field: FieldConfig;
+  value: unknown;
+  onChange: (value: unknown) => void;
+  fetcher?: DataSourceFetcher;
+}
+
+function RadioControl({ field, value, onChange, fetcher }: RadioControlProps) {
+  // Hook ALWAYS called unconditionally — returns idle when ds or fetcher is absent.
+  const dsState = useDataSource(field.dataSource, fetcher);
+
+  if (field.dataSource) {
+    if (dsState.status === 'loading') {
+      return <p className="text-sm text-muted-foreground">Loading…</p>;
+    }
+    if (dsState.status === 'ready' && dsState.options.length > 0) {
+      return (
+        <RadioGroup id={field.key} value={String(value ?? '')} onValueChange={onChange}>
+          {dsState.options.map((opt) => (
+            <div key={String(opt.value)} className="flex items-center gap-2">
+              <RadioGroupItem
+                value={String(opt.value)}
+                id={`${field.key}-${opt.value}`}
+              />
+              <Label htmlFor={`${field.key}-${opt.value}`}>{opt.label}</Label>
+            </div>
+          ))}
+        </RadioGroup>
+      );
+    }
+    // error, idle, or ready with empty options → fallback
+    return (
+      <span className="text-sm text-muted-foreground">
+        {field.dataSource.fallback ?? '無'}
+      </span>
+    );
+  }
+
+  // No dataSource → static options (unchanged behavior)
+  return (
+    <RadioGroup id={field.key} value={String(value ?? '')} onValueChange={onChange}>
+      {(field.options ?? []).map((opt) => (
+        <div key={String(opt.value)} className="flex items-center gap-2">
+          <RadioGroupItem
+            value={String(opt.value)}
+            id={`${field.key}-${opt.value}`}
+          />
+          <Label htmlFor={`${field.key}-${opt.value}`}>{opt.label}</Label>
+        </div>
+      ))}
+    </RadioGroup>
+  );
+}
+
+// --- Main FieldControl ---
+
+export function FieldControl({ field, value, onChange, fetcher }: FieldControlProps) {
   switch (field.component) {
     case 'Textarea':
       return (
@@ -61,20 +184,7 @@ export function FieldControl({ field, value, onChange }: FieldControlProps) {
         />
       );
     case 'Select':
-      return (
-        <Select value={(value as string) ?? ''} onValueChange={onChange}>
-          <SelectTrigger id={field.key} className="w-full">
-            <SelectValue placeholder={field.placeholder} />
-          </SelectTrigger>
-          <SelectContent>
-            {(field.options ?? []).map((opt) => (
-              <SelectItem key={String(opt.value)} value={String(opt.value)}>
-                {opt.label}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      );
+      return <SelectControl field={field} value={value} onChange={onChange} fetcher={fetcher} />;
     case 'Date':
       return (
         <Input
@@ -113,19 +223,7 @@ export function FieldControl({ field, value, onChange }: FieldControlProps) {
         />
       );
     case 'Radio':
-      return (
-        <RadioGroup id={field.key} value={String(value ?? '')} onValueChange={onChange}>
-          {(field.options ?? []).map((opt) => (
-            <div key={String(opt.value)} className="flex items-center gap-2">
-              <RadioGroupItem
-                value={String(opt.value)}
-                id={`${field.key}-${opt.value}`}
-              />
-              <Label htmlFor={`${field.key}-${opt.value}`}>{opt.label}</Label>
-            </div>
-          ))}
-        </RadioGroup>
-      );
+      return <RadioControl field={field} value={value} onChange={onChange} fetcher={fetcher} />;
     case 'DatePicker':
       return (
         <Popover>

--- a/packages/form-builder-ui/src/field-row.spec.tsx
+++ b/packages/form-builder-ui/src/field-row.spec.tsx
@@ -37,9 +37,10 @@ import {
   setConditionField,
   setConditionOperator,
   setConditionValue,
+  setDataSourceField,
   type SiblingField,
 } from './field-row';
-import type { FieldConfig, ConditionalRule } from '@rfjs/form-builder';
+import type { FieldConfig, ConditionalRule, DataSource } from '@rfjs/form-builder';
 
 function renderRow(field: FieldConfig, onUpdate = vi.fn(), onRemove = vi.fn()) {
   render(
@@ -541,6 +542,175 @@ describe('ConditionalEditor — condition rows', () => {
       conditional: {
         logic: 'and',
         filters: [{ field: 'country', dataType: 'string', operator: 'eq', value: '' }],
+      },
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// setDataSourceField — pure helper unit tests
+// ---------------------------------------------------------------------------
+
+describe('setDataSourceField', () => {
+  it('setting url on undefined builds a new dataSource with default extract', () => {
+    const result = setDataSourceField(undefined, 'url', 'https://api.test/items');
+    expect(result).toEqual({
+      request: { url: 'https://api.test/items' },
+      extract: { dialect: 'path', expr: '' },
+    });
+  });
+
+  it('setting url updates request.url on existing dataSource', () => {
+    const current: DataSource = {
+      request: { url: 'https://old.test' },
+      extract: { dialect: 'path', expr: 'data' },
+    };
+    const result = setDataSourceField(current, 'url', 'https://new.test');
+    expect(result?.request.url).toBe('https://new.test');
+  });
+
+  it('clearing url returns undefined (empty url clears the whole dataSource)', () => {
+    const current: DataSource = {
+      request: { url: 'https://api.test/items' },
+      extract: { dialect: 'path', expr: '' },
+    };
+    expect(setDataSourceField(current, 'url', '')).toBeUndefined();
+  });
+
+  it('setting dialect updates extract.dialect', () => {
+    const current: DataSource = {
+      request: { url: 'https://api.test/items' },
+      extract: { dialect: 'path', expr: 'data' },
+    };
+    const result = setDataSourceField(current, 'dialect', 'jsonata');
+    expect(result?.extract.dialect).toBe('jsonata');
+    expect(result?.extract.expr).toBe('data'); // preserved
+  });
+
+  it('setting expr updates extract.expr', () => {
+    const current: DataSource = {
+      request: { url: 'https://api.test/items' },
+      extract: { dialect: 'path', expr: '' },
+    };
+    const result = setDataSourceField(current, 'expr', 'items[*].name');
+    expect(result?.extract.expr).toBe('items[*].name');
+  });
+
+  it('setting optionLabel updates optionLabel', () => {
+    const current: DataSource = {
+      request: { url: 'https://api.test/items' },
+      extract: { dialect: 'path', expr: '' },
+    };
+    const result = setDataSourceField(current, 'optionLabel', 'name');
+    expect(result?.optionLabel).toBe('name');
+  });
+
+  it('setting optionValue updates optionValue', () => {
+    const current: DataSource = {
+      request: { url: 'https://api.test/items' },
+      extract: { dialect: 'path', expr: '' },
+    };
+    const result = setDataSourceField(current, 'optionValue', 'id');
+    expect(result?.optionValue).toBe('id');
+  });
+
+  it('clearing optionLabel removes the key', () => {
+    const current: DataSource = {
+      request: { url: 'https://api.test/items' },
+      extract: { dialect: 'path', expr: '' },
+      optionLabel: 'name',
+    };
+    const result = setDataSourceField(current, 'optionLabel', '');
+    expect(result?.optionLabel).toBeUndefined();
+  });
+
+  it('setting fallback updates fallback', () => {
+    const current: DataSource = {
+      request: { url: 'https://api.test/items' },
+      extract: { dialect: 'path', expr: '' },
+    };
+    const result = setDataSourceField(current, 'fallback', 'N/A');
+    expect(result?.fallback).toBe('N/A');
+  });
+
+  it('clearing fallback removes the key', () => {
+    const current: DataSource = {
+      request: { url: 'https://api.test/items' },
+      extract: { dialect: 'path', expr: '' },
+      fallback: 'N/A',
+    };
+    const result = setDataSourceField(current, 'fallback', '');
+    expect(result?.fallback).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DataSourceEditor — component tests (driveable parts)
+// ---------------------------------------------------------------------------
+
+describe('DataSourceEditor', () => {
+  it('editing the url input calls onUpdate with dataSource built from the new url', () => {
+    const { onUpdate } = renderRow(base);
+    fireEvent.change(screen.getByLabelText('dataSource url'), {
+      target: { value: 'https://api.test/items' },
+    });
+    expect(onUpdate).toHaveBeenCalledWith({
+      dataSource: {
+        request: { url: 'https://api.test/items' },
+        extract: { dialect: 'path', expr: '' },
+      },
+    });
+  });
+
+  it('clearing the url input calls onUpdate with dataSource: undefined', () => {
+    const field: FieldConfig = {
+      ...base,
+      dataSource: {
+        request: { url: 'https://api.test/items' },
+        extract: { dialect: 'path', expr: '' },
+      },
+    };
+    const { onUpdate } = renderRow(field);
+    fireEvent.change(screen.getByLabelText('dataSource url'), { target: { value: '' } });
+    expect(onUpdate).toHaveBeenCalledWith({ dataSource: undefined });
+  });
+
+  it('shows optionLabel and optionValue inputs for Select fields', () => {
+    renderRow(selectField);
+    expect(screen.getByLabelText('dataSource optionLabel')).toBeTruthy();
+    expect(screen.getByLabelText('dataSource optionValue')).toBeTruthy();
+  });
+
+  it('shows optionLabel and optionValue inputs for Radio fields', () => {
+    const radioField: FieldConfig = {
+      key: 'color', label: 'Color', component: 'Radio', dataType: 'string',
+      options: [{ label: 'Red', value: 'red' }],
+    };
+    renderRow(radioField);
+    expect(screen.getByLabelText('dataSource optionLabel')).toBeTruthy();
+    expect(screen.getByLabelText('dataSource optionValue')).toBeTruthy();
+  });
+
+  it('does not show optionLabel/optionValue for non-Select/Radio fields', () => {
+    renderRow(base); // base = Input
+    expect(screen.queryByLabelText('dataSource optionLabel')).toBeNull();
+    expect(screen.queryByLabelText('dataSource optionValue')).toBeNull();
+  });
+
+  it('editing the expr input calls onUpdate with updated extract.expr', () => {
+    const field: FieldConfig = {
+      ...base,
+      dataSource: {
+        request: { url: 'https://api.test/items' },
+        extract: { dialect: 'path', expr: '' },
+      },
+    };
+    const { onUpdate } = renderRow(field);
+    fireEvent.change(screen.getByLabelText('dataSource expr'), { target: { value: 'data.items' } });
+    expect(onUpdate).toHaveBeenCalledWith({
+      dataSource: {
+        request: { url: 'https://api.test/items' },
+        extract: { dialect: 'path', expr: 'data.items' },
       },
     });
   });

--- a/packages/form-builder-ui/src/field-row.spec.tsx
+++ b/packages/form-builder-ui/src/field-row.spec.tsx
@@ -577,6 +577,20 @@ describe('setDataSourceField', () => {
     expect(setDataSourceField(current, 'url', '')).toBeUndefined();
   });
 
+  it('setting method updates request.method and preserves url', () => {
+    const current: DataSource = { request: { url: 'https://api.test/items' }, extract: { dialect: 'path', expr: '' } };
+    const result = setDataSourceField(current, 'method', 'POST');
+    expect(result?.request.method).toBe('POST');
+    expect(result?.request.url).toBe('https://api.test/items');
+  });
+
+  it('clearing method removes the key but keeps url', () => {
+    const current: DataSource = { request: { url: 'https://api.test/items', method: 'POST' }, extract: { dialect: 'path', expr: '' } };
+    const result = setDataSourceField(current, 'method', '');
+    expect(result?.request.method).toBeUndefined();
+    expect(result?.request.url).toBe('https://api.test/items');
+  });
+
   it('setting dialect updates extract.dialect', () => {
     const current: DataSource = {
       request: { url: 'https://api.test/items' },

--- a/packages/form-builder-ui/src/field-row.tsx
+++ b/packages/form-builder-ui/src/field-row.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { ChevronDown, ChevronRight, GripVertical, Trash2 } from 'lucide-react';
-import type { FieldComponent, FieldConfig, FieldOption, FieldValidation, FieldWidth, ConditionalRule } from '@rfjs/form-builder';
+import type { FieldComponent, FieldConfig, FieldOption, FieldValidation, FieldWidth, ConditionalRule, DataSource, DataSourceDialect } from '@rfjs/form-builder';
 import { Input } from '@rfjs/web-ui/components/input';
 import { Textarea } from '@rfjs/web-ui/components/textarea';
 import { Checkbox } from '@rfjs/web-ui/components/checkbox';
@@ -413,6 +413,177 @@ function ConditionalEditor({
   );
 }
 
+// ---------------------------------------------------------------------------
+// DataSource editor — pure helpers (exported for direct unit-testing)
+// ---------------------------------------------------------------------------
+
+/** Keys addressable by the DataSource editor. */
+export type DataSourceField =
+  | 'url'
+  | 'method'
+  | 'dialect'
+  | 'expr'
+  | 'fallback'
+  | 'optionLabel'
+  | 'optionValue';
+
+/**
+ * Apply a single field edit to the current DataSource, returning a new
+ * DataSource (with sensible defaults) or `undefined` when the resulting url
+ * is empty (an url-less dataSource is meaningless).
+ */
+export function setDataSourceField(
+  current: DataSource | undefined,
+  key: DataSourceField,
+  value: string,
+): DataSource | undefined {
+  const base: DataSource = current ?? {
+    request: { url: '' },
+    extract: { dialect: 'path', expr: '' },
+  };
+
+  let next: DataSource;
+
+  switch (key) {
+    case 'url':
+      next = { ...base, request: { ...base.request, url: value } };
+      break;
+    case 'method': {
+      const { method: _m, ...restReq } = base.request;
+      next = {
+        ...base,
+        request: value
+          ? { ...restReq, method: value as 'GET' | 'POST' | 'PUT' | 'DELETE' }
+          : { ...restReq },
+      };
+      break;
+    }
+    case 'dialect':
+      next = { ...base, extract: { ...base.extract, dialect: value as DataSourceDialect } };
+      break;
+    case 'expr':
+      next = { ...base, extract: { ...base.extract, expr: value } };
+      break;
+    case 'fallback': {
+      const { fallback: _f, ...rest } = base;
+      next = value ? { ...rest, fallback: value } : { ...rest };
+      break;
+    }
+    case 'optionLabel': {
+      const { optionLabel: _ol, ...rest } = base;
+      next = value ? { ...rest, optionLabel: value } : { ...rest };
+      break;
+    }
+    case 'optionValue': {
+      const { optionValue: _ov, ...rest } = base;
+      next = value ? { ...rest, optionValue: value } : { ...rest };
+      break;
+    }
+    default:
+      next = base;
+  }
+
+  // Empty url → the whole dataSource is meaningless
+  return next.request.url.trim() === '' ? undefined : next;
+}
+
+function DataSourceEditor({
+  field,
+  onUpdate,
+}: {
+  field: FieldConfig;
+  onUpdate: (patch: Partial<FieldConfig>) => void;
+}) {
+  const ds = field.dataSource;
+  const isOptionsField = field.component === 'Select' || field.component === 'Radio';
+
+  function patch(key: DataSourceField, value: string) {
+    onUpdate({ dataSource: setDataSourceField(ds, key, value) });
+  }
+
+  return (
+    <div className="col-span-full flex flex-col gap-2">
+      <span className="text-xs font-medium text-muted-foreground">Data source</span>
+      <div className="grid grid-cols-[repeat(auto-fit,minmax(140px,1fr))] gap-2">
+        <label className="col-span-full flex flex-col gap-1 text-xs text-muted-foreground">
+          URL
+          <Input
+            className="h-8"
+            aria-label="dataSource url"
+            value={ds?.request.url ?? ''}
+            onChange={(e) => patch('url', e.target.value)}
+          />
+        </label>
+        <span className="flex flex-col gap-1 text-xs text-muted-foreground">
+          Method
+          <Select value={ds?.request.method ?? 'GET'} onValueChange={(v) => patch('method', v)}>
+            <SelectTrigger className="h-8" aria-label="dataSource method">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {(['GET', 'POST', 'PUT', 'DELETE'] as const).map((m) => (
+                <SelectItem key={m} value={m}>{m}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </span>
+        <span className="flex flex-col gap-1 text-xs text-muted-foreground">
+          Dialect
+          <Select value={ds?.extract.dialect ?? 'path'} onValueChange={(v) => patch('dialect', v)}>
+            <SelectTrigger className="h-8" aria-label="dataSource dialect">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="path">path</SelectItem>
+              <SelectItem value="jsonata">jsonata</SelectItem>
+            </SelectContent>
+          </Select>
+        </span>
+        <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+          Expression
+          <Input
+            className="h-8"
+            aria-label="dataSource expr"
+            value={ds?.extract.expr ?? ''}
+            onChange={(e) => patch('expr', e.target.value)}
+          />
+        </label>
+        <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+          Fallback
+          <Input
+            className="h-8"
+            aria-label="dataSource fallback"
+            value={ds?.fallback ?? ''}
+            onChange={(e) => patch('fallback', e.target.value)}
+          />
+        </label>
+        {isOptionsField ? (
+          <>
+            <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+              Option label path
+              <Input
+                className="h-8"
+                aria-label="dataSource optionLabel"
+                value={ds?.optionLabel ?? ''}
+                onChange={(e) => patch('optionLabel', e.target.value)}
+              />
+            </label>
+            <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+              Option value path
+              <Input
+                className="h-8"
+                aria-label="dataSource optionValue"
+                value={ds?.optionValue ?? ''}
+                onChange={(e) => patch('optionValue', e.target.value)}
+              />
+            </label>
+          </>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
 export function localeText(label: FieldConfig['label'], loc: string, fallback: string): string {
   if (typeof label === 'string') return loc === fallback ? label : '';
   return label[loc] ?? '';
@@ -523,6 +694,7 @@ export function FieldItemEditor({ field, onUpdate, locales = ['en'], siblingFiel
       ) : null}
       <ValidationEditor field={field} onUpdate={onUpdate} />
       <ConditionalEditor field={field} siblingFields={siblingFields} onUpdate={onUpdate} />
+      <DataSourceEditor field={field} onUpdate={onUpdate} />
       <label className="col-span-full flex flex-col gap-1 text-xs text-muted-foreground">
         AI note
         <Textarea

--- a/packages/form-builder-ui/src/index.ts
+++ b/packages/form-builder-ui/src/index.ts
@@ -6,3 +6,4 @@ export * from './field-row';
 export * from './item-editor';
 export * from './section-arranger';
 export * from './use-config-builder';
+export * from './use-data-source';

--- a/packages/form-builder-ui/src/use-data-source.spec.ts
+++ b/packages/form-builder-ui/src/use-data-source.spec.ts
@@ -1,0 +1,58 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { useDataSource } from './use-data-source';
+import type { DataSource, DataSourceFetcher } from '@rfjs/form-builder';
+
+const ds: DataSource = {
+  request: { url: 'http://example.com/api' },
+  extract: { dialect: 'path', expr: 'items' },
+  optionLabel: 'name',
+  optionValue: 'id',
+};
+
+describe('useDataSource', () => {
+  it('resolving fetcher → status ready, correct options, value is the list', async () => {
+    const fetcher: DataSourceFetcher = vi
+      .fn()
+      .mockResolvedValue({ items: [{ id: 1, name: 'A' }] });
+    const { result } = renderHook(() => useDataSource(ds, fetcher));
+
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+
+    expect(result.current.options).toHaveLength(1);
+    expect(result.current.options[0]).toEqual({ label: 'A', value: 1 });
+    expect(Array.isArray(result.current.value)).toBe(true);
+    expect(result.current.error).toBeUndefined();
+  });
+
+  it('rejecting fetcher → status error, error set, options empty', async () => {
+    const fetcher: DataSourceFetcher = vi.fn().mockRejectedValue(new Error('fetch failed'));
+    const { result } = renderHook(() => useDataSource(ds, fetcher));
+
+    await waitFor(() => expect(result.current.status).toBe('error'));
+
+    expect(result.current.error).toBe('Error: fetch failed');
+    expect(result.current.options).toEqual([]);
+    expect(result.current.value).toBeUndefined();
+  });
+
+  it('no fetcher → status idle, no fetch', () => {
+    const fetcher = vi.fn();
+    const { result } = renderHook(() => useDataSource(ds, undefined));
+
+    expect(result.current.status).toBe('idle');
+    expect(result.current.value).toBeUndefined();
+    expect(result.current.options).toEqual([]);
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+
+  it('no ds → status idle, fetcher never called', () => {
+    const fetcher: DataSourceFetcher = vi.fn();
+    const { result } = renderHook(() => useDataSource(undefined, fetcher));
+
+    expect(result.current.status).toBe('idle');
+    expect(result.current.value).toBeUndefined();
+    expect(result.current.options).toEqual([]);
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+});

--- a/packages/form-builder-ui/src/use-data-source.ts
+++ b/packages/form-builder-ui/src/use-data-source.ts
@@ -1,0 +1,56 @@
+import * as React from 'react';
+import {
+  loadDataSource,
+  toOptions,
+  type DataSource,
+  type DataSourceFetcher,
+  type FieldOption,
+} from '@rfjs/form-builder';
+
+export interface DataSourceState {
+  status: 'idle' | 'loading' | 'ready' | 'error';
+  value: unknown;
+  options: FieldOption[];
+  error?: string;
+}
+
+const IDLE: DataSourceState = { status: 'idle', value: undefined, options: [] };
+
+/**
+ * Fetches and extracts data from a `DataSource`, converting it to `FieldOption[]`.
+ *
+ * Re-runs whenever `ds` or `fetcher` references change.
+ * Consumers should memoize `fetcher` (e.g. `useCallback`) to avoid unnecessary refetches.
+ */
+export function useDataSource(
+  ds: DataSource | undefined,
+  fetcher?: DataSourceFetcher,
+): DataSourceState {
+  const [state, setState] = React.useState<DataSourceState>(IDLE);
+
+  React.useEffect(() => {
+    if (!ds || !fetcher) {
+      setState(IDLE);
+      return;
+    }
+
+    let active = true;
+    setState({ status: 'loading', value: undefined, options: [] });
+
+    loadDataSource(ds, fetcher)
+      .then((value) => {
+        if (!active) return;
+        setState({ status: 'ready', value, options: toOptions(value, ds) });
+      })
+      .catch((err: unknown) => {
+        if (!active) return;
+        setState({ status: 'error', value: undefined, options: [], error: String(err) });
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [ds, fetcher]);
+
+  return state;
+}

--- a/packages/form-builder/package.json
+++ b/packages/form-builder/package.json
@@ -28,7 +28,9 @@
   "repository": { "type": "git", "url": "git+https://github.com/royfw/rfjs.git", "directory": "packages/form-builder" },
   "files": ["dist", "README.md"],
   "dependencies": {
+    "@rfjs/data-expr": "workspace:*",
     "@rfjs/data-filter": "workspace:*",
+    "@rfjs/object-utils": "workspace:*",
     "zod": "^4.0.0"
   },
   "devDependencies": {

--- a/packages/form-builder/src/config-schema.spec.ts
+++ b/packages/form-builder/src/config-schema.spec.ts
@@ -205,6 +205,82 @@ describe('v1/v2 parse', () => {
   });
 });
 
+describe('dataSource schema', () => {
+  const baseFieldDs = {
+    key: 'country',
+    label: 'Country',
+    component: 'Select',
+    dataType: 'string',
+    dataSource: {
+      request: { url: 'https://api.example.com/countries', method: 'GET' },
+      extract: { dialect: 'path', expr: 'data' },
+      fallback: '無',
+      optionLabel: 'name',
+      optionValue: 'code',
+    },
+  };
+
+  it('accepts a fieldConfig with a valid dataSource (round-trip)', () => {
+    const cfg = { version: 1, fields: [baseFieldDs] };
+    expect(FormConfigSchema.safeParse(cfg).success).toBe(true);
+  });
+
+  it('accepts a content item with a valid dataSource', () => {
+    const cfg = {
+      version: 1,
+      sections: [{
+        id: 's1',
+        rows: [{
+          id: 'r1',
+          items: [{
+            id: 'i1',
+            kind: 'content',
+            text: 'Status',
+            dataSource: {
+              request: { url: 'https://api.example.com/status' },
+              extract: { dialect: 'jsonata', expr: 'result.value' },
+            },
+          }],
+        }],
+      }],
+    };
+    expect(FormConfigSchema.safeParse(cfg).success).toBe(true);
+  });
+
+  it('rejects a dataSource missing extract.expr', () => {
+    const bad = {
+      version: 1,
+      fields: [{
+        ...baseFieldDs,
+        dataSource: { request: { url: 'https://example.com' }, extract: { dialect: 'path' } },
+      }],
+    };
+    expect(FormConfigSchema.safeParse(bad).success).toBe(false);
+  });
+
+  it('rejects a dataSource with an invalid dialect', () => {
+    const bad = {
+      version: 1,
+      fields: [{
+        ...baseFieldDs,
+        dataSource: { request: { url: 'https://example.com' }, extract: { dialect: 'bad', expr: 'data' } },
+      }],
+    };
+    expect(FormConfigSchema.safeParse(bad).success).toBe(false);
+  });
+
+  it('rejects a dataSource missing request.url', () => {
+    const bad = {
+      version: 1,
+      fields: [{
+        ...baseFieldDs,
+        dataSource: { request: { method: 'GET' }, extract: { dialect: 'path', expr: 'data' } },
+      }],
+    };
+    expect(FormConfigSchema.safeParse(bad).success).toBe(false);
+  });
+});
+
 describe('new FieldComponent values', () => {
   it.each(['Number', 'Email', 'Switch', 'Radio', 'DatePicker'] as const)(
     'accepts component: %s',

--- a/packages/form-builder/src/config-schema.ts
+++ b/packages/form-builder/src/config-schema.ts
@@ -21,6 +21,22 @@ const conditionalSchema: ZodTypeAny = z.object({
   filters: z.array(z.union([conditionSchema, z.lazy(() => conditionalSchema as any)])),
 });
 
+const dataSourceSchema = z.object({
+  request: z.object({
+    url: z.string(),
+    method: z.enum(['GET', 'POST', 'PUT', 'DELETE']).optional(),
+    headers: z.record(z.string(), z.string()).optional(),
+    body: z.unknown().optional(),
+  }),
+  extract: z.object({
+    dialect: z.enum(['path', 'jsonata', 'jsonpath']),
+    expr: z.string(),
+  }),
+  fallback: z.string().optional(),
+  optionLabel: z.string().optional(),
+  optionValue: z.string().optional(),
+});
+
 const fieldOptionSchema = z.object({
   label: z.string(),
   value: z.union([z.string(), z.number()]),
@@ -60,6 +76,7 @@ const fieldConfigSchema = z.object({
   width: z.enum(['full', 'half']).optional(),
   validation: fieldValidationSchema.optional(),
   conditional: conditionalSchema.optional(),
+  dataSource: dataSourceSchema.optional(),
 });
 
 const localizedLabelSchema = z.union([z.string(), z.record(z.string(), z.string())]);
@@ -75,6 +92,7 @@ const contentItemSchema = z.object({
   text: localizedLabelSchema,
   locked: z.boolean().optional(),
   conditional: conditionalSchema.optional(),
+  dataSource: dataSourceSchema.optional(),
 });
 const dividerItemSchema = z.object({
   id: z.string().min(1),

--- a/packages/form-builder/src/data-source.spec.ts
+++ b/packages/form-builder/src/data-source.spec.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi } from 'vitest';
+import { extractValue, loadDataSource, toOptions } from './data-source';
+import type { DataSource } from './types';
+
+describe('extractValue', () => {
+  it('path dialect resolves nested value', async () => {
+    await expect(extractValue('path', 'a.b', { a: { b: 5 } })).resolves.toBe(5);
+  });
+
+  it('jsonata dialect evaluates expression', async () => {
+    await expect(extractValue('jsonata', 'x', { x: 7 })).resolves.toBe(7);
+  });
+
+  it('jsonpath dialect throws not-supported error', async () => {
+    await expect(extractValue('jsonpath', '$..a', {})).rejects.toThrow('jsonpath dialect not supported');
+  });
+});
+
+describe('loadDataSource', () => {
+  it('fetches and extracts', async () => {
+    const ds: DataSource = {
+      request: { url: '/x' },
+      extract: { dialect: 'path', expr: 'items' },
+    };
+    const fetcher = vi.fn().mockResolvedValue({ items: [1, 2] });
+    await expect(loadDataSource(ds, fetcher)).resolves.toEqual([1, 2]);
+    expect(fetcher).toHaveBeenCalledWith(ds.request);
+  });
+});
+
+describe('toOptions', () => {
+  const baseDs = { request: { url: '/x' }, extract: { dialect: 'path' as const, expr: 'items' } };
+
+  it('maps objects with optionLabel/optionValue', () => {
+    const ds: DataSource = { ...baseDs, optionLabel: 'name', optionValue: 'id' };
+    expect(toOptions([{ id: 1, name: 'A' }, { id: 2, name: 'B' }], ds)).toEqual([
+      { label: 'A', value: 1 },
+      { label: 'B', value: 2 },
+    ]);
+  });
+
+  it('maps primitive items without optionLabel/optionValue', () => {
+    expect(toOptions(['x', 'y'], baseDs)).toEqual([
+      { label: 'x', value: 'x' },
+      { label: 'y', value: 'y' },
+    ]);
+  });
+
+  it('passes through {label,value} objects when no optionLabel/optionValue', () => {
+    expect(toOptions([{ label: 'L', value: 'v' }], baseDs)).toEqual([{ label: 'L', value: 'v' }]);
+  });
+
+  it('returns [] for non-array input', () => {
+    expect(toOptions('nope', baseDs)).toEqual([]);
+    expect(toOptions(null, baseDs)).toEqual([]);
+    expect(toOptions(42, baseDs)).toEqual([]);
+  });
+});

--- a/packages/form-builder/src/data-source.ts
+++ b/packages/form-builder/src/data-source.ts
@@ -1,0 +1,48 @@
+import { getByPath } from '@rfjs/object-utils';
+import { compile } from '@rfjs/data-expr';
+import type { DataSource, DataSourceDialect, DataSourceFetcher, FieldOption } from './types';
+
+export async function extractValue(
+  dialect: DataSourceDialect,
+  expr: string,
+  data: unknown,
+): Promise<unknown> {
+  switch (dialect) {
+    case 'path':
+      return Promise.resolve(getByPath(data, expr));
+    case 'jsonata':
+      return compile(expr).evaluate(data);
+    case 'jsonpath':
+      throw new Error('dataSource: jsonpath dialect not supported yet');
+  }
+}
+
+export async function loadDataSource(
+  ds: DataSource,
+  fetcher: DataSourceFetcher,
+): Promise<unknown> {
+  const raw = await fetcher(ds.request);
+  return extractValue(ds.extract.dialect, ds.extract.expr, raw);
+}
+
+export function toOptions(extracted: unknown, ds: DataSource): FieldOption[] {
+  if (!Array.isArray(extracted)) return [];
+  return extracted.map((item) => {
+    // Pass through {label, value} objects when no mapping specified
+    if (
+      !ds.optionLabel &&
+      !ds.optionValue &&
+      item !== null &&
+      typeof item === 'object' &&
+      'label' in item &&
+      'value' in item
+    ) {
+      return item as FieldOption;
+    }
+    const label = String(ds.optionLabel ? getByPath(item, ds.optionLabel) : item);
+    const value = ds.optionValue
+      ? (getByPath(item, ds.optionValue) as string | number)
+      : (item as string | number);
+    return { label, value };
+  });
+}

--- a/packages/form-builder/src/index.ts
+++ b/packages/form-builder/src/index.ts
@@ -2,6 +2,7 @@ export * from './types';
 export * from './conditional';
 export * from './config-schema';
 export * from './config-to-zod';
+export * from './data-source';
 export * from './list-ops';
 export * from './localized-label';
 export * from './normalize';

--- a/packages/form-builder/src/types.ts
+++ b/packages/form-builder/src/types.ts
@@ -2,6 +2,24 @@ import type { ConditionalRule } from './conditional';
 
 // Data-type vocabulary — identical to @rfjs/filter-builder's FieldType.
 export type ScalarType = 'string' | 'numeric' | 'date' | 'boolean';
+
+// --- DataSource types ---
+export interface DataSourceRequest {
+  url: string;
+  method?: 'GET' | 'POST' | 'PUT' | 'DELETE';
+  headers?: Record<string, string>;
+  body?: unknown;
+}
+export type DataSourceDialect = 'path' | 'jsonata' | 'jsonpath';
+export interface DataSourceExtract { dialect: DataSourceDialect; expr: string }
+export interface DataSource {
+  request: DataSourceRequest;
+  extract: DataSourceExtract;       // → the value (scalar for content/default; list for options)
+  fallback?: string;                // shown on empty/error; default '無'
+  optionLabel?: string;             // for options: path within each list item → label (default: the item)
+  optionValue?: string;             // for options: path within each list item → value (default: the item)
+}
+export type DataSourceFetcher = (req: DataSourceRequest) => Promise<unknown>;
 export type FieldType = ScalarType | 'object' | 'array';
 
 /** A field label that is either a plain string or a locale-keyed record. */
@@ -49,6 +67,7 @@ export interface FieldConfig {
   width?: FieldWidth;
   validation?: FieldValidation;
   conditional?: ConditionalRule;
+  dataSource?: DataSource;
 }
 
 export type ItemKind = 'field' | 'content' | 'divider' | 'spacer' | 'ai-note';
@@ -65,6 +84,7 @@ export interface ContentItem {
   text: LocalizedLabel;  // markdown-ish display text
   locked?: boolean;      // preset, not editable in builder
   conditional?: ConditionalRule;
+  dataSource?: DataSource;
 }
 export interface DividerItem { id: string; kind: 'divider'; conditional?: ConditionalRule; }
 export interface SpacerItem { id: string; kind: 'spacer'; size?: SpacerSize; conditional?: ConditionalRule; }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -894,9 +894,15 @@ importers:
 
   packages/form-builder:
     dependencies:
+      '@rfjs/data-expr':
+        specifier: workspace:*
+        version: link:../data-expr
       '@rfjs/data-filter':
         specifier: workspace:*
         version: link:../data-filter
+      '@rfjs/object-utils':
+        specifier: workspace:*
+        version: link:../object-utils
       zod:
         specifier: ^4.0.0
         version: 4.4.3


### PR DESCRIPTION
## What

**v2-G — external API `dataSource`** for the config-driven form builder (Group 3b, the last v2 feature). A field/content item can pull values from an external API **at runtime** to populate dynamic **Select/Radio options**, show a **content** value, with a **pluggable, injected fetcher** (the component never hardcodes network/auth — important for shadcn-registry distribution), value extraction via **`path`** or **`jsonata`**, and **loading / empty / error / fallback** states.

### Engine (`@rfjs/form-builder`)
- `DataSource` type (`request {url,method?,headers?,body?}`, `extract {dialect,expr}`, `fallback?`, `optionLabel?`, `optionValue?`) + `DataSourceFetcher`; `dataSource?` on `FieldConfig` (→ FieldItem) and `ContentItem`; structural zod schema.
- Pure helpers `data-source.ts`: `extractValue(dialect, expr, data)` — `path`→`@rfjs/object-utils` `getByPath`, `jsonata`→`@rfjs/data-expr` `compile().evaluate()` (async), `jsonpath`→reserved (throws, documented); `loadDataSource(ds, fetcher)`; `toOptions(extracted, ds)` (list→`{label,value}`).

### UI (`@rfjs/form-builder-ui`)
- `useDataSource(ds, fetcher) → {status, value, options, error}` — idle/loading/ready/error, with an in-flight/unmount guard (late promises from a superseded `ds` can't clobber state).
- `<FieldControl>`: `SelectControl`/`RadioControl` subcomponents (hooks unconditional) use fetched options when `dataSource` is set — loading→disabled, ready→dynamic options, empty/error→fallback. `<ConfigForm>` threads a `fetcher` prop. Content items render an external value via `DataSourceContent`.
- Builder: a **Data source** editor in `FieldItemEditor` (url/method/dialect/expr/fallback + optionLabel/optionValue for Select/Radio) backed by the pure, unit-tested `setDataSourceField` helper (empty url clears the whole dataSource). `<ConfigFormBuilder>` threads `fetcher` to its preview.

### Demo (`apps/web`)
- A module-level **mock fetcher** (no network) + a dynamic **Country** `Select` (`dataSource` → `/api/countries`, `path:'data'`, optionLabel/value) in the seed.

## Testing
- `@rfjs/form-builder` **142** (schema parse/reject; extract path+jsonata+jsonpath-throws; loadDataSource; toOptions), `@rfjs/form-builder-ui` **187** (hook 4-state + unmount; dynamic Select/Radio loading/ready/fallback; content value; `setDataSourceField` build/patch/clear; fetcher threading). All `@rfjs/*` build; UI + `apps/web` `tsc --noEmit` clean.
- Per-task + two adversarial reviews (runtime UI = SHIP; builder/threading = SHIP after `method`-key tests). TDD throughout. Pluggable-fetcher contract verified airtight (no hardcoded `fetch`). **No changeset.**

## Notes
- `jsonpath` dialect reserved (throws) — `path`+`jsonata` cover the recommended defaults without a new dep.
- dataSource-as-field-default-value (spec "可選") deferred. The deferred visual/UX overhaul is separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
