### PR TITLE
feat(form-builder-ui): Direction A — collapsible sections, per-section cols, split preview, JSON copy, width-from-columns

### DIFF
--- a/packages/form-builder-ui/src/config-form-builder.spec.tsx
+++ b/packages/form-builder-ui/src/config-form-builder.spec.tsx
@@ -138,6 +138,19 @@ describe('ConfigFormBuilder', () => {
     expect(trigger.textContent).toContain('1');
   });
 
+  it('switches to the Preview tab and renders the live form there', () => {
+    render(<ConfigFormBuilder initialConfig={initial} />);
+    fireEvent.click(screen.getByRole('tab', { name: /^preview$/i }));
+    const preview = screen.getByTestId('config-form-preview');
+    expect(within(preview).getByText('Name')).toBeTruthy();
+  });
+
+  it('JSON tab exposes a copy button', () => {
+    render(<ConfigFormBuilder initialConfig={initial} />);
+    fireEvent.click(screen.getByRole('tab', { name: /^json$/i }));
+    expect(screen.getByRole('button', { name: /copy json/i })).toBeTruthy();
+  });
+
   it('shows the config as JSON and applies edits back (round-trip)', () => {
     const onChange = vi.fn();
     render(<ConfigFormBuilder initialConfig={initial} onChange={onChange} />);

--- a/packages/form-builder-ui/src/config-form-builder.spec.tsx
+++ b/packages/form-builder-ui/src/config-form-builder.spec.tsx
@@ -33,7 +33,7 @@ describe('ConfigFormBuilder empty state', () => {
   it('shows the empty-state hint when there are no fields', () => {
     render(<ConfigFormBuilder initialConfig={empty} />);
     expect(screen.getByTestId('empty-state-hint')).toBeTruthy();
-    expect(screen.getByText(/no fields yet/i)).toBeTruthy();
+    expect(screen.getByText(/no items yet/i)).toBeTruthy();
   });
 
   it('does not show the empty-state hint when fields are present', () => {

--- a/packages/form-builder-ui/src/config-form-builder.tsx
+++ b/packages/form-builder-ui/src/config-form-builder.tsx
@@ -3,7 +3,6 @@
 import * as React from 'react';
 import type { FormConfig, FormItem, ItemKind, DataSourceFetcher } from '@rfjs/form-builder';
 import { parseFormConfig, normalizeToSections, makeItem } from '@rfjs/form-builder';
-import { Button } from '@rfjs/web-ui/components/button';
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@rfjs/web-ui/components/select';
 
 import { useConfigBuilder } from './use-config-builder';
@@ -89,43 +88,40 @@ export function ConfigFormBuilder({ initialConfig = EMPTY, onChange, locale = 'e
 
   return (
     <div className="flex flex-col gap-5">
-      <div className="flex gap-2 border-b border-input">
-        <button
-          role="tab"
-          type="button"
-          aria-selected={tab === 'builder'}
-          className="px-3 py-1.5 text-sm font-medium"
-          onClick={() => setTab('builder')}
-        >
-          Builder
-        </button>
-        <button
-          role="tab"
-          type="button"
-          aria-selected={tab === 'json'}
-          className="px-3 py-1.5 text-sm font-medium"
-          onClick={() => setTab('json')}
-        >
-          JSON
-        </button>
+      {/* Segmented tabs (A · technical) */}
+      <div className="inline-flex w-fit gap-0.5 rounded-lg border border-input bg-muted/30 p-1">
+        {(['builder', 'json'] as const).map((t) => (
+          <button
+            key={t}
+            role="tab"
+            type="button"
+            aria-selected={tab === t}
+            onClick={() => setTab(t)}
+            className={`rounded-md px-3.5 py-1.5 text-[13px] font-medium transition-colors ${
+              tab === t ? 'bg-background text-foreground shadow-sm' : 'text-muted-foreground hover:text-foreground'
+            }`}
+          >
+            {t === 'builder' ? 'Builder' : 'JSON'}
+          </button>
+        ))}
       </div>
 
       {tab === 'builder' ? (
         <>
-          <div className="flex flex-wrap gap-2">
+          <div className="flex flex-wrap items-center gap-2">
             {KIND_PALETTE.map(({ kind, label }) => (
-              <Button
+              <button
                 key={kind}
                 type="button"
-                variant="outline"
-                size="sm"
                 aria-label={label}
                 onClick={() => addKindItem(kind)}
+                className="inline-flex items-center gap-1.5 rounded-lg border border-input bg-card/40 px-3 py-1.5 font-mono text-[12px] text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
               >
-                {label}
-              </Button>
+                <span className="font-semibold" style={{ color: '#5b8cff' }}>+</span>
+                {label.replace('+ ', '')}
+              </button>
             ))}
-            <span className="ml-auto flex items-center gap-1.5 text-xs text-muted-foreground">
+            <span className="ml-auto flex items-center gap-1.5 font-mono text-[11px] uppercase tracking-wide text-muted-foreground">
               Columns
               <Select
                 value={String(
@@ -153,24 +149,21 @@ export function ConfigFormBuilder({ initialConfig = EMPTY, onChange, locale = 'e
             </span>
           </div>
 
-          <div className="rounded-lg border bg-card p-4">
-            {!hasItems ? (
-              <p
-                data-testid="empty-state-hint"
-                className="py-8 text-center text-sm text-muted-foreground"
-              >
-                No fields yet — add one from the palette above
+          {!hasItems ? (
+            <div className="rounded-xl border border-dashed border-input bg-card/20 py-12 text-center">
+              <p data-testid="empty-state-hint" className="text-sm text-muted-foreground">
+                No items yet — add one from the palette above
               </p>
-            ) : (
-              <SectionArranger
-                config={builder.config}
-                builder={builder}
-                locales={locales}
-              />
-            )}
-          </div>
+            </div>
+          ) : (
+            <SectionArranger config={builder.config} builder={builder} locales={locales} />
+          )}
 
-          <div data-testid="config-form-preview" className="rounded-lg border bg-card p-4">
+          <div data-testid="config-form-preview" className="rounded-xl border border-input bg-card/40 p-5">
+            <div className="mb-4 flex items-center gap-2 font-mono text-[11px] uppercase tracking-[0.15em] text-muted-foreground/60">
+              <span className="size-1.5 rounded-full" style={{ backgroundColor: '#5b8cff' }} />
+              Live preview
+            </div>
             {!hasItems ? (
               <p className="py-4 text-center text-sm text-muted-foreground">Preview will appear here once you add fields</p>
             ) : (

--- a/packages/form-builder-ui/src/config-form-builder.tsx
+++ b/packages/form-builder-ui/src/config-form-builder.tsx
@@ -1,13 +1,33 @@
 'use client';
 
 import * as React from 'react';
+import { Copy, Check } from 'lucide-react';
 import type { FormConfig, FormItem, ItemKind, DataSourceFetcher } from '@rfjs/form-builder';
 import { parseFormConfig, normalizeToSections, makeItem } from '@rfjs/form-builder';
-import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@rfjs/web-ui/components/select';
 
 import { useConfigBuilder } from './use-config-builder';
 import { ConfigForm } from './config-form';
 import { SectionArranger } from './section-arranger';
+
+// ---------------------------------------------------------------------------
+// useMediaQuery — gate the side-by-side split to wide viewports (RWD).
+// Below the breakpoint the builder + preview stack; at/above it they sit
+// side-by-side with a draggable divider. Initialised false (SSR-safe), then
+// synced on mount.
+// ---------------------------------------------------------------------------
+
+function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = React.useState(false);
+  React.useEffect(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) return;
+    const mql = window.matchMedia(query);
+    const onChange = () => setMatches(mql.matches);
+    onChange();
+    mql.addEventListener('change', onChange);
+    return () => mql.removeEventListener('change', onChange);
+  }, [query]);
+  return matches;
+}
 
 // ---------------------------------------------------------------------------
 // Item-kind palette — the new v2 palette adds items by kind.
@@ -46,8 +66,45 @@ export function ConfigFormBuilder({ initialConfig = EMPTY, onChange, locale = 'e
 
   // The form is "empty" only when no items exist at all (covers both v1 fields[] and v2 sections[]).
   const hasItems = normalizeToSections(builder.config).some((s) => s.rows.some((r) => r.items.length > 0));
-  const [tab, setTab] = React.useState<'builder' | 'json'>('builder');
+  const [tab, setTab] = React.useState<'builder' | 'preview' | 'json'>('builder');
   const [jsonError, setJsonError] = React.useState<string | null>(null);
+  const [copied, setCopied] = React.useState(false);
+
+  // --- Side-by-side split (Builder tab) -----------------------------------
+  // On wide viewports the builder + live preview sit side-by-side with a
+  // draggable divider; `splitPct` is the builder column's width (%). Stacks
+  // below `lg` (the divider + inline widths are simply not applied).
+  const isWide = useMediaQuery('(min-width: 1024px)');
+  const [splitPct, setSplitPct] = React.useState(58);
+  const splitRef = React.useRef<HTMLDivElement | null>(null);
+
+  function onDividerPointerDown(e: React.PointerEvent) {
+    e.preventDefault();
+    const el = splitRef.current;
+    if (!el) return;
+    (e.target as HTMLElement).setPointerCapture(e.pointerId);
+    const move = (ev: PointerEvent) => {
+      const rect = el.getBoundingClientRect();
+      const pct = ((ev.clientX - rect.left) / rect.width) * 100;
+      setSplitPct(Math.min(72, Math.max(34, pct)));
+    };
+    const up = () => {
+      window.removeEventListener('pointermove', move);
+      window.removeEventListener('pointerup', up);
+    };
+    window.addEventListener('pointermove', move);
+    window.addEventListener('pointerup', up);
+  }
+
+  async function copyJson() {
+    try {
+      await navigator.clipboard?.writeText(JSON.stringify(builder.config, null, 2));
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1400);
+    } catch {
+      /* clipboard unavailable (e.g. insecure context) — no-op */
+    }
+  }
 
   /**
    * Add a new item of the given kind into the config.
@@ -86,22 +143,44 @@ export function ConfigFormBuilder({ initialConfig = EMPTY, onChange, locale = 'e
     }
   }
 
+  // The live-preview panel — reused by the Builder split (right pane) and the
+  // dedicated Preview tab (full width), so both stay perfectly in sync.
+  const previewPanel = (
+    <div data-testid="config-form-preview" className="rounded-xl border border-input bg-card/40 p-5">
+      <div className="mb-4 flex items-center gap-2 font-mono text-[11px] uppercase tracking-[0.15em] text-muted-foreground/60">
+        <span className="size-1.5 rounded-full" style={{ backgroundColor: '#5b8cff' }} />
+        Live preview
+      </div>
+      {!hasItems ? (
+        <p className="py-4 text-center text-sm text-muted-foreground">Preview will appear here once you add fields</p>
+      ) : (
+        <ConfigForm config={builder.config} locale={locale} fetcher={fetcher} onSubmit={() => {}} />
+      )}
+    </div>
+  );
+
+  const TABS = [
+    { id: 'builder', label: 'Builder' },
+    { id: 'preview', label: 'Preview' },
+    { id: 'json', label: 'JSON' },
+  ] as const;
+
   return (
     <div className="flex flex-col gap-5">
-      {/* Segmented tabs (A · technical) */}
+      {/* Segmented tabs (A · technical): Builder | Preview | JSON */}
       <div className="inline-flex w-fit gap-0.5 rounded-lg border border-input bg-muted/30 p-1">
-        {(['builder', 'json'] as const).map((t) => (
+        {TABS.map((t) => (
           <button
-            key={t}
+            key={t.id}
             role="tab"
             type="button"
-            aria-selected={tab === t}
-            onClick={() => setTab(t)}
+            aria-selected={tab === t.id}
+            onClick={() => setTab(t.id)}
             className={`rounded-md px-3.5 py-1.5 text-[13px] font-medium transition-colors ${
-              tab === t ? 'bg-background text-foreground shadow-sm' : 'text-muted-foreground hover:text-foreground'
+              tab === t.id ? 'bg-background text-foreground shadow-sm' : 'text-muted-foreground hover:text-foreground'
             }`}
           >
-            {t === 'builder' ? 'Builder' : 'JSON'}
+            {t.label}
           </button>
         ))}
       </div>
@@ -121,70 +200,71 @@ export function ConfigFormBuilder({ initialConfig = EMPTY, onChange, locale = 'e
                 {label.replace('+ ', '')}
               </button>
             ))}
-            <span className="ml-auto flex items-center gap-1.5 font-mono text-[11px] uppercase tracking-wide text-muted-foreground">
-              Columns
-              <Select
-                value={String(
-                  normalizeToSections(builder.config)[0]?.columns ??
-                  builder.config.columns ??
-                  1,
-                )}
-                onValueChange={(v) => {
-                  const sections = normalizeToSections(builder.config);
-                  const s0 = sections[0];
-                  if (s0) {
-                    builder.setSectionColumns(s0.id, Number(v) as 1 | 2 | 3 | 4);
-                  } else {
-                    builder.setColumns(Number(v) as FormConfig['columns']);
-                  }
-                }}
-              >
-                <SelectTrigger className="h-8" aria-label="columns">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  {[1, 2, 3, 4].map((n) => <SelectItem key={n} value={String(n)}>{n}</SelectItem>)}
-                </SelectContent>
-              </Select>
-            </span>
           </div>
 
-          {!hasItems ? (
-            <div className="rounded-xl border border-dashed border-input bg-card/20 py-12 text-center">
-              <p data-testid="empty-state-hint" className="text-sm text-muted-foreground">
-                No items yet — add one from the palette above
-              </p>
+          {/* Side-by-side split: builder (left) + live preview (right). Stacks
+              below lg; above lg a draggable divider resizes the two panes. */}
+          <div ref={splitRef} className="flex flex-col gap-5 lg:flex-row lg:items-start">
+            <div
+              className="min-w-0"
+              style={isWide ? { flexBasis: `${splitPct}%`, flexGrow: 0, flexShrink: 1 } : undefined}
+            >
+              {!hasItems ? (
+                <div className="rounded-xl border border-dashed border-input bg-card/20 py-12 text-center">
+                  <p data-testid="empty-state-hint" className="text-sm text-muted-foreground">
+                    No items yet — add one from the palette above
+                  </p>
+                </div>
+              ) : (
+                <SectionArranger config={builder.config} builder={builder} locales={locales} />
+              )}
             </div>
-          ) : (
-            <SectionArranger config={builder.config} builder={builder} locales={locales} />
-          )}
 
-          <div data-testid="config-form-preview" className="rounded-xl border border-input bg-card/40 p-5">
-            <div className="mb-4 flex items-center gap-2 font-mono text-[11px] uppercase tracking-[0.15em] text-muted-foreground/60">
-              <span className="size-1.5 rounded-full" style={{ backgroundColor: '#5b8cff' }} />
-              Live preview
+            {/* Draggable divider — wide viewports only. */}
+            <div
+              role="separator"
+              aria-orientation="vertical"
+              aria-label="resize preview"
+              onPointerDown={onDividerPointerDown}
+              className="group hidden shrink-0 cursor-col-resize select-none self-stretch px-1 lg:flex lg:items-stretch"
+            >
+              <div className="h-full w-1.5 rounded-full bg-input transition-colors group-hover:bg-[#5b8cff]" />
             </div>
-            {!hasItems ? (
-              <p className="py-4 text-center text-sm text-muted-foreground">Preview will appear here once you add fields</p>
-            ) : (
-              <ConfigForm
-                config={builder.config}
-                locale={locale}
-                fetcher={fetcher}
-                onSubmit={() => {}}
-              />
-            )}
+
+            <div
+              className="min-w-0 lg:sticky lg:top-4"
+              style={isWide ? { flexBasis: `${100 - splitPct}%`, flexGrow: 0, flexShrink: 1 } : undefined}
+            >
+              {previewPanel}
+            </div>
           </div>
         </>
+      ) : tab === 'preview' ? (
+        previewPanel
       ) : (
-        <div>
+        <div className="flex flex-col gap-2">
+          <div className="flex items-center justify-between">
+            <span className="font-mono text-[11px] uppercase tracking-[0.15em] text-muted-foreground/60">
+              Config JSON — edits sync back to the builder
+            </span>
+            <button
+              type="button"
+              onClick={copyJson}
+              aria-label="copy json"
+              className="inline-flex items-center gap-1.5 rounded-md border border-input bg-card/40 px-2.5 py-1 font-mono text-[12px] text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
+            >
+              {copied ? <Check className="size-3.5" style={{ color: '#5b8cff' }} /> : <Copy className="size-3.5" />}
+              {copied ? 'Copied' : 'Copy'}
+            </button>
+          </div>
           <textarea
             aria-label="config json"
-            className="h-64 w-full rounded-md border border-input bg-background p-3 font-mono text-xs"
+            spellCheck={false}
+            className="h-[28rem] w-full rounded-md border border-input bg-background p-4 font-mono text-[13px] leading-relaxed"
             defaultValue={JSON.stringify(builder.config, null, 2)}
             onChange={(e) => onJsonChange(e.target.value)}
           />
-          {jsonError ? <p className="mt-1 text-xs text-destructive">Invalid config: {jsonError}</p> : null}
+          {jsonError ? <p className="text-xs text-destructive">Invalid config: {jsonError}</p> : null}
         </div>
       )}
     </div>

--- a/packages/form-builder-ui/src/config-form.spec.tsx
+++ b/packages/form-builder-ui/src/config-form.spec.tsx
@@ -376,7 +376,7 @@ describe('v2 sections rendering', () => {
     expect(screen.getByLabelText('Name')).toBeTruthy();
   });
 
-  it('puts two items of one v2 row in a single flex container, and a second row in its own', () => {
+  it('puts two items of one v2 row in a single grid container, and a second row in its own', () => {
     const cfg = { version: 1, sections: [{ id: 's1', rows: [
       { id: 'r1', items: [
         { id: 'first', kind: 'field', key: 'first', label: 'First', component: 'Input', dataType: 'string', width: 'half' },
@@ -393,8 +393,31 @@ describe('v2 sections rendering', () => {
     expect(rows[0]!.querySelectorAll('[data-width="half"]')).toHaveLength(2);
     expect(screen.getByLabelText('First')).toBeTruthy();
     expect(screen.getByLabelText('Last')).toBeTruthy();
-    // the second row's item is in a distinct container
-    expect(rows[1]!.querySelector('[data-width="full"]')).toBeTruthy();
+    // the second row's item is in a distinct container; an unset width is now "auto" (#3)
+    expect(rows[1]!.querySelector('[data-width="auto"]')).toBeTruthy();
     expect(screen.getByLabelText('Email')).toBeTruthy();
+  });
+
+  it('derives field span from the section column count (#3: columns drive width)', () => {
+    // A 2-column section with two unset-width fields → each occupies one cell
+    // (span 1) and the row is a 2-col grid. No per-field width needed.
+    const cfg = { version: 1, sections: [{ id: 's1', columns: 2, rows: [
+      { id: 'r1', items: [
+        { id: 'a', kind: 'field', key: 'a', label: 'A', component: 'Input', dataType: 'string' },
+        { id: 'b', kind: 'field', key: 'b', label: 'B', component: 'Input', dataType: 'string' },
+      ] },
+      { id: 'r2', items: [
+        { id: 'c', kind: 'field', key: 'c', label: 'C', component: 'Input', dataType: 'string', width: 'full' },
+      ] },
+    ] }] };
+    const { container } = render(<ConfigForm config={cfg as any} onSubmit={() => {}} />);
+    const rows = container.querySelectorAll('[data-testid="form-row"]');
+    // Row grid is driven by the section's columns.
+    expect((rows[0] as HTMLElement).style.gridTemplateColumns).toBe('repeat(2, minmax(0, 1fr))');
+    // Unset-width fields span a single cell; a full field spans the whole row.
+    const a = container.querySelector('[data-width="auto"]') as HTMLElement;
+    expect(a.style.gridColumn).toBe('span 1 / span 1');
+    const c = container.querySelector('[data-width="full"]') as HTMLElement;
+    expect(c.style.gridColumn).toBe('1 / -1');
   });
 });

--- a/packages/form-builder-ui/src/config-form.tsx
+++ b/packages/form-builder-ui/src/config-form.tsx
@@ -12,6 +12,7 @@ import {
   isFieldItem,
   type FormConfig,
   type FormItem,
+  type FieldWidth,
   type DataSource,
   type DataSourceFetcher,
 } from '@rfjs/form-builder';
@@ -91,14 +92,25 @@ export function ConfigForm({ config, defaultValues, onSubmit, submitLabel = 'Sub
 
   const spacerHeights: Record<string, number> = { sm: 8, md: 16, lg: 32 };
 
-  // Width is applied via INLINE styles, not Tailwind `basis-*` / `col-span-full`
-  // utilities — those aren't reliably emitted for this package, which left preview
-  // fields collapsed to their intrinsic width ("not full-width"). Inline is guaranteed.
-  // v2 flex row → flex-basis; v1 grid → grid-column span.
-  const fullSpan = (flow: 'grid' | 'flex'): React.CSSProperties =>
-    flow === 'flex' ? { flexBasis: '100%', minWidth: 0 } : { gridColumn: '1 / -1' };
+  // Span styles are applied INLINE, not via Tailwind `col-span-*` utilities —
+  // those aren't reliably emitted for this package. Inline is guaranteed.
+  // Items always span the full row width.
+  const FULL_SPAN: React.CSSProperties = { gridColumn: '1 / -1' };
 
-  function renderItem(item: FormItem, flow: 'grid' | 'flex') {
+  // Field grid-span derived from the field's width AND the section's column count.
+  // #3: columns DRIVE width — an unset width is a single cell, so a section with
+  // `columns: 2` lays its fields two-per-row automatically (no per-field width
+  // needed). 'half' ≈ half the row; 'full' spans the whole row. `flow: 'v1'`
+  // keeps the legacy behaviour (unset = full) for back-compat with `fields[]`.
+  function fieldSpanStyle(width: FieldWidth | undefined, flow: 'v1' | 'section', cols: number): React.CSSProperties {
+    if (flow === 'v1') return { gridColumn: (width ?? 'full') === 'full' ? '1 / -1' : undefined };
+    if (width === 'full') return FULL_SPAN;
+    const cells = width === 'half' ? Math.max(1, Math.ceil(cols / 2)) : 1;
+    const span = Math.min(cells, cols);
+    return { gridColumn: `span ${span} / span ${span}`, minWidth: 0 };
+  }
+
+  function renderItem(item: FormItem, flow: 'v1' | 'section', cols: number) {
     const vals = values as Record<string, unknown>;
 
     if (item.kind === 'ai-note') {
@@ -107,19 +119,19 @@ export function ConfigForm({ config, defaultValues, onSubmit, submitLabel = 'Sub
 
     if (item.kind === 'divider') {
       if (!evaluateConditional(item.conditional, vals)) return null;
-      return <hr key={item.id} className="w-full border-input" style={fullSpan(flow)} />;
+      return <hr key={item.id} className="w-full border-input" style={FULL_SPAN} />;
     }
 
     if (item.kind === 'spacer') {
       if (!evaluateConditional(item.conditional, vals)) return null;
       const height = spacerHeights[item.size ?? 'md'];
-      return <div key={item.id} style={{ ...fullSpan(flow), height }} />;
+      return <div key={item.id} style={{ ...FULL_SPAN, height }} />;
     }
 
     if (item.kind === 'content') {
       if (!evaluateConditional(item.conditional, vals)) return null;
       return (
-        <div key={item.id} className="text-sm" style={fullSpan(flow)}>
+        <div key={item.id} className="text-sm" style={FULL_SPAN}>
           {item.dataSource ? (
             <DataSourceContent ds={item.dataSource} fetcher={fetcher} />
           ) : (
@@ -131,13 +143,16 @@ export function ConfigForm({ config, defaultValues, onSubmit, submitLabel = 'Sub
 
     // kind === 'field'
     if (!evaluateConditional(item.conditional, vals)) return null;
-    const width = item.width ?? 'full';
-    const fieldStyle: React.CSSProperties =
-      flow === 'flex'
-        ? { flexBasis: width === 'full' ? '100%' : 'calc(50% - 0.5rem)', minWidth: 0 }
-        : { gridColumn: width === 'full' ? '1 / -1' : undefined };
+    // data-width reflects the raw setting: 'auto' (cols-driven) in sections, but
+    // the legacy 'full' default in v1 so existing fields[] behaviour is unchanged.
+    const dataWidth = item.width ?? (flow === 'v1' ? 'full' : 'auto');
     return (
-      <div key={item.key} className="flex min-w-0 flex-col gap-1.5" data-width={width} style={fieldStyle}>
+      <div
+        key={item.key}
+        className="flex min-w-0 flex-col gap-1.5"
+        data-width={dataWidth}
+        style={fieldSpanStyle(item.width, flow, cols)}
+      >
         <Label htmlFor={item.key}>{resolveLabel(item.label, locale)}</Label>
         <Controller
           control={control}
@@ -175,32 +190,36 @@ export function ConfigForm({ config, defaultValues, onSubmit, submitLabel = 'Sub
       style={{ '--form-cols': String(columns) } as React.CSSProperties}
       data-columns={columns}
     >
-      {sections.map((section) => (
-        <React.Fragment key={section.id}>
-          {section.title && (
-            <h3 className="font-semibold text-sm" style={{ gridColumn: '1 / -1' }}>
-              {resolveLabel(section.title, locale)}
-            </h3>
-          )}
-          {section.rows.map((row) =>
-            isV2 ? (
-              <div
-                key={row.id}
-                data-testid="form-row"
-                className="flex flex-wrap gap-4"
-                style={{ gridColumn: '1 / -1' }}
-              >
-                {row.items.map((item) => renderItem(item, 'flex'))}
-              </div>
-            ) : (
-              // v1 implicit section: render items FLAT into the section grid (unchanged v1 behavior).
-              <React.Fragment key={row.id}>
-                {row.items.map((item) => renderItem(item, 'grid'))}
-              </React.Fragment>
-            ),
-          )}
-        </React.Fragment>
-      ))}
+      {sections.map((section) => {
+        // Per-section column count drives the row grid (and thus field widths).
+        const sectionCols = section.columns ?? 1;
+        return (
+          <React.Fragment key={section.id}>
+            {section.title && (
+              <h3 className="font-semibold text-sm" style={{ gridColumn: '1 / -1' }}>
+                {resolveLabel(section.title, locale)}
+              </h3>
+            )}
+            {section.rows.map((row) =>
+              isV2 ? (
+                <div
+                  key={row.id}
+                  data-testid="form-row"
+                  className="grid gap-4"
+                  style={{ gridColumn: '1 / -1', gridTemplateColumns: `repeat(${sectionCols}, minmax(0, 1fr))` }}
+                >
+                  {row.items.map((item) => renderItem(item, 'section', sectionCols))}
+                </div>
+              ) : (
+                // v1 implicit section: render items FLAT into the outer grid (unchanged v1 behavior).
+                <React.Fragment key={row.id}>
+                  {row.items.map((item) => renderItem(item, 'v1', sectionCols))}
+                </React.Fragment>
+              ),
+            )}
+          </React.Fragment>
+        );
+      })}
       <div style={{ gridColumn: '1 / -1' }}>
         <Button
           type="submit"

--- a/packages/form-builder-ui/src/config-form.tsx
+++ b/packages/form-builder-ui/src/config-form.tsx
@@ -202,7 +202,11 @@ export function ConfigForm({ config, defaultValues, onSubmit, submitLabel = 'Sub
         </React.Fragment>
       ))}
       <div style={{ gridColumn: '1 / -1' }}>
-        <Button type="submit" className="self-start">
+        <Button
+          type="submit"
+          className="self-start border-0 text-white"
+          style={{ background: 'linear-gradient(180deg,#5b8cff,#4a78ee)', boxShadow: '0 6px 16px rgba(74,120,238,.3)' }}
+        >
           {submitLabel}
         </Button>
       </div>

--- a/packages/form-builder-ui/src/field-row.spec.tsx
+++ b/packages/form-builder-ui/src/field-row.spec.tsx
@@ -73,10 +73,11 @@ describe('FieldRow', () => {
     expect(trigger.textContent).toContain('Input');
   });
   it('width trigger renders the current width value', () => {
-    // Radix Select cannot be driven by fireEvent.change; assert the trigger shows current value
+    // Radix Select cannot be driven by fireEvent.change; assert the trigger shows current value.
+    // An unset width defaults to "Auto" (column-driven) — #3.
     renderRow(base);
     const trigger = screen.getByLabelText('width for name');
-    expect(trigger.textContent).toContain('Full');
+    expect(trigger.textContent).toContain('Auto');
   });
   it('width trigger shows Half when field.width is half', () => {
     renderRow({ ...base, width: 'half' });

--- a/packages/form-builder-ui/src/field-row.tsx
+++ b/packages/form-builder-ui/src/field-row.tsx
@@ -671,13 +671,17 @@ export function FieldItemEditor({ field, onUpdate, locales = ['en'], siblingFiel
       )}
       <span className="flex flex-col gap-1 text-xs text-muted-foreground">
         Width
-        <Select value={field.width ?? 'full'} onValueChange={(v) => onUpdate({ width: v as FieldWidth })}>
+        <Select
+          value={field.width ?? 'auto'}
+          onValueChange={(v) => onUpdate({ width: v === 'auto' ? undefined : (v as FieldWidth) })}
+        >
           <SelectTrigger className="h-8" aria-label={`width for ${field.key}`}>
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="full">Full</SelectItem>
+            <SelectItem value="auto">Auto (by columns)</SelectItem>
             <SelectItem value="half">Half</SelectItem>
+            <SelectItem value="full">Full</SelectItem>
           </SelectContent>
         </Select>
       </span>

--- a/packages/form-builder-ui/src/item-editor.tsx
+++ b/packages/form-builder-ui/src/item-editor.tsx
@@ -190,10 +190,10 @@ export function ItemEditor({ item, siblingFields = [], locales = ['en'], onUpdat
     >
       <div
         // Thin inset left accent (no layout shift, lighter than a full colored border).
-        className={`flex items-center gap-1.5 rounded-md py-1 pl-2.5 pr-1.5 ${open ? '' : 'transition-colors hover:bg-muted/40'}`}
+        className={`flex items-center gap-2 rounded-md py-2 pl-3 pr-2 ${open ? '' : 'transition-colors hover:bg-muted/40'}`}
         style={{ boxShadow: `inset 2px 0 0 ${meta.color}` }}
       >
-        <span className="shrink-0 opacity-40 transition-opacity group-hover/item:opacity-100">
+        <span className="-ml-0.5 shrink-0 text-muted-foreground/40 transition-opacity group-hover/item:text-muted-foreground">
           {dragHandle}
         </span>
         {/* Single disclosure control: chevron + kind icon + summary all toggle the card. */}
@@ -217,7 +217,7 @@ export function ItemEditor({ item, siblingFields = [], locales = ['en'], onUpdat
           <span className="truncate text-sm font-medium text-foreground">{title}</span>
           {sub ? <span className="truncate font-mono text-[11px] text-muted-foreground/70">{sub}</span> : null}
         </button>
-        <div className="flex shrink-0 items-center gap-1">
+        <div className="flex shrink-0 items-center gap-1.5 pl-2">
           {required ? <Pill tone="danger">required</Pill> : null}
           {hasConditional ? <Pill tone="warn">when</Pill> : null}
           {hasDataSource ? <Pill tone="src">datasource</Pill> : null}

--- a/packages/form-builder-ui/src/item-editor.tsx
+++ b/packages/form-builder-ui/src/item-editor.tsx
@@ -26,26 +26,30 @@ interface KindMeta {
 // common case); content/ai-note get gentle blue/violet; layout kinds are neutral.
 // Mid-tone, mid-saturation hues chosen to read on BOTH the dark and light surfaces
 // (the builder must look good in either theme).
+// Direction "A · Technical": brighter blue/violet/gold accents that read on both
+// the dark and light surfaces (kept as inline hex — the web-ui palette doesn't emit
+// these). field=blue, content=violet, ai-note=gold, layout=slate.
 const KIND_META: Record<ItemKind, KindMeta> = {
-  field: { label: 'Field', Icon: Type, color: '#5b82c4' },
-  content: { label: 'Content', Icon: AlignLeft, color: '#6d7bf0' },
-  'ai-note': { label: 'AI Note', Icon: Sparkles, color: '#9168e8' },
-  divider: { label: 'Divider', Icon: Minus, color: '#7a8394' },
-  spacer: { label: 'Spacer', Icon: MoveVertical, color: '#7a8394' },
+  field: { label: 'Field', Icon: Type, color: '#5b8cff' },
+  content: { label: 'Content', Icon: AlignLeft, color: '#7c5cff' },
+  'ai-note': { label: 'AI Note', Icon: Sparkles, color: '#d9a441' },
+  divider: { label: 'Divider', Icon: Minus, color: '#6b7280' },
+  spacer: { label: 'Spacer', Icon: MoveVertical, color: '#6b7280' },
 };
 
 const PILL_COLORS: Record<string, string> = {
-  danger: '#d65a55',
-  warn: '#bd842f',
-  accent: '#8b63dd',
+  danger: '#e0635e',
+  warn: '#d9a441',
+  accent: '#7c5cff',
+  src: '#5b8cff',
 };
 
-function Pill({ tone = 'accent', children }: { tone?: 'danger' | 'warn' | 'accent'; children: React.ReactNode }) {
+function Pill({ tone = 'accent', children }: { tone?: 'danger' | 'warn' | 'accent' | 'src'; children: React.ReactNode }) {
   const c = PILL_COLORS[tone];
   return (
     <span
-      className="rounded px-1.5 py-px text-[10px] font-medium uppercase tracking-wide leading-none"
-      style={{ color: c, backgroundColor: `${c}24` }}
+      className="rounded px-1.5 py-px font-mono text-[10px] font-medium uppercase tracking-wide leading-none"
+      style={{ color: c, backgroundColor: `${c}22` }}
     >
       {children}
     </span>
@@ -175,6 +179,7 @@ export function ItemEditor({ item, siblingFields = [], locales = ['en'], onUpdat
   const required = item.kind === 'field' && Boolean(item.required);
   const hasConditional = (item.kind === 'field' || item.kind === 'content' || item.kind === 'divider' || item.kind === 'spacer') && Boolean((item as { conditional?: unknown }).conditional);
   const locked = item.kind === 'content' && Boolean(item.locked);
+  const hasDataSource = (item.kind === 'field' || item.kind === 'content') && Boolean((item as { dataSource?: unknown }).dataSource);
 
   return (
     <div
@@ -202,13 +207,20 @@ export function ItemEditor({ item, siblingFields = [], locales = ['en'], onUpdat
           <ChevronRight
             className={`size-3.5 shrink-0 text-muted-foreground transition-transform duration-200 ${open ? 'rotate-90' : ''}`}
           />
-          <Icon className="size-4 shrink-0" style={{ color: meta.color }} aria-hidden />
+          <span
+            className="flex size-[19px] shrink-0 items-center justify-center rounded-[5px]"
+            style={{ backgroundColor: `${meta.color}1f`, color: meta.color }}
+            aria-hidden
+          >
+            <Icon className="size-3" />
+          </span>
           <span className="truncate text-sm font-medium text-foreground">{title}</span>
           {sub ? <span className="truncate font-mono text-[11px] text-muted-foreground/70">{sub}</span> : null}
         </button>
         <div className="flex shrink-0 items-center gap-1">
           {required ? <Pill tone="danger">required</Pill> : null}
           {hasConditional ? <Pill tone="warn">when</Pill> : null}
+          {hasDataSource ? <Pill tone="src">datasource</Pill> : null}
           {locked ? <Pill tone="accent">locked</Pill> : null}
           <Button
             type="button"

--- a/packages/form-builder-ui/src/item-editor.tsx
+++ b/packages/form-builder-ui/src/item-editor.tsx
@@ -190,10 +190,11 @@ export function ItemEditor({ item, siblingFields = [], locales = ['en'], onUpdat
     >
       <div
         // Thin inset left accent (no layout shift, lighter than a full colored border).
-        className={`flex items-center gap-2 rounded-md py-2 pl-3 pr-2 ${open ? '' : 'transition-colors hover:bg-muted/40'}`}
+        // pl-4 keeps the grip clear of the accent bar instead of jammed against it.
+        className={`flex items-center gap-2.5 rounded-md py-2 pl-4 pr-2 ${open ? '' : 'transition-colors hover:bg-muted/40'}`}
         style={{ boxShadow: `inset 2px 0 0 ${meta.color}` }}
       >
-        <span className="-ml-0.5 shrink-0 text-muted-foreground/40 transition-opacity group-hover/item:text-muted-foreground">
+        <span className="shrink-0 text-muted-foreground/40 transition-opacity group-hover/item:text-muted-foreground">
           {dragHandle}
         </span>
         {/* Single disclosure control: chevron + kind icon + summary all toggle the card. */}

--- a/packages/form-builder-ui/src/section-arranger.tsx
+++ b/packages/form-builder-ui/src/section-arranger.tsx
@@ -135,21 +135,21 @@ function SectionView({ section, config, builder, locales }: SectionViewProps) {
   const title = section.title ? labelOf(section.title) : 'Section';
   return (
     <section className="overflow-hidden rounded-xl border border-input/70 bg-gradient-to-b from-card/60 to-card/20 shadow-sm">
-      <header className="flex items-center gap-2.5 border-b border-input/60 bg-muted/30 px-3.5 py-2">
+      <header className="flex items-center gap-2.5 border-b border-input/60 bg-muted/30 px-4 py-2.5">
         <span className="text-[13px] font-semibold text-foreground">{title}</span>
         <span className="font-mono text-[11px] text-muted-foreground/55">{section.id}</span>
         <span className="ml-auto font-mono text-[10px] uppercase tracking-wider text-muted-foreground/55">
           {itemCount} item{itemCount === 1 ? '' : 's'}
         </span>
       </header>
-      <div className="flex flex-col p-1.5">
+      <div className="flex flex-col gap-1 px-2.5 py-2.5">
         <NewRowDropZone id={`newrow:${section.id}:0`} />
         {section.rows.map((row, rowIndex) => {
           const itemIds = row.items.map((i) => i.id);
           return (
             <React.Fragment key={row.id}>
               <SortableContext items={itemIds} strategy={verticalListSortingStrategy}>
-                <div className="flex flex-col gap-0.5">
+                <div className="flex flex-col gap-1">
                   {row.items.map((item) => (
                     <SortableItemCard
                       key={item.id}

--- a/packages/form-builder-ui/src/section-arranger.tsx
+++ b/packages/form-builder-ui/src/section-arranger.tsx
@@ -12,9 +12,10 @@ import {
 } from '@dnd-kit/core';
 import { SortableContext, useSortable, verticalListSortingStrategy } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import { GripVertical } from 'lucide-react';
+import { GripVertical, ChevronDown } from 'lucide-react';
 import type { FormConfig, FormSection, FormItem } from '@rfjs/form-builder';
 import { normalizeToSections, collectFieldItems } from '@rfjs/form-builder';
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@rfjs/web-ui/components/select';
 
 import { ItemEditor } from './item-editor';
 import type { ConfigBuilderApi } from './use-config-builder';
@@ -131,18 +132,45 @@ interface SectionViewProps {
 }
 
 function SectionView({ section, config, builder, locales }: SectionViewProps) {
+  const [collapsed, setCollapsed] = React.useState(false);
   const itemCount = section.rows.reduce((n, r) => n + r.items.length, 0);
   const title = section.title ? labelOf(section.title) : 'Section';
+  const columns = section.columns ?? 1;
   return (
     <section className="overflow-hidden rounded-xl border border-input/70 bg-gradient-to-b from-card/60 to-card/20 shadow-sm">
-      <header className="flex items-center gap-2.5 border-b border-input/60 bg-muted/30 px-4 py-2.5">
-        <span className="text-[13px] font-semibold text-foreground">{title}</span>
-        <span className="font-mono text-[11px] text-muted-foreground/55">{section.id}</span>
-        <span className="ml-auto font-mono text-[10px] uppercase tracking-wider text-muted-foreground/55">
+      <header className="flex items-center gap-2.5 border-b border-input/60 bg-muted/40 px-2.5 py-2.5">
+        <button
+          type="button"
+          aria-label={collapsed ? 'expand section' : 'collapse section'}
+          aria-expanded={!collapsed}
+          onClick={() => setCollapsed((v) => !v)}
+          className="flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent/60 hover:text-foreground"
+        >
+          <ChevronDown className={`size-4 transition-transform duration-200 ${collapsed ? '-rotate-90' : ''}`} />
+        </button>
+        <span className="text-[15px] font-semibold leading-none text-foreground">{title}</span>
+        <span className="font-mono text-[11px] text-muted-foreground/50">{section.id}</span>
+        <span className="font-mono text-[10px] uppercase tracking-wider text-muted-foreground/45">
           {itemCount} item{itemCount === 1 ? '' : 's'}
         </span>
+        {/* Per-section column count — drives the preview grid + field widths for THIS section. */}
+        <label className="ml-auto flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-wide text-muted-foreground/70">
+          Cols
+          <Select
+            value={String(columns)}
+            onValueChange={(v) => builder.setSectionColumns(section.id, Number(v) as 1 | 2 | 3 | 4)}
+          >
+            <SelectTrigger className="h-7 w-16 px-2.5" aria-label={`columns for ${title}`}>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {[1, 2, 3, 4].map((n) => <SelectItem key={n} value={String(n)}>{n}</SelectItem>)}
+            </SelectContent>
+          </Select>
+        </label>
       </header>
-      <div className="flex flex-col gap-1 px-2.5 py-2.5">
+      {collapsed ? null : (
+      <div className="flex flex-col gap-1 px-3 py-3">
         <NewRowDropZone id={`newrow:${section.id}:0`} />
         {section.rows.map((row, rowIndex) => {
           const itemIds = row.items.map((i) => i.id);
@@ -168,6 +196,7 @@ function SectionView({ section, config, builder, locales }: SectionViewProps) {
           );
         })}
       </div>
+      )}
     </section>
   );
 }

--- a/packages/form-builder-ui/src/section-arranger.tsx
+++ b/packages/form-builder-ui/src/section-arranger.tsx
@@ -134,10 +134,11 @@ function SectionView({ section, config, builder, locales }: SectionViewProps) {
   const itemCount = section.rows.reduce((n, r) => n + r.items.length, 0);
   const title = section.title ? labelOf(section.title) : 'Section';
   return (
-    <section className="overflow-hidden rounded-lg border border-input/70 bg-card/30">
-      <header className="flex items-center gap-2 bg-muted/30 px-3 py-1.5">
-        <span className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">{title}</span>
-        <span className="text-[10px] text-muted-foreground/60">
+    <section className="overflow-hidden rounded-xl border border-input/70 bg-gradient-to-b from-card/60 to-card/20 shadow-sm">
+      <header className="flex items-center gap-2.5 border-b border-input/60 bg-muted/30 px-3.5 py-2">
+        <span className="text-[13px] font-semibold text-foreground">{title}</span>
+        <span className="font-mono text-[11px] text-muted-foreground/55">{section.id}</span>
+        <span className="ml-auto font-mono text-[10px] uppercase tracking-wider text-muted-foreground/55">
           {itemCount} item{itemCount === 1 ? '' : 's'}
         </span>
       </header>


### PR DESCRIPTION
Direction A (linear, structured) visual/UX redo of the config-driven form-builder, addressing the punch-list.

## What changed
- **Sections collapse** via a header chevron; **bigger section title** fixes the inverted hierarchy (title now larger than item content).
- **Column count moved into each section header** (was an ambiguous global control); widened the trigger so the value shows.
- **Width derived from section columns** — v2 rows render as a grid of `section.columns`; an unset field width is a single cell, so `COLS=2` lays fields two-per-row with no per-field width. `half`/`full` remain overrides; the editor's Width control gains an "Auto (by columns)" default. v1 `fields[]` behaviour unchanged.
- **Preview is a top tab** (Builder | Preview | JSON). The Builder tab shows builder + live preview **side-by-side with a draggable divider**, stacking below `lg` (RWD). Preview tab is full-width.
- **JSON tab**: larger mono font, a **Copy** button, and two-way sync (edits round-trip back to the builder).
- **Drag handle** un-jammed from the accent bar (spacing fix).

## Verification
- `@rfjs/form-builder-ui`: 192 tests + `check-types` green.
- Screenshot-verified in **dark and light** themes (split, narrow/RWD, JSON, columns reflow).

Engine logic (validation / conditional / dataSource / live preview) is the existing, working stack — this PR is the editor's structure/visuals.