### PR TITLE
feat(web): Direction C — 2D canvas form-builder prototype (hybrid: groups + drag)

### DIFF
--- a/apps/web/src/app/[locale]/form-canvas/canvas-prototype.tsx
+++ b/apps/web/src/app/[locale]/form-canvas/canvas-prototype.tsx
@@ -11,34 +11,37 @@ import {
   ChevronDown,
   GripVertical,
   Plus,
+  Copy,
+  Check,
 } from "lucide-react";
 
 // ---------------------------------------------------------------------------
-// Direction C (hybrid) — "A's structure + C's drag freedom".
-//
-// A vertical stack of GROUP frames. Each group is a 12-column grid that fills
-// the container width. Cards live on the grid as {col, span, row}: drag the
-// body to move (snaps to a column + row, and across groups), drag the right
-// edge to resize the column span. Click to select, Delete to remove. No engine
-// logic — layout evaluation only.
+// Direction C (hybrid) — "A structure + C drag freedom", now with a builder
+// shell: Canvas | Preview | JSON tabs, a right-hand inspector for per-field
+// config, and bidirectional JSON (edit JSON → rebuild the canvas). RWD-aware.
+// Still a layout-evaluation prototype — no real validation/data engine.
 // ---------------------------------------------------------------------------
 
 const COLS = 12;
-const ROW_H = 84; // px per grid row
+const ROW_H = 84;
 const GAP = 8;
 const clamp = (v: number, lo: number, hi: number) => Math.max(lo, Math.min(hi, v));
 
 type Kind = "field" | "content" | "divider" | "spacer" | "ai-note";
+type Component = "Input" | "Textarea" | "Select" | "Number" | "Switch" | "DatePicker";
+const COMPONENTS: Component[] = ["Input", "Textarea", "Select", "Number", "Switch", "DatePicker"];
 
 interface Card {
   id: string;
   groupId: string;
   kind: Kind;
   label: string;
-  sub?: string;
-  col: number; // 1-based start column
-  span: number; // column span (1..12)
-  row: number; // 1-based grid row
+  key?: string;
+  component?: Component;
+  required?: boolean;
+  col: number;
+  span: number;
+  row: number;
 }
 
 interface Group {
@@ -49,7 +52,7 @@ interface Group {
 
 const KIND_META: Record<
   Kind,
-  { color: string; icon: React.ComponentType<{ className?: string }>; label: string; field?: boolean }
+  { color: string; icon: React.ComponentType<{ className?: string; style?: React.CSSProperties }>; label: string; field?: boolean }
 > = {
   field: { color: "#5b8cff", icon: Type, label: "Field", field: true },
   content: { color: "#7c5cff", icon: AlignLeft, label: "Content" },
@@ -58,43 +61,123 @@ const KIND_META: Record<
   spacer: { color: "#6b7280", icon: MoveVertical, label: "Spacer" },
 };
 
+const fieldSub = (c: Card) => (c.kind === "field" ? `${c.key ?? "field"} · ${c.component ?? "Input"}` : undefined);
+
 const SEED_GROUPS: Group[] = [
   { id: "g_account", title: "Account", collapsed: false },
   { id: "g_profile", title: "Profile", collapsed: false },
 ];
 
 const SEED_CARDS: Card[] = [
-  { id: "c1", groupId: "g_account", kind: "field", label: "Name", sub: "name · Input", col: 1, span: 6, row: 1 },
-  { id: "c2", groupId: "g_account", kind: "field", label: "Email", sub: "email · Input", col: 7, span: 6, row: 1 },
-  { id: "c3", groupId: "g_account", kind: "field", label: "Role", sub: "role · Select", col: 1, span: 6, row: 2 },
+  { id: "c1", groupId: "g_account", kind: "field", label: "Name", key: "name", component: "Input", required: true, col: 1, span: 6, row: 1 },
+  { id: "c2", groupId: "g_account", kind: "field", label: "Email", key: "email", component: "Input", required: true, col: 7, span: 6, row: 1 },
+  { id: "c3", groupId: "g_account", kind: "field", label: "Role", key: "role", component: "Select", col: 1, span: 6, row: 2 },
   { id: "c4", groupId: "g_account", kind: "ai-note", label: "If unsure, default to 'user'", col: 7, span: 6, row: 2 },
-  { id: "c5", groupId: "g_account", kind: "field", label: "Bio", sub: "bio · Textarea", col: 1, span: 12, row: 3 },
-  { id: "c6", groupId: "g_profile", kind: "field", label: "Age", sub: "age · Number", col: 1, span: 4, row: 1 },
-  { id: "c7", groupId: "g_profile", kind: "field", label: "Country", sub: "country · Select", col: 5, span: 4, row: 1 },
-  { id: "c8", groupId: "g_profile", kind: "field", label: "Birthday", sub: "birthday · DatePicker", col: 9, span: 4, row: 1 },
-  { id: "c9", groupId: "g_profile", kind: "field", label: "Subscribe", sub: "newsletter · Switch", col: 1, span: 6, row: 2 },
+  { id: "c5", groupId: "g_account", kind: "field", label: "Bio", key: "bio", component: "Textarea", col: 1, span: 12, row: 3 },
+  { id: "c6", groupId: "g_profile", kind: "field", label: "Age", key: "age", component: "Number", col: 1, span: 4, row: 1 },
+  { id: "c7", groupId: "g_profile", kind: "field", label: "Country", key: "country", component: "Select", col: 5, span: 4, row: 1 },
+  { id: "c8", groupId: "g_profile", kind: "field", label: "Birthday", key: "birthday", component: "DatePicker", col: 9, span: 4, row: 1 },
+  { id: "c9", groupId: "g_profile", kind: "field", label: "Subscribe", key: "newsletter", component: "Switch", col: 1, span: 6, row: 2 },
 ];
 
 let seq = 100;
 let gseq = 10;
 
+// --- (de)serialize: the canvas <-> a readable config JSON --------------------
+function serialize(groups: Group[], cards: Card[]) {
+  return {
+    version: 1,
+    groups: groups.map((g) => ({
+      id: g.id,
+      title: g.title,
+      cols: COLS,
+      items: cards
+        .filter((c) => c.groupId === g.id)
+        .sort((a, b) => a.row - b.row || a.col - b.col)
+        .map((c) => ({
+          id: c.id,
+          kind: c.kind,
+          label: c.label,
+          ...(c.kind === "field" ? { key: c.key, component: c.component, required: c.required || undefined } : {}),
+          col: c.col,
+          span: c.span,
+          row: c.row,
+        })),
+    })),
+  };
+}
+
+function parse(obj: unknown): { groups: Group[]; cards: Card[] } {
+  if (!obj || typeof obj !== "object" || !Array.isArray((obj as { groups?: unknown }).groups)) {
+    throw new Error("expected { groups: [...] }");
+  }
+  const groups: Group[] = [];
+  const cards: Card[] = [];
+  for (const g of (obj as { groups: Array<Record<string, unknown>> }).groups) {
+    const gid = String(g.id ?? `g${groups.length}`);
+    groups.push({ id: gid, title: String(g.title ?? "Section"), collapsed: false });
+    const items = Array.isArray(g.items) ? (g.items as Array<Record<string, unknown>>) : [];
+    items.forEach((it, i) => {
+      cards.push({
+        id: String(it.id ?? `${gid}_${i}`),
+        groupId: gid,
+        kind: (it.kind as Kind) ?? "field",
+        label: String(it.label ?? "Field"),
+        key: it.key as string | undefined,
+        component: it.component as Component | undefined,
+        required: Boolean(it.required),
+        col: clamp(Number(it.col ?? 1), 1, COLS),
+        span: clamp(Number(it.span ?? 6), 1, COLS),
+        row: Number(it.row ?? i + 1),
+      });
+    });
+  }
+  return { groups, cards };
+}
+
+function useMediaQuery(query: string) {
+  const [m, setM] = React.useState(false);
+  React.useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return;
+    const mql = window.matchMedia(query);
+    const on = () => setM(mql.matches);
+    on();
+    mql.addEventListener("change", on);
+    return () => mql.removeEventListener("change", on);
+  }, [query]);
+  return m;
+}
+
 export function CanvasPrototype() {
   const [groups, setGroups] = React.useState<Group[]>(SEED_GROUPS);
   const [cards, setCards] = React.useState<Card[]>(SEED_CARDS);
   const [selected, setSelected] = React.useState<string | null>(null);
+  const [tab, setTab] = React.useState<"canvas" | "preview" | "json">("canvas");
+  const [jsonError, setJsonError] = React.useState<string | null>(null);
+  const [copied, setCopied] = React.useState(false);
   const bodyRefs = React.useRef<Record<string, HTMLDivElement | null>>({});
-  const drag = React.useRef<
-    | { id: string; mode: "move" | "resize"; col: number; span: number; row: number; groupId: string }
-    | null
-  >(null);
+  const drag = React.useRef<{ id: string; mode: "move" | "resize"; col: number; span: number } | null>(null);
+  const isWidePreview = useMediaQuery("(min-width: 768px)");
 
-  const patch = (id: string, p: Partial<Card>) =>
-    setCards((cs) => cs.map((c) => (c.id === id ? { ...c, ...p } : c)));
+  const selectedCard = cards.find((c) => c.id === selected) ?? null;
 
-  // Map a pointer position to a {groupId, col, row} grid cell.
+  const patch = (id: string, p: Partial<Card>) => setCards((cs) => cs.map((c) => (c.id === id ? { ...c, ...p } : c)));
+
+  function updateCard(id: string, p: Partial<Card>) {
+    setCards((cs) =>
+      cs.map((c) => {
+        if (c.id !== id) return c;
+        const next = { ...c, ...p };
+        next.span = clamp(next.span, 1, COLS);
+        next.col = clamp(next.col, 1, COLS - next.span + 1);
+        return next;
+      }),
+    );
+  }
+
   function cellAt(clientX: number, clientY: number, fallbackGroup: string) {
     let groupId = fallbackGroup;
-    let rect: DOMRect | null = bodyRefs.current[fallbackGroup]?.getBoundingClientRect() ?? null;
+    let rect = bodyRefs.current[fallbackGroup]?.getBoundingClientRect() ?? null;
     for (const [gid, el] of Object.entries(bodyRefs.current)) {
       if (!el) continue;
       const r = el.getBoundingClientRect();
@@ -104,31 +187,32 @@ export function CanvasPrototype() {
         break;
       }
     }
-    if (!rect) return { groupId, col: 1, row: 1, colW: 0, rect: null as DOMRect | null };
+    if (!rect) return { groupId, col: 1, row: 1 };
     const colW = (rect.width + GAP) / COLS;
-    const col = clamp(Math.round((clientX - rect.left) / colW) + 1, 1, COLS);
-    const row = clamp(Math.round((clientY - rect.top) / (ROW_H + GAP)) + 1, 1, 99);
-    return { groupId, col, row, colW, rect };
+    return {
+      groupId,
+      col: clamp(Math.round((clientX - rect.left) / colW) + 1, 1, COLS),
+      row: clamp(Math.round((clientY - rect.top) / (ROW_H + GAP)) + 1, 1, 99),
+    };
   }
 
   function beginDrag(e: React.PointerEvent, card: Card, mode: "move" | "resize") {
     e.preventDefault();
     e.stopPropagation();
     setSelected(card.id);
-    drag.current = { id: card.id, mode, col: card.col, span: card.span, row: card.row, groupId: card.groupId };
-
+    drag.current = { id: card.id, mode, col: card.col, span: card.span };
     const onMove = (ev: PointerEvent) => {
       const d = drag.current;
       if (!d) return;
       if (d.mode === "move") {
-        const { groupId, col, row } = cellAt(ev.clientX, ev.clientY, d.groupId);
-        patch(d.id, { groupId, col: clamp(col, 1, COLS - d.span + 1), row });
+        const { groupId, col, row } = cellAt(ev.clientX, ev.clientY, card.groupId);
+        patch(d.id, { groupId, col: clamp(col, 1, COLS - card.span + 1), row });
       } else {
-        const body = bodyRefs.current[d.groupId];
+        const body = bodyRefs.current[card.groupId];
         if (!body) return;
         const rect = body.getBoundingClientRect();
         const colW = (rect.width + GAP) / COLS;
-        const rightCol = Math.round((ev.clientX - rect.left) / colW); // 0-based exclusive edge
+        const rightCol = Math.round((ev.clientX - rect.left) / colW);
         patch(d.id, { span: clamp(rightCol - (d.col - 1), 1, COLS - d.col + 1) });
       }
     };
@@ -142,169 +226,276 @@ export function CanvasPrototype() {
   }
 
   function addCard(kind: Kind) {
-    const groupId = (selected && cards.find((c) => c.id === selected)?.groupId) || groups[0]?.id;
+    const groupId = selectedCard?.groupId || groups[0]?.id;
     if (!groupId) return;
     const maxRow = cards.filter((c) => c.groupId === groupId).reduce((m, c) => Math.max(m, c.row), 0);
     seq += 1;
     const id = `c${seq}`;
     setCards((cs) => [
       ...cs,
-      { id, groupId, kind, label: KIND_META[kind].label, sub: kind === "field" ? "field · Input" : undefined, col: 1, span: kind === "field" ? 6 : 12, row: maxRow + 1 },
+      {
+        id,
+        groupId,
+        kind,
+        label: KIND_META[kind].label,
+        ...(kind === "field" ? { key: `field_${seq}`, component: "Input" as Component } : {}),
+        col: 1,
+        span: kind === "field" ? 6 : 12,
+        row: maxRow + 1,
+      },
     ]);
     setSelected(id);
   }
 
-  function addGroup() {
-    gseq += 1;
-    setGroups((gs) => [...gs, { id: `g${gseq}`, title: `Section ${gs.length + 1}`, collapsed: false }]);
+  function applyJson(text: string) {
+    try {
+      const { groups: g, cards: c } = parse(JSON.parse(text));
+      setGroups(g);
+      setCards(c);
+      setJsonError(null);
+    } catch (err) {
+      setJsonError(err instanceof Error ? err.message : "invalid JSON");
+    }
   }
 
-  function removeSelected() {
-    if (!selected) return;
-    setCards((cs) => cs.filter((c) => c.id !== selected));
-    setSelected(null);
+  async function copyJson() {
+    try {
+      await navigator.clipboard?.writeText(JSON.stringify(serialize(groups, cards), null, 2));
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1400);
+    } catch {
+      /* clipboard unavailable */
+    }
   }
 
   React.useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
+      const el = e.target as HTMLElement;
+      if (el && (el.tagName === "INPUT" || el.tagName === "TEXTAREA" || el.tagName === "SELECT")) return;
       if ((e.key === "Delete" || e.key === "Backspace") && selected) {
         e.preventDefault();
-        removeSelected();
+        setCards((cs) => cs.filter((c) => c.id !== selected));
+        setSelected(null);
       }
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selected]);
 
   const PALETTE: Kind[] = ["field", "content", "divider", "spacer", "ai-note"];
+  const TABS = [
+    { id: "canvas", label: "Canvas" },
+    { id: "preview", label: "Preview" },
+    { id: "json", label: "JSON" },
+  ] as const;
 
   return (
     <div className="min-h-screen bg-background text-foreground">
-      <header className="border-b border-border px-6 py-4">
+      <header className="flex flex-wrap items-center gap-x-4 gap-y-2 border-b border-border px-4 py-3 sm:px-6">
         <div className="flex items-baseline gap-3">
           <h1 className="text-xl font-semibold">Form Canvas</h1>
-          <span className="font-mono text-xs uppercase tracking-[0.18em] text-muted-foreground">
-            Direction C · structure + drag
+          <span className="hidden font-mono text-xs uppercase tracking-[0.18em] text-muted-foreground sm:inline">
+            Direction C · hybrid
           </span>
         </div>
-        <p className="mt-1 text-sm text-muted-foreground">
-          {COLS}-column groups · drag to move (across groups too) · drag the right edge to resize · Delete to remove.
-        </p>
+        <div className="inline-flex w-fit gap-0.5 rounded-lg border border-input bg-muted/30 p-1 sm:ml-2">
+          {TABS.map((t) => (
+            <button
+              key={t.id}
+              type="button"
+              onClick={() => setTab(t.id)}
+              aria-selected={tab === t.id}
+              className={`rounded-md px-3 py-1.5 text-[13px] font-medium transition-colors ${
+                tab === t.id ? "bg-background text-foreground shadow-sm" : "text-muted-foreground hover:text-foreground"
+              }`}
+            >
+              {t.label}
+            </button>
+          ))}
+        </div>
       </header>
 
-      <div className="flex flex-wrap items-center gap-2 border-b border-border px-6 py-3">
-        {PALETTE.map((kind) => {
-          const m = KIND_META[kind];
-          const Icon = m.icon;
-          return (
-            <button
-              key={kind}
-              type="button"
-              onClick={() => addCard(kind)}
-              className="inline-flex items-center gap-1.5 rounded-lg border border-input bg-card/40 px-3 py-1.5 font-mono text-xs text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
-            >
-              <Icon className="size-3.5" style={{ color: m.color }} />
-              {m.label}
-            </button>
-          );
-        })}
-        <div className="ml-auto flex items-center gap-2">
-          <button
-            type="button"
-            onClick={addGroup}
-            className="inline-flex items-center gap-1.5 rounded-lg border border-input bg-card/40 px-3 py-1.5 font-mono text-xs text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
-          >
-            <Plus className="size-3.5" />
-            Group
-          </button>
-          <button
-            type="button"
-            onClick={removeSelected}
-            disabled={!selected}
-            className="inline-flex items-center gap-1.5 rounded-lg border border-input bg-card/40 px-3 py-1.5 font-mono text-xs text-muted-foreground transition-colors enabled:hover:border-destructive/50 enabled:hover:text-destructive disabled:opacity-40"
-          >
-            <Trash2 className="size-3.5" />
-            Delete
-          </button>
-        </div>
-      </div>
-
-      {/* Stacked group frames */}
-      <div className="flex flex-col gap-4 p-6" onPointerDown={() => setSelected(null)}>
-        {groups.map((group) => {
-          const groupCards = cards.filter((c) => c.groupId === group.id);
-          const maxRow = groupCards.reduce((m, c) => Math.max(m, c.row), 0);
-          const rows = Math.max(maxRow + 1, 2); // keep a spare row as a drop target
-          return (
-            <section key={group.id} className="overflow-hidden rounded-xl border border-border bg-card/20">
-              <header className="flex items-center gap-2.5 border-b border-border bg-muted/40 px-3 py-2.5">
+      {tab === "canvas" ? (
+        <>
+          <div className="flex flex-wrap items-center gap-2 border-b border-border px-4 py-3 sm:px-6">
+            {PALETTE.map((kind) => {
+              const meta = KIND_META[kind];
+              const Icon = meta.icon;
+              return (
                 <button
+                  key={kind}
                   type="button"
-                  aria-label={group.collapsed ? "expand" : "collapse"}
-                  onClick={() =>
-                    setGroups((gs) => gs.map((g) => (g.id === group.id ? { ...g, collapsed: !g.collapsed } : g)))
-                  }
-                  className="flex size-6 items-center justify-center rounded-md text-muted-foreground hover:bg-accent/60 hover:text-foreground"
+                  onClick={() => addCard(kind)}
+                  className="inline-flex items-center gap-1.5 rounded-lg border border-input bg-card/40 px-3 py-1.5 font-mono text-xs text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
                 >
-                  <ChevronDown className={`size-4 transition-transform ${group.collapsed ? "-rotate-90" : ""}`} />
+                  <Icon className="size-3.5" style={{ color: meta.color }} />
+                  {meta.label}
                 </button>
-                <span className="text-[15px] font-semibold">{group.title}</span>
-                <span className="font-mono text-[11px] text-muted-foreground/50">{group.id}</span>
-                <span className="font-mono text-[10px] uppercase tracking-wider text-muted-foreground/45">
-                  {groupCards.length} item{groupCards.length === 1 ? "" : "s"}
-                </span>
-                <span className="ml-auto font-mono text-[10px] uppercase tracking-wide text-muted-foreground/55">
-                  {COLS} cols
-                </span>
-              </header>
+              );
+            })}
+            <div className="ml-auto flex items-center gap-2">
+              <button
+                type="button"
+                onClick={() => setGroups((gs) => [...gs, { id: `g${(gseq += 1)}`, title: `Section ${gs.length + 1}`, collapsed: false }])}
+                className="inline-flex items-center gap-1.5 rounded-lg border border-input bg-card/40 px-3 py-1.5 font-mono text-xs text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
+              >
+                <Plus className="size-3.5" />
+                Group
+              </button>
+            </div>
+          </div>
 
-              {group.collapsed ? null : (
-                <div
-                  ref={(el) => {
-                    bodyRefs.current[group.id] = el;
-                  }}
-                  className="relative p-3"
-                  style={{
-                    display: "grid",
-                    gridTemplateColumns: `repeat(${COLS}, minmax(0, 1fr))`,
-                    gridAutoRows: `${ROW_H}px`,
-                    gap: GAP,
-                    minHeight: rows * (ROW_H + GAP),
-                    // faint column guides
-                    backgroundImage:
-                      "repeating-linear-gradient(to right, color-mix(in srgb, var(--muted-foreground) 8%, transparent) 0 1px, transparent 1px calc(100% / 12))",
-                    backgroundPosition: "12px 0",
-                    backgroundSize: "calc(100% - 24px) 100%",
-                    backgroundRepeat: "no-repeat",
-                  }}
-                >
-                  {groupCards.length === 0 ? (
-                    <div className="pointer-events-none col-span-12 row-start-1 flex items-center justify-center text-xs text-muted-foreground/50">
-                      Drop fields here
-                    </div>
-                  ) : null}
-                  {groupCards.map((card) => (
-                    <CanvasCard
-                      key={card.id}
-                      card={card}
-                      selected={selected === card.id}
-                      onMoveStart={(e) => beginDrag(e, card, "move")}
-                      onResizeStart={(e) => beginDrag(e, card, "resize")}
-                    />
-                  ))}
-                </div>
-              )}
-            </section>
-          );
-        })}
-      </div>
+          {/* Canvas + inspector (RWD: stacks below lg) */}
+          <div className="flex flex-col gap-4 p-4 lg:flex-row lg:items-start sm:p-6">
+            <div className="min-w-0 flex-1" onPointerDown={() => setSelected(null)}>
+              <div className="flex flex-col gap-4">
+                {groups.map((group) => (
+                  <GroupFrame
+                    key={group.id}
+                    group={group}
+                    cards={cards.filter((c) => c.groupId === group.id)}
+                    selected={selected}
+                    bodyRef={(el) => {
+                      bodyRefs.current[group.id] = el;
+                    }}
+                    onToggle={() =>
+                      setGroups((gs) => gs.map((g) => (g.id === group.id ? { ...g, collapsed: !g.collapsed } : g)))
+                    }
+                    onMoveStart={beginDrag}
+                    onResizeStart={beginDrag}
+                  />
+                ))}
+              </div>
+            </div>
+
+            <aside className="shrink-0 lg:w-80">
+              <Inspector
+                card={selectedCard}
+                groups={groups}
+                onChange={(p) => selectedCard && updateCard(selectedCard.id, p)}
+                onRemove={() => {
+                  if (!selectedCard) return;
+                  setCards((cs) => cs.filter((c) => c.id !== selectedCard.id));
+                  setSelected(null);
+                }}
+              />
+            </aside>
+          </div>
+        </>
+      ) : tab === "preview" ? (
+        <div className="p-4 sm:p-6">
+          <PreviewForm groups={groups} cards={cards} wide={isWidePreview} />
+        </div>
+      ) : (
+        <div className="flex flex-col gap-2 p-4 sm:p-6">
+          <div className="flex items-center justify-between">
+            <span className="font-mono text-[11px] uppercase tracking-[0.15em] text-muted-foreground/60">
+              Config JSON — edits rebuild the canvas
+            </span>
+            <button
+              type="button"
+              onClick={copyJson}
+              className="inline-flex items-center gap-1.5 rounded-md border border-input bg-card/40 px-2.5 py-1 font-mono text-xs text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
+            >
+              {copied ? <Check className="size-3.5" style={{ color: "#5b8cff" }} /> : <Copy className="size-3.5" />}
+              {copied ? "Copied" : "Copy"}
+            </button>
+          </div>
+          <textarea
+            aria-label="config json"
+            spellCheck={false}
+            className="h-[28rem] w-full rounded-md border border-input bg-background p-4 font-mono text-[13px] leading-relaxed"
+            defaultValue={JSON.stringify(serialize(groups, cards), null, 2)}
+            onChange={(e) => applyJson(e.target.value)}
+          />
+          {jsonError ? <p className="text-xs text-destructive">Invalid config: {jsonError}</p> : null}
+        </div>
+      )}
     </div>
   );
 }
 
 // ---------------------------------------------------------------------------
-// CanvasCard — a grid-placed, draggable, resizable card.
+// GroupFrame
+// ---------------------------------------------------------------------------
+
+function GroupFrame({
+  group,
+  cards,
+  selected,
+  bodyRef,
+  onToggle,
+  onMoveStart,
+  onResizeStart,
+}: {
+  group: Group;
+  cards: Card[];
+  selected: string | null;
+  bodyRef: (el: HTMLDivElement | null) => void;
+  onToggle: () => void;
+  onMoveStart: (e: React.PointerEvent, card: Card, mode: "move") => void;
+  onResizeStart: (e: React.PointerEvent, card: Card, mode: "resize") => void;
+}) {
+  const maxRow = cards.reduce((m, c) => Math.max(m, c.row), 0);
+  const rows = Math.max(maxRow + 1, 2);
+  return (
+    <section className="overflow-hidden rounded-xl border border-border bg-card/20">
+      <header className="flex items-center gap-2.5 border-b border-border bg-muted/40 px-3 py-2.5">
+        <button
+          type="button"
+          aria-label={group.collapsed ? "expand" : "collapse"}
+          onClick={onToggle}
+          className="flex size-6 items-center justify-center rounded-md text-muted-foreground hover:bg-accent/60 hover:text-foreground"
+        >
+          <ChevronDown className={`size-4 transition-transform ${group.collapsed ? "-rotate-90" : ""}`} />
+        </button>
+        <span className="text-[15px] font-semibold">{group.title}</span>
+        <span className="font-mono text-[11px] text-muted-foreground/50">{group.id}</span>
+        <span className="font-mono text-[10px] uppercase tracking-wider text-muted-foreground/45">
+          {cards.length} item{cards.length === 1 ? "" : "s"}
+        </span>
+        <span className="ml-auto font-mono text-[10px] uppercase tracking-wide text-muted-foreground/55">{COLS} cols</span>
+      </header>
+
+      {group.collapsed ? null : (
+        <div
+          ref={bodyRef}
+          className="relative p-3"
+          style={{
+            display: "grid",
+            gridTemplateColumns: `repeat(${COLS}, minmax(0, 1fr))`,
+            gridAutoRows: `${ROW_H}px`,
+            gap: GAP,
+            minHeight: rows * (ROW_H + GAP),
+            backgroundImage:
+              "repeating-linear-gradient(to right, color-mix(in srgb, var(--muted-foreground) 8%, transparent) 0 1px, transparent 1px calc(100% / 12))",
+            backgroundPosition: "12px 0",
+            backgroundSize: "calc(100% - 24px) 100%",
+            backgroundRepeat: "no-repeat",
+          }}
+        >
+          {cards.length === 0 ? (
+            <div className="pointer-events-none col-span-12 row-start-1 flex items-center justify-center text-xs text-muted-foreground/50">
+              Drop fields here
+            </div>
+          ) : null}
+          {cards.map((card) => (
+            <CanvasCard
+              key={card.id}
+              card={card}
+              selected={selected === card.id}
+              onMoveStart={(e) => onMoveStart(e, card, "move")}
+              onResizeStart={(e) => onResizeStart(e, card, "resize")}
+            />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// CanvasCard
 // ---------------------------------------------------------------------------
 
 function CanvasCard({
@@ -320,18 +511,14 @@ function CanvasCard({
 }) {
   const m = KIND_META[card.kind];
   const Icon = m.icon;
-
+  const sub = fieldSub(card);
   return (
     <div
       onPointerDown={onMoveStart}
       className={`group relative cursor-grab touch-none select-none rounded-lg border bg-card shadow-sm transition-shadow active:cursor-grabbing ${
         selected ? "border-transparent ring-2 ring-[#5b8cff]" : "border-border hover:shadow-md"
       }`}
-      style={{
-        gridColumn: `${card.col} / span ${card.span}`,
-        gridRow: card.row,
-        boxShadow: `inset 3px 0 0 ${m.color}`,
-      }}
+      style={{ gridColumn: `${card.col} / span ${card.span}`, gridRow: card.row, boxShadow: `inset 3px 0 0 ${m.color}` }}
     >
       {card.kind === "divider" ? (
         <div className="flex h-full items-center gap-2 px-3">
@@ -349,25 +536,209 @@ function CanvasCard({
               <Icon className="size-3" />
             </span>
             <span className="truncate text-sm font-medium">{card.label}</span>
-            {card.sub ? (
-              <span className="truncate font-mono text-[11px] text-muted-foreground/70">{card.sub}</span>
+            {sub ? <span className="truncate font-mono text-[11px] text-muted-foreground/70">{sub}</span> : null}
+            {card.required ? (
+              <span
+                className="ml-auto rounded px-1.5 py-px font-mono text-[10px] uppercase leading-none"
+                style={{ color: "#e0635e", backgroundColor: "#e0635e22" }}
+              >
+                req
+              </span>
             ) : null}
           </div>
           {m.field ? <div className="h-7 rounded-md border border-input bg-background/60" /> : null}
         </div>
       )}
-
-      {/* Resize handle (right edge) */}
       <div
         onPointerDown={onResizeStart}
         className="absolute right-0 top-0 flex h-full w-3 cursor-col-resize items-center justify-center"
       >
-        <div
-          className={`h-8 w-1 rounded-full transition-colors ${
-            selected ? "bg-[#5b8cff]" : "bg-transparent group-hover:bg-border"
-          }`}
-        />
+        <div className={`h-8 w-1 rounded-full transition-colors ${selected ? "bg-[#5b8cff]" : "bg-transparent group-hover:bg-border"}`} />
       </div>
     </div>
   );
+}
+
+// ---------------------------------------------------------------------------
+// Inspector — right-hand per-card config panel
+// ---------------------------------------------------------------------------
+
+function Inspector({
+  card,
+  groups,
+  onChange,
+  onRemove,
+}: {
+  card: Card | null;
+  groups: Group[];
+  onChange: (p: Partial<Card>) => void;
+  onRemove: () => void;
+}) {
+  if (!card) {
+    return (
+      <div className="rounded-xl border border-dashed border-border bg-card/20 p-6 text-center text-sm text-muted-foreground">
+        Select a card to edit its config
+      </div>
+    );
+  }
+  const m = KIND_META[card.kind];
+  const Icon = m.icon;
+  const input = "h-8 w-full rounded-md border border-input bg-background px-2 text-sm";
+  return (
+    <div className="flex flex-col gap-3 rounded-xl border border-border bg-card/30 p-4">
+      <div className="flex items-center gap-2">
+        <span className="flex size-5 items-center justify-center rounded-[5px]" style={{ backgroundColor: `${m.color}1f`, color: m.color }}>
+          <Icon className="size-3" />
+        </span>
+        <span className="text-sm font-semibold">{m.label}</span>
+        <span className="ml-auto font-mono text-[11px] text-muted-foreground/50">{card.id}</span>
+      </div>
+
+      <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+        Label
+        <input className={input} value={card.label} onChange={(e) => onChange({ label: e.target.value })} />
+      </label>
+
+      {card.kind === "field" ? (
+        <>
+          <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+            Key
+            <input className={`${input} font-mono`} value={card.key ?? ""} onChange={(e) => onChange({ key: e.target.value })} />
+          </label>
+          <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+            Component
+            <select className={input} value={card.component ?? "Input"} onChange={(e) => onChange({ component: e.target.value as Component })}>
+              {COMPONENTS.map((c) => (
+                <option key={c} value={c}>
+                  {c}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="flex items-center gap-2 text-xs text-muted-foreground">
+            <input type="checkbox" checked={Boolean(card.required)} onChange={(e) => onChange({ required: e.target.checked })} />
+            Required
+          </label>
+        </>
+      ) : null}
+
+      <div className="grid grid-cols-2 gap-2">
+        <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+          Width (cols)
+          <select className={input} value={card.span} onChange={(e) => onChange({ span: Number(e.target.value) })}>
+            {Array.from({ length: COLS }, (_, i) => i + 1).map((n) => (
+              <option key={n} value={n}>
+                {n}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+          Group
+          <select className={input} value={card.groupId} onChange={(e) => onChange({ groupId: e.target.value })}>
+            {groups.map((g) => (
+              <option key={g.id} value={g.id}>
+                {g.title}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+
+      <button
+        type="button"
+        onClick={onRemove}
+        className="mt-1 inline-flex items-center justify-center gap-1.5 rounded-md border border-input px-3 py-1.5 text-xs text-muted-foreground transition-colors hover:border-destructive/50 hover:text-destructive"
+      >
+        <Trash2 className="size-3.5" />
+        Delete card
+      </button>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// PreviewForm — renders the model as an actual form (RWD: 1-col on narrow)
+// ---------------------------------------------------------------------------
+
+function PreviewForm({ groups, cards, wide }: { groups: Group[]; cards: Card[]; wide: boolean }) {
+  return (
+    <div className="mx-auto flex max-w-3xl flex-col gap-8 rounded-xl border border-border bg-card/30 p-6">
+      {groups.map((group) => {
+        const groupCards = cards
+          .filter((c) => c.groupId === group.id && c.kind !== "ai-note")
+          .sort((a, b) => a.row - b.row || a.col - b.col);
+        return (
+          <section key={group.id} className="flex flex-col gap-4">
+            <h3 className="text-sm font-semibold">{group.title}</h3>
+            <div
+              className="grid gap-4"
+              style={{ gridTemplateColumns: wide ? `repeat(${COLS}, minmax(0, 1fr))` : "1fr" }}
+            >
+              {groupCards.map((c) => (
+                <div key={c.id} style={{ gridColumn: wide ? `span ${c.span}` : "1 / -1" }}>
+                  <PreviewField card={c} />
+                </div>
+              ))}
+            </div>
+          </section>
+        );
+      })}
+    </div>
+  );
+}
+
+function PreviewField({ card }: { card: Card }) {
+  if (card.kind === "divider") return <hr className="border-border" />;
+  if (card.kind === "spacer") return <div className="h-4" />;
+  if (card.kind === "content") return <p className="text-sm text-muted-foreground">{card.label}</p>;
+
+  const ctrl = "mt-1.5 w-full rounded-md border border-input bg-background px-3 text-sm";
+  const label = (
+    <label className="text-sm font-medium">
+      {card.label}
+      {card.required ? <span className="ml-1 text-destructive">*</span> : null}
+    </label>
+  );
+  switch (card.component) {
+    case "Textarea":
+      return (
+        <div>
+          {label}
+          <textarea className={`${ctrl} h-20 py-2`} />
+        </div>
+      );
+    case "Select":
+      return (
+        <div>
+          {label}
+          <select className={`${ctrl} h-9`}>
+            <option>—</option>
+          </select>
+        </div>
+      );
+    case "Switch":
+      return (
+        <div className="flex items-center justify-between">
+          {label}
+          <span className="h-5 w-9 rounded-full bg-input" />
+        </div>
+      );
+    case "DatePicker":
+      return (
+        <div>
+          {label}
+          <button type="button" className={`${ctrl} h-9 text-left text-muted-foreground`}>
+            Pick a date
+          </button>
+        </div>
+      );
+    default:
+      return (
+        <div>
+          {label}
+          <input type={card.component === "Number" ? "number" : "text"} className={`${ctrl} h-9`} />
+        </div>
+      );
+  }
 }

--- a/apps/web/src/app/[locale]/form-canvas/canvas-prototype.tsx
+++ b/apps/web/src/app/[locale]/form-canvas/canvas-prototype.tsx
@@ -1,89 +1,135 @@
 "use client";
 
 import * as React from "react";
-import { Type, AlignLeft, Minus, MoveVertical, Sparkles, Trash2, Grid3x3 } from "lucide-react";
+import {
+  Type,
+  AlignLeft,
+  Minus,
+  MoveVertical,
+  Sparkles,
+  Trash2,
+  ChevronDown,
+  GripVertical,
+  Plus,
+} from "lucide-react";
 
 // ---------------------------------------------------------------------------
-// Direction C — 2D free-canvas form builder (evaluation prototype).
+// Direction C (hybrid) — "A's structure + C's drag freedom".
 //
-// Cards are positioned absolutely on a snap-to-grid canvas: drag the body to
-// move, drag the right edge to resize the width, click to select, Delete to
-// remove. No engine logic (validation/conditional/dataSource) is wired — this
-// only evaluates whether free 2D layout beats the linear section→row model.
+// A vertical stack of GROUP frames. Each group is a 12-column grid that fills
+// the container width. Cards live on the grid as {col, span, row}: drag the
+// body to move (snaps to a column + row, and across groups), drag the right
+// edge to resize the column span. Click to select, Delete to remove. No engine
+// logic — layout evaluation only.
 // ---------------------------------------------------------------------------
 
-const GRID = 24; // snap step (px)
-const snap = (v: number) => Math.round(v / GRID) * GRID;
-const clamp = (v: number, min: number, max: number) => Math.max(min, Math.min(max, v));
+const COLS = 12;
+const ROW_H = 84; // px per grid row
+const GAP = 8;
+const clamp = (v: number, lo: number, hi: number) => Math.max(lo, Math.min(hi, v));
 
 type Kind = "field" | "content" | "divider" | "spacer" | "ai-note";
 
-interface CanvasNode {
+interface Card {
   id: string;
+  groupId: string;
   kind: Kind;
   label: string;
   sub?: string;
-  x: number;
-  y: number;
-  w: number;
+  col: number; // 1-based start column
+  span: number; // column span (1..12)
+  row: number; // 1-based grid row
+}
+
+interface Group {
+  id: string;
+  title: string;
+  collapsed: boolean;
 }
 
 const KIND_META: Record<
   Kind,
-  { color: string; icon: React.ComponentType<{ className?: string }>; h: number; label: string }
+  { color: string; icon: React.ComponentType<{ className?: string }>; label: string; field?: boolean }
 > = {
-  field: { color: "#5b8cff", icon: Type, h: 72, label: "Field" },
-  content: { color: "#7c5cff", icon: AlignLeft, h: 48, label: "Content" },
-  "ai-note": { color: "#d9a441", icon: Sparkles, h: 48, label: "AI Note" },
-  divider: { color: "#6b7280", icon: Minus, h: 24, label: "Divider" },
-  spacer: { color: "#6b7280", icon: MoveVertical, h: 48, label: "Spacer" },
+  field: { color: "#5b8cff", icon: Type, label: "Field", field: true },
+  content: { color: "#7c5cff", icon: AlignLeft, label: "Content" },
+  "ai-note": { color: "#d9a441", icon: Sparkles, label: "AI Note" },
+  divider: { color: "#6b7280", icon: Minus, label: "Divider" },
+  spacer: { color: "#6b7280", icon: MoveVertical, label: "Spacer" },
 };
 
-const SEED: CanvasNode[] = [
-  { id: "n1", kind: "field", label: "Name", sub: "name · Input", x: 24, y: 24, w: 240 },
-  { id: "n2", kind: "field", label: "Email", sub: "email · Input", x: 288, y: 24, w: 240 },
-  { id: "n3", kind: "field", label: "Bio", sub: "bio · Textarea", x: 24, y: 120, w: 504 },
-  { id: "n4", kind: "divider", label: "Divider", x: 24, y: 216, w: 504 },
-  { id: "n5", kind: "field", label: "Role", sub: "role · Select", x: 24, y: 264, w: 240 },
-  { id: "n6", kind: "ai-note", label: "If unsure, default to 'user'", x: 288, y: 264, w: 240 },
+const SEED_GROUPS: Group[] = [
+  { id: "g_account", title: "Account", collapsed: false },
+  { id: "g_profile", title: "Profile", collapsed: false },
 ];
 
-let seq = SEED.length;
+const SEED_CARDS: Card[] = [
+  { id: "c1", groupId: "g_account", kind: "field", label: "Name", sub: "name · Input", col: 1, span: 6, row: 1 },
+  { id: "c2", groupId: "g_account", kind: "field", label: "Email", sub: "email · Input", col: 7, span: 6, row: 1 },
+  { id: "c3", groupId: "g_account", kind: "field", label: "Role", sub: "role · Select", col: 1, span: 6, row: 2 },
+  { id: "c4", groupId: "g_account", kind: "ai-note", label: "If unsure, default to 'user'", col: 7, span: 6, row: 2 },
+  { id: "c5", groupId: "g_account", kind: "field", label: "Bio", sub: "bio · Textarea", col: 1, span: 12, row: 3 },
+  { id: "c6", groupId: "g_profile", kind: "field", label: "Age", sub: "age · Number", col: 1, span: 4, row: 1 },
+  { id: "c7", groupId: "g_profile", kind: "field", label: "Country", sub: "country · Select", col: 5, span: 4, row: 1 },
+  { id: "c8", groupId: "g_profile", kind: "field", label: "Birthday", sub: "birthday · DatePicker", col: 9, span: 4, row: 1 },
+  { id: "c9", groupId: "g_profile", kind: "field", label: "Subscribe", sub: "newsletter · Switch", col: 1, span: 6, row: 2 },
+];
+
+let seq = 100;
+let gseq = 10;
 
 export function CanvasPrototype() {
-  const [nodes, setNodes] = React.useState<CanvasNode[]>(SEED);
+  const [groups, setGroups] = React.useState<Group[]>(SEED_GROUPS);
+  const [cards, setCards] = React.useState<Card[]>(SEED_CARDS);
   const [selected, setSelected] = React.useState<string | null>(null);
-  const [showGrid, setShowGrid] = React.useState(true);
-  const canvasRef = React.useRef<HTMLDivElement | null>(null);
-  // Live drag state kept in a ref so window listeners read fresh values.
+  const bodyRefs = React.useRef<Record<string, HTMLDivElement | null>>({});
   const drag = React.useRef<
-    | { id: string; mode: "move" | "resize"; px: number; py: number; nx: number; ny: number; nw: number }
+    | { id: string; mode: "move" | "resize"; col: number; span: number; row: number; groupId: string }
     | null
   >(null);
 
-  const patch = (id: string, p: Partial<CanvasNode>) =>
-    setNodes((ns) => ns.map((n) => (n.id === id ? { ...n, ...p } : n)));
+  const patch = (id: string, p: Partial<Card>) =>
+    setCards((cs) => cs.map((c) => (c.id === id ? { ...c, ...p } : c)));
 
-  function beginDrag(e: React.PointerEvent, node: CanvasNode, mode: "move" | "resize") {
+  // Map a pointer position to a {groupId, col, row} grid cell.
+  function cellAt(clientX: number, clientY: number, fallbackGroup: string) {
+    let groupId = fallbackGroup;
+    let rect: DOMRect | null = bodyRefs.current[fallbackGroup]?.getBoundingClientRect() ?? null;
+    for (const [gid, el] of Object.entries(bodyRefs.current)) {
+      if (!el) continue;
+      const r = el.getBoundingClientRect();
+      if (clientX >= r.left && clientX <= r.right && clientY >= r.top && clientY <= r.bottom) {
+        groupId = gid;
+        rect = r;
+        break;
+      }
+    }
+    if (!rect) return { groupId, col: 1, row: 1, colW: 0, rect: null as DOMRect | null };
+    const colW = (rect.width + GAP) / COLS;
+    const col = clamp(Math.round((clientX - rect.left) / colW) + 1, 1, COLS);
+    const row = clamp(Math.round((clientY - rect.top) / (ROW_H + GAP)) + 1, 1, 99);
+    return { groupId, col, row, colW, rect };
+  }
+
+  function beginDrag(e: React.PointerEvent, card: Card, mode: "move" | "resize") {
     e.preventDefault();
     e.stopPropagation();
-    setSelected(node.id);
-    drag.current = { id: node.id, mode, px: e.clientX, py: e.clientY, nx: node.x, ny: node.y, nw: node.w };
+    setSelected(card.id);
+    drag.current = { id: card.id, mode, col: card.col, span: card.span, row: card.row, groupId: card.groupId };
 
     const onMove = (ev: PointerEvent) => {
       const d = drag.current;
-      const canvas = canvasRef.current;
-      if (!d || !canvas) return;
-      const rect = canvas.getBoundingClientRect();
-      const dx = ev.clientX - d.px;
-      const dy = ev.clientY - d.py;
+      if (!d) return;
       if (d.mode === "move") {
-        const maxX = rect.width - d.nw;
-        const maxY = rect.height - KIND_META[node.kind].h;
-        patch(d.id, { x: clamp(snap(d.nx + dx), 0, Math.max(0, maxX)), y: clamp(snap(d.ny + dy), 0, Math.max(0, maxY)) });
+        const { groupId, col, row } = cellAt(ev.clientX, ev.clientY, d.groupId);
+        patch(d.id, { groupId, col: clamp(col, 1, COLS - d.span + 1), row });
       } else {
-        const maxW = rect.width - d.nx;
-        patch(d.id, { w: clamp(snap(d.nw + dx), GRID * 3, maxW) });
+        const body = bodyRefs.current[d.groupId];
+        if (!body) return;
+        const rect = body.getBoundingClientRect();
+        const colW = (rect.width + GAP) / COLS;
+        const rightCol = Math.round((ev.clientX - rect.left) / colW); // 0-based exclusive edge
+        patch(d.id, { span: clamp(rightCol - (d.col - 1), 1, COLS - d.col + 1) });
       }
     };
     const onUp = () => {
@@ -95,19 +141,27 @@ export function CanvasPrototype() {
     window.addEventListener("pointerup", onUp);
   }
 
-  function addNode(kind: Kind) {
+  function addCard(kind: Kind) {
+    const groupId = (selected && cards.find((c) => c.id === selected)?.groupId) || groups[0]?.id;
+    if (!groupId) return;
+    const maxRow = cards.filter((c) => c.groupId === groupId).reduce((m, c) => Math.max(m, c.row), 0);
     seq += 1;
-    const id = `n${seq}`;
-    setNodes((ns) => [
-      ...ns,
-      { id, kind, label: KIND_META[kind].label, sub: kind === "field" ? "field · Input" : undefined, x: 24, y: 24, w: 240 },
+    const id = `c${seq}`;
+    setCards((cs) => [
+      ...cs,
+      { id, groupId, kind, label: KIND_META[kind].label, sub: kind === "field" ? "field · Input" : undefined, col: 1, span: kind === "field" ? 6 : 12, row: maxRow + 1 },
     ]);
     setSelected(id);
   }
 
+  function addGroup() {
+    gseq += 1;
+    setGroups((gs) => [...gs, { id: `g${gseq}`, title: `Section ${gs.length + 1}`, collapsed: false }]);
+  }
+
   function removeSelected() {
     if (!selected) return;
-    setNodes((ns) => ns.filter((n) => n.id !== selected));
+    setCards((cs) => cs.filter((c) => c.id !== selected));
     setSelected(null);
   }
 
@@ -127,20 +181,18 @@ export function CanvasPrototype() {
 
   return (
     <div className="min-h-screen bg-background text-foreground">
-      {/* Header */}
       <header className="border-b border-border px-6 py-4">
         <div className="flex items-baseline gap-3">
           <h1 className="text-xl font-semibold">Form Canvas</h1>
           <span className="font-mono text-xs uppercase tracking-[0.18em] text-muted-foreground">
-            Direction C · 2D prototype
+            Direction C · structure + drag
           </span>
         </div>
         <p className="mt-1 text-sm text-muted-foreground">
-          Drag to move · drag the right edge to resize · click to select · Delete to remove. Snaps to a {GRID}px grid.
+          {COLS}-column groups · drag to move (across groups too) · drag the right edge to resize · Delete to remove.
         </p>
       </header>
 
-      {/* Toolbar */}
       <div className="flex flex-wrap items-center gap-2 border-b border-border px-6 py-3">
         {PALETTE.map((kind) => {
           const m = KIND_META[kind];
@@ -149,7 +201,7 @@ export function CanvasPrototype() {
             <button
               key={kind}
               type="button"
-              onClick={() => addNode(kind)}
+              onClick={() => addCard(kind)}
               className="inline-flex items-center gap-1.5 rounded-lg border border-input bg-card/40 px-3 py-1.5 font-mono text-xs text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
             >
               <Icon className="size-3.5" style={{ color: m.color }} />
@@ -157,20 +209,14 @@ export function CanvasPrototype() {
             </button>
           );
         })}
-
         <div className="ml-auto flex items-center gap-2">
           <button
             type="button"
-            onClick={() => setShowGrid((v) => !v)}
-            aria-pressed={showGrid}
-            className={`inline-flex items-center gap-1.5 rounded-lg border px-3 py-1.5 font-mono text-xs transition-colors ${
-              showGrid
-                ? "border-[#5b8cff]/40 bg-[#5b8cff]/10 text-foreground"
-                : "border-input bg-card/40 text-muted-foreground hover:text-foreground"
-            }`}
+            onClick={addGroup}
+            className="inline-flex items-center gap-1.5 rounded-lg border border-input bg-card/40 px-3 py-1.5 font-mono text-xs text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
           >
-            <Grid3x3 className="size-3.5" />
-            Grid
+            <Plus className="size-3.5" />
+            Group
           </button>
           <button
             type="button"
@@ -184,91 +230,137 @@ export function CanvasPrototype() {
         </div>
       </div>
 
-      {/* Canvas */}
-      <div className="p-6">
-        <div
-          ref={canvasRef}
-          onPointerDown={() => setSelected(null)}
-          className="relative min-h-[640px] w-full overflow-hidden rounded-xl border border-border bg-card/20"
-          style={
-            showGrid
-              ? {
-                  backgroundImage:
-                    "radial-gradient(circle, color-mix(in srgb, var(--muted-foreground) 22%, transparent) 1px, transparent 1px)",
-                  backgroundSize: `${GRID}px ${GRID}px`,
-                  backgroundPosition: "0 0",
-                }
-              : undefined
-          }
-        >
-          {nodes.map((node) => (
-            <CanvasCard
-              key={node.id}
-              node={node}
-              selected={selected === node.id}
-              onMoveStart={(e) => beginDrag(e, node, "move")}
-              onResizeStart={(e) => beginDrag(e, node, "resize")}
-            />
-          ))}
-        </div>
+      {/* Stacked group frames */}
+      <div className="flex flex-col gap-4 p-6" onPointerDown={() => setSelected(null)}>
+        {groups.map((group) => {
+          const groupCards = cards.filter((c) => c.groupId === group.id);
+          const maxRow = groupCards.reduce((m, c) => Math.max(m, c.row), 0);
+          const rows = Math.max(maxRow + 1, 2); // keep a spare row as a drop target
+          return (
+            <section key={group.id} className="overflow-hidden rounded-xl border border-border bg-card/20">
+              <header className="flex items-center gap-2.5 border-b border-border bg-muted/40 px-3 py-2.5">
+                <button
+                  type="button"
+                  aria-label={group.collapsed ? "expand" : "collapse"}
+                  onClick={() =>
+                    setGroups((gs) => gs.map((g) => (g.id === group.id ? { ...g, collapsed: !g.collapsed } : g)))
+                  }
+                  className="flex size-6 items-center justify-center rounded-md text-muted-foreground hover:bg-accent/60 hover:text-foreground"
+                >
+                  <ChevronDown className={`size-4 transition-transform ${group.collapsed ? "-rotate-90" : ""}`} />
+                </button>
+                <span className="text-[15px] font-semibold">{group.title}</span>
+                <span className="font-mono text-[11px] text-muted-foreground/50">{group.id}</span>
+                <span className="font-mono text-[10px] uppercase tracking-wider text-muted-foreground/45">
+                  {groupCards.length} item{groupCards.length === 1 ? "" : "s"}
+                </span>
+                <span className="ml-auto font-mono text-[10px] uppercase tracking-wide text-muted-foreground/55">
+                  {COLS} cols
+                </span>
+              </header>
+
+              {group.collapsed ? null : (
+                <div
+                  ref={(el) => {
+                    bodyRefs.current[group.id] = el;
+                  }}
+                  className="relative p-3"
+                  style={{
+                    display: "grid",
+                    gridTemplateColumns: `repeat(${COLS}, minmax(0, 1fr))`,
+                    gridAutoRows: `${ROW_H}px`,
+                    gap: GAP,
+                    minHeight: rows * (ROW_H + GAP),
+                    // faint column guides
+                    backgroundImage:
+                      "repeating-linear-gradient(to right, color-mix(in srgb, var(--muted-foreground) 8%, transparent) 0 1px, transparent 1px calc(100% / 12))",
+                    backgroundPosition: "12px 0",
+                    backgroundSize: "calc(100% - 24px) 100%",
+                    backgroundRepeat: "no-repeat",
+                  }}
+                >
+                  {groupCards.length === 0 ? (
+                    <div className="pointer-events-none col-span-12 row-start-1 flex items-center justify-center text-xs text-muted-foreground/50">
+                      Drop fields here
+                    </div>
+                  ) : null}
+                  {groupCards.map((card) => (
+                    <CanvasCard
+                      key={card.id}
+                      card={card}
+                      selected={selected === card.id}
+                      onMoveStart={(e) => beginDrag(e, card, "move")}
+                      onResizeStart={(e) => beginDrag(e, card, "resize")}
+                    />
+                  ))}
+                </div>
+              )}
+            </section>
+          );
+        })}
       </div>
     </div>
   );
 }
 
 // ---------------------------------------------------------------------------
-// CanvasCard — a single positioned, draggable, resizable field card.
+// CanvasCard — a grid-placed, draggable, resizable card.
 // ---------------------------------------------------------------------------
 
 function CanvasCard({
-  node,
+  card,
   selected,
   onMoveStart,
   onResizeStart,
 }: {
-  node: CanvasNode;
+  card: Card;
   selected: boolean;
   onMoveStart: (e: React.PointerEvent) => void;
   onResizeStart: (e: React.PointerEvent) => void;
 }) {
-  const m = KIND_META[node.kind];
+  const m = KIND_META[card.kind];
   const Icon = m.icon;
 
   return (
     <div
       onPointerDown={onMoveStart}
-      className={`group absolute cursor-grab touch-none select-none rounded-lg border bg-card shadow-sm transition-shadow active:cursor-grabbing ${
+      className={`group relative cursor-grab touch-none select-none rounded-lg border bg-card shadow-sm transition-shadow active:cursor-grabbing ${
         selected ? "border-transparent ring-2 ring-[#5b8cff]" : "border-border hover:shadow-md"
       }`}
-      style={{ left: node.x, top: node.y, width: node.w, height: m.h, boxShadow: `inset 3px 0 0 ${m.color}` }}
+      style={{
+        gridColumn: `${card.col} / span ${card.span}`,
+        gridRow: card.row,
+        boxShadow: `inset 3px 0 0 ${m.color}`,
+      }}
     >
-      {node.kind === "divider" ? (
+      {card.kind === "divider" ? (
         <div className="flex h-full items-center gap-2 px-3">
           <Icon className="size-3.5 shrink-0" style={{ color: m.color }} />
           <hr className="w-full border-border" />
         </div>
       ) : (
-        <div className="flex h-full flex-col justify-center gap-1 px-3">
+        <div className="flex h-full flex-col justify-center gap-1.5 px-3">
           <div className="flex items-center gap-2">
+            <GripVertical className="size-3.5 shrink-0 text-muted-foreground/30 group-hover:text-muted-foreground/70" />
             <span
               className="flex size-[18px] shrink-0 items-center justify-center rounded-[5px]"
               style={{ backgroundColor: `${m.color}1f`, color: m.color }}
             >
               <Icon className="size-3" />
             </span>
-            <span className="truncate text-sm font-medium">{node.label}</span>
-            {node.sub ? <span className="truncate font-mono text-[11px] text-muted-foreground/70">{node.sub}</span> : null}
+            <span className="truncate text-sm font-medium">{card.label}</span>
+            {card.sub ? (
+              <span className="truncate font-mono text-[11px] text-muted-foreground/70">{card.sub}</span>
+            ) : null}
           </div>
-          {node.kind === "field" ? (
-            <div className="h-7 rounded-md border border-input bg-background/60" />
-          ) : null}
+          {m.field ? <div className="h-7 rounded-md border border-input bg-background/60" /> : null}
         </div>
       )}
 
       {/* Resize handle (right edge) */}
       <div
         onPointerDown={onResizeStart}
-        className="absolute right-0 top-0 flex h-full w-2.5 cursor-col-resize items-center justify-center"
+        className="absolute right-0 top-0 flex h-full w-3 cursor-col-resize items-center justify-center"
       >
         <div
           className={`h-8 w-1 rounded-full transition-colors ${

--- a/apps/web/src/app/[locale]/form-canvas/canvas-prototype.tsx
+++ b/apps/web/src/app/[locale]/form-canvas/canvas-prototype.tsx
@@ -39,6 +39,7 @@ interface Card {
   key?: string;
   component?: Component;
   required?: boolean;
+  placeholder?: string;
   col: number;
   span: number;
   row: number;
@@ -69,8 +70,8 @@ const SEED_GROUPS: Group[] = [
 ];
 
 const SEED_CARDS: Card[] = [
-  { id: "c1", groupId: "g_account", kind: "field", label: "Name", key: "name", component: "Input", required: true, col: 1, span: 6, row: 1 },
-  { id: "c2", groupId: "g_account", kind: "field", label: "Email", key: "email", component: "Input", required: true, col: 7, span: 6, row: 1 },
+  { id: "c1", groupId: "g_account", kind: "field", label: "Name", key: "name", component: "Input", required: true, placeholder: "e.g. Jane Doe", col: 1, span: 6, row: 1 },
+  { id: "c2", groupId: "g_account", kind: "field", label: "Email", key: "email", component: "Input", required: true, placeholder: "you@example.com", col: 7, span: 6, row: 1 },
   { id: "c3", groupId: "g_account", kind: "field", label: "Role", key: "role", component: "Select", col: 1, span: 6, row: 2 },
   { id: "c4", groupId: "g_account", kind: "ai-note", label: "If unsure, default to 'user'", col: 7, span: 6, row: 2 },
   { id: "c5", groupId: "g_account", kind: "field", label: "Bio", key: "bio", component: "Textarea", col: 1, span: 12, row: 3 },
@@ -98,7 +99,9 @@ function serialize(groups: Group[], cards: Card[]) {
           id: c.id,
           kind: c.kind,
           label: c.label,
-          ...(c.kind === "field" ? { key: c.key, component: c.component, required: c.required || undefined } : {}),
+          ...(c.kind === "field"
+            ? { key: c.key, component: c.component, required: c.required || undefined, placeholder: c.placeholder || undefined }
+            : {}),
           col: c.col,
           span: c.span,
           row: c.row,
@@ -126,6 +129,7 @@ function parse(obj: unknown): { groups: Group[]; cards: Card[] } {
         key: it.key as string | undefined,
         component: it.component as Component | undefined,
         required: Boolean(it.required),
+        placeholder: it.placeholder as string | undefined,
         col: clamp(Number(it.col ?? 1), 1, COLS),
         span: clamp(Number(it.span ?? 6), 1, COLS),
         row: Number(it.row ?? i + 1),
@@ -155,6 +159,7 @@ export function CanvasPrototype() {
   const [tab, setTab] = React.useState<"canvas" | "preview" | "json">("canvas");
   const [jsonError, setJsonError] = React.useState<string | null>(null);
   const [copied, setCopied] = React.useState(false);
+  const [dropGroup, setDropGroup] = React.useState<string | null>(null);
   const bodyRefs = React.useRef<Record<string, HTMLDivElement | null>>({});
   const drag = React.useRef<{ id: string; mode: "move" | "resize"; col: number; span: number } | null>(null);
   const isWidePreview = useMediaQuery("(min-width: 768px)");
@@ -206,6 +211,7 @@ export function CanvasPrototype() {
       if (!d) return;
       if (d.mode === "move") {
         const { groupId, col, row } = cellAt(ev.clientX, ev.clientY, card.groupId);
+        setDropGroup(groupId);
         patch(d.id, { groupId, col: clamp(col, 1, COLS - card.span + 1), row });
       } else {
         const body = bodyRefs.current[card.groupId];
@@ -218,6 +224,7 @@ export function CanvasPrototype() {
     };
     const onUp = () => {
       drag.current = null;
+      setDropGroup(null);
       window.removeEventListener("pointermove", onMove);
       window.removeEventListener("pointerup", onUp);
     };
@@ -355,6 +362,7 @@ export function CanvasPrototype() {
                     group={group}
                     cards={cards.filter((c) => c.groupId === group.id)}
                     selected={selected}
+                    dropOver={dropGroup === group.id}
                     bodyRef={(el) => {
                       bodyRefs.current[group.id] = el;
                     }}
@@ -423,6 +431,7 @@ function GroupFrame({
   group,
   cards,
   selected,
+  dropOver,
   bodyRef,
   onToggle,
   onMoveStart,
@@ -431,6 +440,7 @@ function GroupFrame({
   group: Group;
   cards: Card[];
   selected: string | null;
+  dropOver: boolean;
   bodyRef: (el: HTMLDivElement | null) => void;
   onToggle: () => void;
   onMoveStart: (e: React.PointerEvent, card: Card, mode: "move") => void;
@@ -439,7 +449,11 @@ function GroupFrame({
   const maxRow = cards.reduce((m, c) => Math.max(m, c.row), 0);
   const rows = Math.max(maxRow + 1, 2);
   return (
-    <section className="overflow-hidden rounded-xl border border-border bg-card/20">
+    <section
+      className={`overflow-hidden rounded-xl border bg-card/20 transition-colors ${
+        dropOver ? "border-[#5b8cff]/70 ring-1 ring-[#5b8cff]/40" : "border-border"
+      }`}
+    >
       <header className="flex items-center gap-2.5 border-b border-border bg-muted/40 px-3 py-2.5">
         <button
           type="button"
@@ -615,6 +629,15 @@ function Inspector({
               ))}
             </select>
           </label>
+          <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+            Placeholder
+            <input
+              className={input}
+              value={card.placeholder ?? ""}
+              placeholder="(shown in the preview control)"
+              onChange={(e) => onChange({ placeholder: e.target.value })}
+            />
+          </label>
           <label className="flex items-center gap-2 text-xs text-muted-foreground">
             <input type="checkbox" checked={Boolean(card.required)} onChange={(e) => onChange({ required: e.target.checked })} />
             Required
@@ -700,20 +723,23 @@ function PreviewField({ card }: { card: Card }) {
       {card.required ? <span className="ml-1 text-destructive">*</span> : null}
     </label>
   );
+  const ph = card.placeholder;
   switch (card.component) {
     case "Textarea":
       return (
         <div>
           {label}
-          <textarea className={`${ctrl} h-20 py-2`} />
+          <textarea className={`${ctrl} h-20 py-2`} placeholder={ph} />
         </div>
       );
     case "Select":
       return (
         <div>
           {label}
-          <select className={`${ctrl} h-9`}>
-            <option>—</option>
+          <select className={`${ctrl} h-9`} defaultValue="">
+            <option value="" disabled>
+              {ph || "—"}
+            </option>
           </select>
         </div>
       );
@@ -729,7 +755,7 @@ function PreviewField({ card }: { card: Card }) {
         <div>
           {label}
           <button type="button" className={`${ctrl} h-9 text-left text-muted-foreground`}>
-            Pick a date
+            {ph || "Pick a date"}
           </button>
         </div>
       );
@@ -737,7 +763,7 @@ function PreviewField({ card }: { card: Card }) {
       return (
         <div>
           {label}
-          <input type={card.component === "Number" ? "number" : "text"} className={`${ctrl} h-9`} />
+          <input type={card.component === "Number" ? "number" : "text"} className={`${ctrl} h-9`} placeholder={ph} />
         </div>
       );
   }

--- a/apps/web/src/app/[locale]/form-canvas/canvas-prototype.tsx
+++ b/apps/web/src/app/[locale]/form-canvas/canvas-prototype.tsx
@@ -1,0 +1,281 @@
+"use client";
+
+import * as React from "react";
+import { Type, AlignLeft, Minus, MoveVertical, Sparkles, Trash2, Grid3x3 } from "lucide-react";
+
+// ---------------------------------------------------------------------------
+// Direction C — 2D free-canvas form builder (evaluation prototype).
+//
+// Cards are positioned absolutely on a snap-to-grid canvas: drag the body to
+// move, drag the right edge to resize the width, click to select, Delete to
+// remove. No engine logic (validation/conditional/dataSource) is wired — this
+// only evaluates whether free 2D layout beats the linear section→row model.
+// ---------------------------------------------------------------------------
+
+const GRID = 24; // snap step (px)
+const snap = (v: number) => Math.round(v / GRID) * GRID;
+const clamp = (v: number, min: number, max: number) => Math.max(min, Math.min(max, v));
+
+type Kind = "field" | "content" | "divider" | "spacer" | "ai-note";
+
+interface CanvasNode {
+  id: string;
+  kind: Kind;
+  label: string;
+  sub?: string;
+  x: number;
+  y: number;
+  w: number;
+}
+
+const KIND_META: Record<
+  Kind,
+  { color: string; icon: React.ComponentType<{ className?: string }>; h: number; label: string }
+> = {
+  field: { color: "#5b8cff", icon: Type, h: 72, label: "Field" },
+  content: { color: "#7c5cff", icon: AlignLeft, h: 48, label: "Content" },
+  "ai-note": { color: "#d9a441", icon: Sparkles, h: 48, label: "AI Note" },
+  divider: { color: "#6b7280", icon: Minus, h: 24, label: "Divider" },
+  spacer: { color: "#6b7280", icon: MoveVertical, h: 48, label: "Spacer" },
+};
+
+const SEED: CanvasNode[] = [
+  { id: "n1", kind: "field", label: "Name", sub: "name · Input", x: 24, y: 24, w: 240 },
+  { id: "n2", kind: "field", label: "Email", sub: "email · Input", x: 288, y: 24, w: 240 },
+  { id: "n3", kind: "field", label: "Bio", sub: "bio · Textarea", x: 24, y: 120, w: 504 },
+  { id: "n4", kind: "divider", label: "Divider", x: 24, y: 216, w: 504 },
+  { id: "n5", kind: "field", label: "Role", sub: "role · Select", x: 24, y: 264, w: 240 },
+  { id: "n6", kind: "ai-note", label: "If unsure, default to 'user'", x: 288, y: 264, w: 240 },
+];
+
+let seq = SEED.length;
+
+export function CanvasPrototype() {
+  const [nodes, setNodes] = React.useState<CanvasNode[]>(SEED);
+  const [selected, setSelected] = React.useState<string | null>(null);
+  const [showGrid, setShowGrid] = React.useState(true);
+  const canvasRef = React.useRef<HTMLDivElement | null>(null);
+  // Live drag state kept in a ref so window listeners read fresh values.
+  const drag = React.useRef<
+    | { id: string; mode: "move" | "resize"; px: number; py: number; nx: number; ny: number; nw: number }
+    | null
+  >(null);
+
+  const patch = (id: string, p: Partial<CanvasNode>) =>
+    setNodes((ns) => ns.map((n) => (n.id === id ? { ...n, ...p } : n)));
+
+  function beginDrag(e: React.PointerEvent, node: CanvasNode, mode: "move" | "resize") {
+    e.preventDefault();
+    e.stopPropagation();
+    setSelected(node.id);
+    drag.current = { id: node.id, mode, px: e.clientX, py: e.clientY, nx: node.x, ny: node.y, nw: node.w };
+
+    const onMove = (ev: PointerEvent) => {
+      const d = drag.current;
+      const canvas = canvasRef.current;
+      if (!d || !canvas) return;
+      const rect = canvas.getBoundingClientRect();
+      const dx = ev.clientX - d.px;
+      const dy = ev.clientY - d.py;
+      if (d.mode === "move") {
+        const maxX = rect.width - d.nw;
+        const maxY = rect.height - KIND_META[node.kind].h;
+        patch(d.id, { x: clamp(snap(d.nx + dx), 0, Math.max(0, maxX)), y: clamp(snap(d.ny + dy), 0, Math.max(0, maxY)) });
+      } else {
+        const maxW = rect.width - d.nx;
+        patch(d.id, { w: clamp(snap(d.nw + dx), GRID * 3, maxW) });
+      }
+    };
+    const onUp = () => {
+      drag.current = null;
+      window.removeEventListener("pointermove", onMove);
+      window.removeEventListener("pointerup", onUp);
+    };
+    window.addEventListener("pointermove", onMove);
+    window.addEventListener("pointerup", onUp);
+  }
+
+  function addNode(kind: Kind) {
+    seq += 1;
+    const id = `n${seq}`;
+    setNodes((ns) => [
+      ...ns,
+      { id, kind, label: KIND_META[kind].label, sub: kind === "field" ? "field · Input" : undefined, x: 24, y: 24, w: 240 },
+    ]);
+    setSelected(id);
+  }
+
+  function removeSelected() {
+    if (!selected) return;
+    setNodes((ns) => ns.filter((n) => n.id !== selected));
+    setSelected(null);
+  }
+
+  React.useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.key === "Delete" || e.key === "Backspace") && selected) {
+        e.preventDefault();
+        removeSelected();
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selected]);
+
+  const PALETTE: Kind[] = ["field", "content", "divider", "spacer", "ai-note"];
+
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      {/* Header */}
+      <header className="border-b border-border px-6 py-4">
+        <div className="flex items-baseline gap-3">
+          <h1 className="text-xl font-semibold">Form Canvas</h1>
+          <span className="font-mono text-xs uppercase tracking-[0.18em] text-muted-foreground">
+            Direction C · 2D prototype
+          </span>
+        </div>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Drag to move · drag the right edge to resize · click to select · Delete to remove. Snaps to a {GRID}px grid.
+        </p>
+      </header>
+
+      {/* Toolbar */}
+      <div className="flex flex-wrap items-center gap-2 border-b border-border px-6 py-3">
+        {PALETTE.map((kind) => {
+          const m = KIND_META[kind];
+          const Icon = m.icon;
+          return (
+            <button
+              key={kind}
+              type="button"
+              onClick={() => addNode(kind)}
+              className="inline-flex items-center gap-1.5 rounded-lg border border-input bg-card/40 px-3 py-1.5 font-mono text-xs text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
+            >
+              <Icon className="size-3.5" style={{ color: m.color }} />
+              {m.label}
+            </button>
+          );
+        })}
+
+        <div className="ml-auto flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => setShowGrid((v) => !v)}
+            aria-pressed={showGrid}
+            className={`inline-flex items-center gap-1.5 rounded-lg border px-3 py-1.5 font-mono text-xs transition-colors ${
+              showGrid
+                ? "border-[#5b8cff]/40 bg-[#5b8cff]/10 text-foreground"
+                : "border-input bg-card/40 text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            <Grid3x3 className="size-3.5" />
+            Grid
+          </button>
+          <button
+            type="button"
+            onClick={removeSelected}
+            disabled={!selected}
+            className="inline-flex items-center gap-1.5 rounded-lg border border-input bg-card/40 px-3 py-1.5 font-mono text-xs text-muted-foreground transition-colors enabled:hover:border-destructive/50 enabled:hover:text-destructive disabled:opacity-40"
+          >
+            <Trash2 className="size-3.5" />
+            Delete
+          </button>
+        </div>
+      </div>
+
+      {/* Canvas */}
+      <div className="p-6">
+        <div
+          ref={canvasRef}
+          onPointerDown={() => setSelected(null)}
+          className="relative min-h-[640px] w-full overflow-hidden rounded-xl border border-border bg-card/20"
+          style={
+            showGrid
+              ? {
+                  backgroundImage:
+                    "radial-gradient(circle, color-mix(in srgb, var(--muted-foreground) 22%, transparent) 1px, transparent 1px)",
+                  backgroundSize: `${GRID}px ${GRID}px`,
+                  backgroundPosition: "0 0",
+                }
+              : undefined
+          }
+        >
+          {nodes.map((node) => (
+            <CanvasCard
+              key={node.id}
+              node={node}
+              selected={selected === node.id}
+              onMoveStart={(e) => beginDrag(e, node, "move")}
+              onResizeStart={(e) => beginDrag(e, node, "resize")}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// CanvasCard — a single positioned, draggable, resizable field card.
+// ---------------------------------------------------------------------------
+
+function CanvasCard({
+  node,
+  selected,
+  onMoveStart,
+  onResizeStart,
+}: {
+  node: CanvasNode;
+  selected: boolean;
+  onMoveStart: (e: React.PointerEvent) => void;
+  onResizeStart: (e: React.PointerEvent) => void;
+}) {
+  const m = KIND_META[node.kind];
+  const Icon = m.icon;
+
+  return (
+    <div
+      onPointerDown={onMoveStart}
+      className={`group absolute cursor-grab touch-none select-none rounded-lg border bg-card shadow-sm transition-shadow active:cursor-grabbing ${
+        selected ? "border-transparent ring-2 ring-[#5b8cff]" : "border-border hover:shadow-md"
+      }`}
+      style={{ left: node.x, top: node.y, width: node.w, height: m.h, boxShadow: `inset 3px 0 0 ${m.color}` }}
+    >
+      {node.kind === "divider" ? (
+        <div className="flex h-full items-center gap-2 px-3">
+          <Icon className="size-3.5 shrink-0" style={{ color: m.color }} />
+          <hr className="w-full border-border" />
+        </div>
+      ) : (
+        <div className="flex h-full flex-col justify-center gap-1 px-3">
+          <div className="flex items-center gap-2">
+            <span
+              className="flex size-[18px] shrink-0 items-center justify-center rounded-[5px]"
+              style={{ backgroundColor: `${m.color}1f`, color: m.color }}
+            >
+              <Icon className="size-3" />
+            </span>
+            <span className="truncate text-sm font-medium">{node.label}</span>
+            {node.sub ? <span className="truncate font-mono text-[11px] text-muted-foreground/70">{node.sub}</span> : null}
+          </div>
+          {node.kind === "field" ? (
+            <div className="h-7 rounded-md border border-input bg-background/60" />
+          ) : null}
+        </div>
+      )}
+
+      {/* Resize handle (right edge) */}
+      <div
+        onPointerDown={onResizeStart}
+        className="absolute right-0 top-0 flex h-full w-2.5 cursor-col-resize items-center justify-center"
+      >
+        <div
+          className={`h-8 w-1 rounded-full transition-colors ${
+            selected ? "bg-[#5b8cff]" : "bg-transparent group-hover:bg-border"
+          }`}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/[locale]/form-canvas/page.tsx
+++ b/apps/web/src/app/[locale]/form-canvas/page.tsx
@@ -1,0 +1,16 @@
+import { setRequestLocale } from "next-intl/server";
+
+import { CanvasPrototype } from "./canvas-prototype";
+
+// Standalone evaluation route (no AppShell/sidebar) for the Direction C
+// "2D free canvas" form-builder concept. Not registered as a tool — it's a
+// throwaway prototype for picking a layout direction.
+export default async function FormCanvasPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+  return <CanvasPrototype />;
+}


### PR DESCRIPTION
**Evaluation prototype** for the form-builder layout direction. Standalone route `apps/web/src/app/[locale]/form-canvas/` (no AppShell) — not registered as a tool. No engine logic wired; this is for picking a layout direction vs Direction A (#206).

## What it is — "A structure + C drag freedom"
- A vertical stack of **group frames**, each a **12-column grid that fills the container width**. Cards are placed as `{col, span, row}`.
- **Drag** the body to move (snaps to a cell, **across groups**); **drag the right edge** to resize the column span; **drop-target group is highlighted** while dragging.
- Click to select, **Delete** to remove. Groups have a title, item count and collapse.

## Builder shell
- **Canvas | Preview | JSON** tabs.
- **Inspector** (right): label / key / component / required / **placeholder** / width (cols) / group / delete for the selected card — edits flow live into the canvas + preview.
- **Preview**: renders the model as a real form; **reflows to one column on mobile**.
- **JSON**: bidirectional — editing rebuilds the canvas; Copy button.
- **RWD**: header/toolbar wrap, inspector stacks below the canvas on narrow viewports. (The editing canvas stays 12-col — drag-building is desktop-first.)

## Verification
- `web` `check-types` green. Screenshot-verified (dark + light, wide + narrow) across all three tabs and the inspector.

## History
`a360efa` free-canvas → `a80be29` hybrid 12-col groups → `4cd2197` builder shell → `45ad22a` placeholder + drop highlight.