### PR TITLE
feat: 12-column grid layout for FormConfig — form-canvas previews real ConfigForm

### DIFF
--- a/.superpowers/sdd/task-3-report.md
+++ b/.superpowers/sdd/task-3-report.md
@@ -1,38 +1,39 @@
-# Task 3 Report: seeded/framed first-run and empty state
+# Task 3 Report — Canvas `cardsToFormConfig` / `formConfigToCards` mappers
 
-## Changes
+## Status: DONE
 
-### 1. Empty state — `packages/form-builder-ui/src/config-form-builder.tsx`
-- When `builder.config.fields.length === 0`, the field-list area renders a `<p data-testid="empty-state-hint">` with "No fields yet — add one from the palette above" instead of an empty DnD list.
-- The preview panel (`data-testid="config-form-preview"`) also shows a muted placeholder ("Preview will appear here once you add fields") and suppresses the `<ConfigForm>` (and therefore its Submit button) when empty.
+## Commits
+- `6506b59` feat(web): canvas <-> FormConfig mappers (model.ts)
 
-### 2. Framing/polish — `packages/form-builder-ui/src/config-form-builder.tsx`
-- Field-list area wrapped in `rounded-lg border bg-card p-4`.
-- Preview panel border upgraded from `rounded-md border-input` to `rounded-lg border bg-card p-4`.
-- No new deps added; all existing `data-testid`/`aria-label`/`role` hooks preserved.
+## Steps completed
 
-### 3. Seed sample — `apps/web/src/tools/form-builder/ui.tsx`
-- `SAMPLE_CONFIG` constant: Name (Input, string, required), Email (Input, string), Role (Select, string, options Admin/User).
-- Passed as `initialConfig` to `<ConfigFormBuilder>`. `locales={["en","zh-TW"]}` retained.
+### Type comparison (`ui.tsx` vs brief)
+The local `Kind`, `Component`, `Card`, `Group` declarations in `ui.tsx` matched the brief's `model.ts` exactly — field names, types, optional markers all identical. No NEEDS_CONTEXT stop required.
 
-## TDD evidence
-- 3 new tests in `config-form-builder.spec.tsx`:
-  - `shows the empty-state hint when there are no fields` — asserts `data-testid="empty-state-hint"` and `/no fields yet/i`.
-  - `does not show the empty-state hint when fields are present` — asserts hint is absent.
-  - `preview panel has a placeholder and no Submit when fields are empty` — asserts preview text and no Submit button.
+### Step 1 — `model.ts` created
+`apps/web/src/tools/form-canvas/model.ts` created verbatim per the brief:
+- Re-exports `Kind`, `Component`, `Card`, `Group`
+- `DATATYPE` mapping: `Input/Textarea/Select → string`, `Number → numeric`, `Switch → boolean`, `DatePicker → date`
+- `cardsToFormConfig` — maps groups → `FormSection[]` with `rows` + `section.layout.placements` (col/span/row preserved 1:1)
+- `formConfigToCards` — inverse, reads placements from `layout.placements` by itemId
+- `jsonToCards` — parses raw JSON text via `parseFormConfig` + `formConfigToCards`
 
-## Test results
-- `pnpm -F @rfjs/form-builder-ui vitest:run`: **39 passed, 0 failed** (5 test files)
-- `pnpm -F web vitest:run`: **73 passed, 0 failed** (23 test files) — registry/nav/i18n tests unaffected; the MISSING_MESSAGE IntlError on `Operators` is a pre-existing noise from `_filter-builder` tests, not caused by this task.
+Imports verified against built `@rfjs/form-builder` dist: `FormConfig`, `FormSection`, `FormItem`, `ScalarType`, `parseFormConfig` all exported. `FieldComponent` is a superset of canvas `Component`, so no cast issues.
 
-## Check-types
-- `pnpm -F @rfjs/form-builder-ui check-types`: clean
-- `pnpm -F web check-types`: clean
+### Step 2 — `model.spec.ts` created
+`apps/web/src/tools/form-canvas/model.spec.ts` created verbatim per the brief.
 
-## Files modified
-- `packages/form-builder-ui/src/config-form-builder.tsx` — empty state + framing
-- `packages/form-builder-ui/src/config-form-builder.spec.tsx` — 3 new TDD tests
-- `apps/web/src/tools/form-builder/ui.tsx` — seed config
+### Step 3 — Tests pass
+`pnpm -F web vitest:run src/tools/form-canvas/model.spec.ts` → 2/2 passed.
+
+### Step 4 — `ui.tsx` type-move
+Deleted local `type Kind`, `type Component`, `interface Card`, `interface Group`. Added `import type { Card, Group, Kind, Component } from "./model";`. `COMPONENTS` array and all behavior (`serialize`/`parse`/`PreviewForm`) left unchanged.
+
+### Step 5 — Typecheck
+`pnpm -F web check-types` → no errors.
+
+### Step 6 — Commit
+Single commit `6506b59` with 3 files (model.ts + model.spec.ts + ui.tsx).
 
 ## Concerns
-None. The web's pre-existing IntlError for `Operators` is not introduced by this task.
+None. Types matched exactly, imports resolved cleanly, both tests pass, typecheck clean.

--- a/apps/web/src/tools/form-canvas/model.spec.ts
+++ b/apps/web/src/tools/form-canvas/model.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { cardsToFormConfig, formConfigToCards, type Card, type Group } from "./model";
+import type { FormConfig } from "@rfjs/form-builder";
 
 const groups: Group[] = [{ id: "g1", title: "Account", collapsed: false }];
 const cards: Card[] = [
@@ -24,5 +25,60 @@ describe("canvas <-> FormConfig", () => {
     const back = formConfigToCards(cardsToFormConfig(groups, cards));
     expect(back.cards).toHaveLength(2);
     expect(back.cards[1]).toMatchObject({ id: "c2", col: 8, span: 5, row: 1, component: "Number" });
+  });
+});
+
+describe("formConfigToCards — import guards", () => {
+  it("normalizes an unsupported component (Checkbox) to Input and round-trips with a defined dataType", () => {
+    const config: FormConfig = {
+      version: 1,
+      sections: [
+        {
+          id: "s1",
+          title: "Section",
+          rows: [
+            {
+              id: "r1",
+              items: [
+                // "Checkbox" is valid in form-builder but not in the canvas Component union
+                { id: "f1", kind: "field", key: "agree", label: "Agree", component: "Checkbox" as never, dataType: "boolean" },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    const { cards } = formConfigToCards(config);
+    expect(cards[0]?.component).toBe("Input"); // normalized
+    const cfg = cardsToFormConfig([{ id: "s1", title: "Section", collapsed: false }], cards);
+    const item = cfg.sections![0]!.rows[0]!.items[0]!;
+    expect("dataType" in item && (item as { dataType?: unknown }).dataType).toBeDefined();
+    expect((item as { dataType?: unknown }).dataType).toBe("string");
+  });
+
+  it("assigns distinct rows (index-based) when no layout.placements present", () => {
+    const config: FormConfig = {
+      version: 1,
+      sections: [
+        {
+          id: "s1",
+          title: "Section",
+          rows: [
+            {
+              id: "r1",
+              items: [
+                { id: "f1", kind: "field", key: "a", label: "A", component: "Input", dataType: "string" },
+                { id: "f2", kind: "field", key: "b", label: "B", component: "Input", dataType: "string" },
+              ],
+            },
+          ],
+          // no layout — simulates a plain flow config pasted in
+        },
+      ],
+    };
+    const { cards } = formConfigToCards(config);
+    expect(cards[0]?.row).toBe(1);
+    expect(cards[1]?.row).toBe(2);
+    expect(cards[0]?.row).not.toBe(cards[1]?.row);
   });
 });

--- a/apps/web/src/tools/form-canvas/model.spec.ts
+++ b/apps/web/src/tools/form-canvas/model.spec.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { cardsToFormConfig, formConfigToCards, type Card, type Group } from "./model";
+
+const groups: Group[] = [{ id: "g1", title: "Account", collapsed: false }];
+const cards: Card[] = [
+  { id: "c1", groupId: "g1", kind: "field", label: "Name", key: "name", component: "Input", required: true, col: 1, span: 7, row: 1 },
+  { id: "c2", groupId: "g1", kind: "field", label: "Age", key: "age", component: "Number", col: 8, span: 5, row: 1 },
+];
+
+describe("canvas <-> FormConfig", () => {
+  it("emits a FormConfig whose section.layout keeps exact col/span/row", () => {
+    const cfg = cardsToFormConfig(groups, cards);
+    expect(cfg.sections![0]!.layout).toEqual({
+      columns: 12,
+      placements: [
+        { itemId: "c1", colStart: 1, colSpan: 7, row: 1 },
+        { itemId: "c2", colStart: 8, colSpan: 5, row: 1 },
+      ],
+    });
+    expect(cfg.sections![0]!.rows[0]!.items[1]).toMatchObject({ key: "age", component: "Number", dataType: "numeric" });
+  });
+
+  it("round-trips canvas -> FormConfig -> canvas without losing placement", () => {
+    const back = formConfigToCards(cardsToFormConfig(groups, cards));
+    expect(back.cards).toHaveLength(2);
+    expect(back.cards[1]).toMatchObject({ id: "c2", col: 8, span: 5, row: 1, component: "Number" });
+  });
+});

--- a/apps/web/src/tools/form-canvas/model.ts
+++ b/apps/web/src/tools/form-canvas/model.ts
@@ -34,6 +34,9 @@ const DATATYPE: Record<Component, ScalarType> = {
   DatePicker: "date",
 };
 
+// Canvas-supported components — anything outside this set is normalized to "Input" on import.
+const CANVAS_COMPONENT_SET = new Set<string>(Object.keys(DATATYPE));
+
 function cardToItem(c: Card): FormItem {
   switch (c.kind) {
     case "field":
@@ -43,7 +46,7 @@ function cardToItem(c: Card): FormItem {
         key: c.key ?? c.id,
         label: c.label,
         component: c.component ?? "Input",
-        dataType: DATATYPE[c.component ?? "Input"],
+        dataType: DATATYPE[c.component ?? "Input"] ?? "string",
         ...(c.required ? { required: true } : {}),
         ...(c.placeholder ? { placeholder: c.placeholder } : {}),
       };
@@ -88,11 +91,13 @@ export function formConfigToCards(config: FormConfig): { groups: Group[]; cards:
   for (const section of config.sections ?? []) {
     groups.push({ id: section.id, title: labelToString(section.title) || "Section", collapsed: false });
     const byId = new Map((section.layout?.placements ?? []).map((p) => [p.itemId, p]));
-    for (const item of section.rows.flatMap((r) => r.items)) {
+    for (const [i, item] of section.rows.flatMap((r) => r.items).entries()) {
       const p = byId.get(item.id);
-      const base = { id: item.id, groupId: section.id, col: p?.colStart ?? 1, span: p?.colSpan ?? 6, row: p?.row ?? 1 };
+      const base = { id: item.id, groupId: section.id, col: p?.colStart ?? 1, span: p?.colSpan ?? 6, row: p?.row ?? (i + 1) };
       if (item.kind === "field") {
-        cards.push({ ...base, kind: "field", label: labelToString(item.label), key: item.key, component: item.component as Component, required: item.required, placeholder: item.placeholder });
+        const rawComponent = item.component;
+        const component = (rawComponent && CANVAS_COMPONENT_SET.has(rawComponent) ? rawComponent : "Input") as Component;
+        cards.push({ ...base, kind: "field", label: labelToString(item.label), key: item.key, component, required: item.required, placeholder: item.placeholder });
       } else if (item.kind === "content" || item.kind === "ai-note") {
         cards.push({ ...base, kind: item.kind, label: labelToString(item.text) });
       } else {

--- a/apps/web/src/tools/form-canvas/model.ts
+++ b/apps/web/src/tools/form-canvas/model.ts
@@ -1,0 +1,109 @@
+import { parseFormConfig, type FormConfig, type FormItem, type FormSection, type ScalarType } from "@rfjs/form-builder";
+
+export type Kind = "field" | "content" | "divider" | "spacer" | "ai-note";
+export type Component = "Input" | "Textarea" | "Select" | "Number" | "Switch" | "DatePicker";
+
+export interface Card {
+  id: string;
+  groupId: string;
+  kind: Kind;
+  label: string;
+  key?: string;
+  component?: Component;
+  required?: boolean;
+  placeholder?: string;
+  col: number;
+  span: number;
+  row: number;
+}
+export interface Group {
+  id: string;
+  title: string;
+  collapsed: boolean;
+}
+
+const CANVAS_COLUMNS = 12;
+
+// Component → engine dataType (controls validation/coercion downstream).
+const DATATYPE: Record<Component, ScalarType> = {
+  Input: "string",
+  Textarea: "string",
+  Select: "string",
+  Number: "numeric",
+  Switch: "boolean",
+  DatePicker: "date",
+};
+
+function cardToItem(c: Card): FormItem {
+  switch (c.kind) {
+    case "field":
+      return {
+        id: c.id,
+        kind: "field",
+        key: c.key ?? c.id,
+        label: c.label,
+        component: c.component ?? "Input",
+        dataType: DATATYPE[c.component ?? "Input"],
+        ...(c.required ? { required: true } : {}),
+        ...(c.placeholder ? { placeholder: c.placeholder } : {}),
+      };
+    case "content":
+      return { id: c.id, kind: "content", text: c.label };
+    case "ai-note":
+      return { id: c.id, kind: "ai-note", text: c.label };
+    case "divider":
+      return { id: c.id, kind: "divider" };
+    case "spacer":
+      return { id: c.id, kind: "spacer" };
+  }
+}
+
+export function cardsToFormConfig(groups: Group[], cards: Card[]): FormConfig {
+  const sections: FormSection[] = groups.map((g) => {
+    const groupCards = cards
+      .filter((c) => c.groupId === g.id)
+      .sort((a, b) => a.row - b.row || a.col - b.col);
+    return {
+      id: g.id,
+      title: g.title,
+      rows: [{ id: `${g.id}_row`, items: groupCards.map(cardToItem) }],
+      layout: {
+        columns: CANVAS_COLUMNS,
+        placements: groupCards.map((c) => ({ itemId: c.id, colStart: c.col, colSpan: c.span, row: c.row })),
+      },
+    };
+  });
+  return { version: 1, sections };
+}
+
+function labelToString(label: unknown): string {
+  if (typeof label === "string") return label;
+  if (label && typeof label === "object") return String(Object.values(label as Record<string, string>)[0] ?? "");
+  return "";
+}
+
+export function formConfigToCards(config: FormConfig): { groups: Group[]; cards: Card[] } {
+  const groups: Group[] = [];
+  const cards: Card[] = [];
+  for (const section of config.sections ?? []) {
+    groups.push({ id: section.id, title: labelToString(section.title) || "Section", collapsed: false });
+    const byId = new Map((section.layout?.placements ?? []).map((p) => [p.itemId, p]));
+    for (const item of section.rows.flatMap((r) => r.items)) {
+      const p = byId.get(item.id);
+      const base = { id: item.id, groupId: section.id, col: p?.colStart ?? 1, span: p?.colSpan ?? 6, row: p?.row ?? 1 };
+      if (item.kind === "field") {
+        cards.push({ ...base, kind: "field", label: labelToString(item.label), key: item.key, component: item.component as Component, required: item.required, placeholder: item.placeholder });
+      } else if (item.kind === "content" || item.kind === "ai-note") {
+        cards.push({ ...base, kind: item.kind, label: labelToString(item.text) });
+      } else {
+        cards.push({ ...base, kind: item.kind, label: item.kind === "divider" ? "Divider" : "Spacer" });
+      }
+    }
+  }
+  return { groups, cards };
+}
+
+// Parse JSON text → canvas model (throws on invalid FormConfig).
+export function jsonToCards(text: string): { groups: Group[]; cards: Card[] } {
+  return formConfigToCards(parseFormConfig(JSON.parse(text)));
+}

--- a/apps/web/src/tools/form-canvas/ui.spec.tsx
+++ b/apps/web/src/tools/form-canvas/ui.spec.tsx
@@ -22,7 +22,7 @@ if (typeof window !== 'undefined' && !window.ResizeObserver) {
 }
 
 import { describe, it, expect } from "vitest";
-import { render, screen, fireEvent, within } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import { FormCanvasTool } from "./ui";
 
 describe("FormCanvasTool preview", () => {

--- a/apps/web/src/tools/form-canvas/ui.spec.tsx
+++ b/apps/web/src/tools/form-canvas/ui.spec.tsx
@@ -1,0 +1,46 @@
+// jsdom shim: radix-ui Select uses pointer capture and scrollIntoView APIs not available in jsdom
+if (typeof Element !== 'undefined') {
+  if (!Element.prototype.hasPointerCapture) {
+    Element.prototype.hasPointerCapture = () => false;
+  }
+  if (!Element.prototype.setPointerCapture) {
+    Element.prototype.setPointerCapture = () => {};
+  }
+  if (!Element.prototype.releasePointerCapture) {
+    Element.prototype.releasePointerCapture = () => {};
+  }
+  if (!Element.prototype.scrollIntoView) {
+    Element.prototype.scrollIntoView = () => {};
+  }
+}
+if (typeof window !== 'undefined' && !window.ResizeObserver) {
+  window.ResizeObserver = class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+}
+
+import { describe, it, expect } from "vitest";
+import { render, screen, fireEvent, within } from "@testing-library/react";
+import { FormCanvasTool } from "./ui";
+
+describe("FormCanvasTool preview", () => {
+  it("Preview tab renders the real ConfigForm with a labelled control", () => {
+    render(<FormCanvasTool />);
+    fireEvent.click(screen.getByRole("button", { name: /^preview$/i }));
+    // The seed has a "Name" field → real <Label> + a real input render.
+    expect(screen.getByText("Name")).toBeTruthy();
+    expect(screen.getByRole("button", { name: /submit/i })).toBeTruthy();
+  });
+
+  it("JSON tab shows a FormConfig (version + sections)", () => {
+    render(<FormCanvasTool />);
+    fireEvent.click(screen.getByRole("button", { name: /^json$/i }));
+    const ta = screen.getByLabelText(/config json/i) as HTMLTextAreaElement;
+    const parsed = JSON.parse(ta.value);
+    expect(parsed.version).toBe(1);
+    expect(Array.isArray(parsed.sections)).toBe(true);
+    expect(parsed.sections[0].layout.columns).toBe(12);
+  });
+});

--- a/apps/web/src/tools/form-canvas/ui.tsx
+++ b/apps/web/src/tools/form-canvas/ui.tsx
@@ -23,7 +23,7 @@ import { cardsToFormConfig, jsonToCards } from "./model";
 // Direction C (hybrid) — "A structure + C drag freedom", now with a builder
 // shell: Canvas | Preview | JSON tabs, a right-hand inspector for per-field
 // config, and bidirectional JSON (edit JSON → rebuild the canvas). RWD-aware.
-// Still a layout-evaluation prototype — no real validation/data engine.
+// Edits a real FormConfig (cards → groups → fields) and previews it via ConfigForm.
 // ---------------------------------------------------------------------------
 
 const COLS = 12;

--- a/apps/web/src/tools/form-canvas/ui.tsx
+++ b/apps/web/src/tools/form-canvas/ui.tsx
@@ -15,7 +15,9 @@ import {
   Check,
 } from "lucide-react";
 
+import { ConfigForm } from "@rfjs/form-builder-ui";
 import type { Card, Group, Kind, Component } from "./model";
+import { cardsToFormConfig, jsonToCards } from "./model";
 
 // ---------------------------------------------------------------------------
 // Direction C (hybrid) — "A structure + C drag freedom", now with a builder
@@ -64,73 +66,6 @@ const SEED_CARDS: Card[] = [
 let seq = 100;
 let gseq = 10;
 
-// --- (de)serialize: the canvas <-> a readable config JSON --------------------
-function serialize(groups: Group[], cards: Card[]) {
-  return {
-    version: 1,
-    groups: groups.map((g) => ({
-      id: g.id,
-      title: g.title,
-      cols: COLS,
-      items: cards
-        .filter((c) => c.groupId === g.id)
-        .sort((a, b) => a.row - b.row || a.col - b.col)
-        .map((c) => ({
-          id: c.id,
-          kind: c.kind,
-          label: c.label,
-          ...(c.kind === "field"
-            ? { key: c.key, component: c.component, required: c.required || undefined, placeholder: c.placeholder || undefined }
-            : {}),
-          col: c.col,
-          span: c.span,
-          row: c.row,
-        })),
-    })),
-  };
-}
-
-function parse(obj: unknown): { groups: Group[]; cards: Card[] } {
-  if (!obj || typeof obj !== "object" || !Array.isArray((obj as { groups?: unknown }).groups)) {
-    throw new Error("expected { groups: [...] }");
-  }
-  const groups: Group[] = [];
-  const cards: Card[] = [];
-  for (const g of (obj as { groups: Array<Record<string, unknown>> }).groups) {
-    const gid = String(g.id ?? `g${groups.length}`);
-    groups.push({ id: gid, title: String(g.title ?? "Section"), collapsed: false });
-    const items = Array.isArray(g.items) ? (g.items as Array<Record<string, unknown>>) : [];
-    items.forEach((it, i) => {
-      cards.push({
-        id: String(it.id ?? `${gid}_${i}`),
-        groupId: gid,
-        kind: (it.kind as Kind) ?? "field",
-        label: String(it.label ?? "Field"),
-        key: it.key as string | undefined,
-        component: it.component as Component | undefined,
-        required: Boolean(it.required),
-        placeholder: it.placeholder as string | undefined,
-        col: clamp(Number(it.col ?? 1), 1, COLS),
-        span: clamp(Number(it.span ?? 6), 1, COLS),
-        row: Number(it.row ?? i + 1),
-      });
-    });
-  }
-  return { groups, cards };
-}
-
-function useMediaQuery(query: string) {
-  const [m, setM] = React.useState(false);
-  React.useEffect(() => {
-    if (typeof window === "undefined" || !window.matchMedia) return;
-    const mql = window.matchMedia(query);
-    const on = () => setM(mql.matches);
-    on();
-    mql.addEventListener("change", on);
-    return () => mql.removeEventListener("change", on);
-  }, [query]);
-  return m;
-}
 
 export function FormCanvasTool() {
   const [groups, setGroups] = React.useState<Group[]>(SEED_GROUPS);
@@ -142,9 +77,9 @@ export function FormCanvasTool() {
   const [dropGroup, setDropGroup] = React.useState<string | null>(null);
   const bodyRefs = React.useRef<Record<string, HTMLDivElement | null>>({});
   const drag = React.useRef<{ id: string; mode: "move" | "resize"; col: number; span: number } | null>(null);
-  const isWidePreview = useMediaQuery("(min-width: 768px)");
 
   const selectedCard = cards.find((c) => c.id === selected) ?? null;
+  const formConfig = cardsToFormConfig(groups, cards);
 
   const patch = (id: string, p: Partial<Card>) => setCards((cs) => cs.map((c) => (c.id === id ? { ...c, ...p } : c)));
 
@@ -236,18 +171,18 @@ export function FormCanvasTool() {
 
   function applyJson(text: string) {
     try {
-      const { groups: g, cards: c } = parse(JSON.parse(text));
+      const { groups: g, cards: c } = jsonToCards(text);
       setGroups(g);
       setCards(c);
       setJsonError(null);
     } catch (err) {
-      setJsonError(err instanceof Error ? err.message : "invalid JSON");
+      setJsonError(err instanceof Error ? err.message : "invalid config");
     }
   }
 
   async function copyJson() {
     try {
-      await navigator.clipboard?.writeText(JSON.stringify(serialize(groups, cards), null, 2));
+      await navigator.clipboard?.writeText(JSON.stringify(formConfig, null, 2));
       setCopied(true);
       window.setTimeout(() => setCopied(false), 1400);
     } catch {
@@ -363,7 +298,9 @@ export function FormCanvasTool() {
           </div>
         </>
       ) : tab === "preview" ? (
-        <PreviewForm groups={groups} cards={cards} wide={isWidePreview} />
+        <div className="rounded-xl border border-border bg-card/30 p-6">
+          <ConfigForm config={formConfig} locale="en" onSubmit={() => {}} />
+        </div>
       ) : (
         <div className="flex flex-col gap-2">
           <div className="flex items-center justify-between">
@@ -383,7 +320,7 @@ export function FormCanvasTool() {
             aria-label="config json"
             spellCheck={false}
             className="h-[28rem] w-full rounded-md border border-input bg-background p-4 font-mono text-[13px] leading-relaxed"
-            defaultValue={JSON.stringify(serialize(groups, cards), null, 2)}
+            defaultValue={JSON.stringify(formConfig, null, 2)}
             onChange={(e) => applyJson(e.target.value)}
           />
           {jsonError ? <p className="text-xs text-destructive">Invalid config: {jsonError}</p> : null}
@@ -650,91 +587,3 @@ function Inspector({
   );
 }
 
-// ---------------------------------------------------------------------------
-// PreviewForm — renders the model as an actual form (RWD: 1-col on narrow)
-// ---------------------------------------------------------------------------
-
-function PreviewForm({ groups, cards, wide }: { groups: Group[]; cards: Card[]; wide: boolean }) {
-  return (
-    <div className="mx-auto flex max-w-3xl flex-col gap-8 rounded-xl border border-border bg-card/30 p-6">
-      {groups.map((group) => {
-        const groupCards = cards
-          .filter((c) => c.groupId === group.id && c.kind !== "ai-note")
-          .sort((a, b) => a.row - b.row || a.col - b.col);
-        return (
-          <section key={group.id} className="flex flex-col gap-4">
-            <h3 className="text-sm font-semibold">{group.title}</h3>
-            <div
-              className="grid gap-4"
-              style={{ gridTemplateColumns: wide ? `repeat(${COLS}, minmax(0, 1fr))` : "1fr" }}
-            >
-              {groupCards.map((c) => (
-                <div key={c.id} style={{ gridColumn: wide ? `span ${c.span}` : "1 / -1" }}>
-                  <PreviewField card={c} />
-                </div>
-              ))}
-            </div>
-          </section>
-        );
-      })}
-    </div>
-  );
-}
-
-function PreviewField({ card }: { card: Card }) {
-  if (card.kind === "divider") return <hr className="border-border" />;
-  if (card.kind === "spacer") return <div className="h-4" />;
-  if (card.kind === "content") return <p className="text-sm text-muted-foreground">{card.label}</p>;
-
-  const ctrl = "mt-1.5 w-full rounded-md border border-input bg-background px-3 text-sm";
-  const label = (
-    <label className="text-sm font-medium">
-      {card.label}
-      {card.required ? <span className="ml-1 text-destructive">*</span> : null}
-    </label>
-  );
-  const ph = card.placeholder;
-  switch (card.component) {
-    case "Textarea":
-      return (
-        <div>
-          {label}
-          <textarea className={`${ctrl} h-20 py-2`} placeholder={ph} />
-        </div>
-      );
-    case "Select":
-      return (
-        <div>
-          {label}
-          <select className={`${ctrl} h-9`} defaultValue="">
-            <option value="" disabled>
-              {ph || "—"}
-            </option>
-          </select>
-        </div>
-      );
-    case "Switch":
-      return (
-        <div className="flex items-center justify-between">
-          {label}
-          <span className="h-5 w-9 rounded-full bg-input" />
-        </div>
-      );
-    case "DatePicker":
-      return (
-        <div>
-          {label}
-          <button type="button" className={`${ctrl} h-9 text-left text-muted-foreground`}>
-            {ph || "Pick a date"}
-          </button>
-        </div>
-      );
-    default:
-      return (
-        <div>
-          {label}
-          <input type={card.component === "Number" ? "number" : "text"} className={`${ctrl} h-9`} placeholder={ph} />
-        </div>
-      );
-  }
-}

--- a/apps/web/src/tools/form-canvas/ui.tsx
+++ b/apps/web/src/tools/form-canvas/ui.tsx
@@ -15,6 +15,8 @@ import {
   Check,
 } from "lucide-react";
 
+import type { Card, Group, Kind, Component } from "./model";
+
 // ---------------------------------------------------------------------------
 // Direction C (hybrid) — "A structure + C drag freedom", now with a builder
 // shell: Canvas | Preview | JSON tabs, a right-hand inspector for per-field
@@ -27,29 +29,7 @@ const ROW_H = 84;
 const GAP = 8;
 const clamp = (v: number, lo: number, hi: number) => Math.max(lo, Math.min(hi, v));
 
-type Kind = "field" | "content" | "divider" | "spacer" | "ai-note";
-type Component = "Input" | "Textarea" | "Select" | "Number" | "Switch" | "DatePicker";
 const COMPONENTS: Component[] = ["Input", "Textarea", "Select", "Number", "Switch", "DatePicker"];
-
-interface Card {
-  id: string;
-  groupId: string;
-  kind: Kind;
-  label: string;
-  key?: string;
-  component?: Component;
-  required?: boolean;
-  placeholder?: string;
-  col: number;
-  span: number;
-  row: number;
-}
-
-interface Group {
-  id: string;
-  title: string;
-  collapsed: boolean;
-}
 
 const KIND_META: Record<
   Kind,

--- a/docs/superpowers/plans/2026-06-28-form-config-grid-layout.md
+++ b/docs/superpowers/plans/2026-06-28-form-config-grid-layout.md
@@ -1,0 +1,638 @@
+# Form-Config Grid Layout (make Direction-C "real") Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend `@rfjs/form-builder` with native 12-column grid coordinates so the Direction-C 2D canvas (`form-canvas` tool) edits a *real* `FormConfig` — its Preview becomes the real `ConfigForm` (true validation / conditional / dataSource) and its JSON becomes a valid `FormConfig`, with zero layout fidelity loss.
+
+**Architecture:** Add an optional `layout?: { columns, placements[] }` descriptor to `FormSection` (additive, backward-compatible). Items keep living in `section.rows[].items[]` (so `collectFieldItems` / validation / conditional / dataSource keep working untouched); `layout.placements` position items by their stable `id` on a CSS grid. `ConfigForm` gains a grid-mode branch that honors `{colStart, colSpan, row}`. The canvas tool maps its `{groups, cards}` to/from this `FormConfig` 1:1 and renders the engine's `ConfigForm` for preview.
+
+**Tech Stack:** TypeScript 5.7+, Zod, React 19, Vitest, Next.js (apps/web), pnpm/Turborepo. `@rfjs/form-builder` builds to **dist** (must rebuild after engine edits); `@rfjs/form-builder-ui` and the `form-canvas` tool are source-consumed via Next `transpilePackages`.
+
+## Global Constraints
+
+- Work in worktree `feat-form-config-grid` (branch `feat-form-config-grid`, off `origin/main`). Run `pnpm install` once at start; run `pnpm -F @rfjs/form-builder build` after **every** engine (`packages/form-builder`) source change before UI/app typecheck or tests.
+- The change to `FormConfig` is **additive and backward-compatible**: existing configs (no `layout`) must keep rendering exactly as today. Do not change `FieldWidth`, `FormSection.columns`, or the flow renderer path.
+- `config-schema.ts` uses default strip-mode `z.object` — any new persisted key **must** be mirrored into the schema or it is silently dropped. Every new key gets a round-trip test.
+- Co-locate `*.spec.ts(x)` next to source (vitest glob `src/**/*.spec.ts`). Conventional-commit messages, subject ≤ 100 chars, lowercase subject, no `Direction`/PascalCase start. End commit bodies with the `Co-Authored-By` trailer.
+- No changeset (these are private/preview surfaces; `@rfjs/form-builder` is `preview`). DRY, YAGNI, TDD, commit per task.
+
+---
+
+### Task 1: Engine — persist grid layout on `FormSection` (types + schema + round-trip)
+
+**Files:**
+- Modify: `packages/form-builder/src/types.ts` (add `GridPlacement`, `SectionLayout`; add `layout?` to `FormSection`)
+- Modify: `packages/form-builder/src/config-schema.ts` (mirror the new shape into the zod schema)
+- Test: `packages/form-builder/src/config-schema.spec.ts` (add round-trip + rejection tests; create the file if absent)
+
+**Interfaces:**
+- Produces:
+  - `interface GridPlacement { itemId: string; colStart: number; colSpan: number; row: number; rowSpan?: number }`
+  - `interface SectionLayout { columns: number; placements: GridPlacement[] }`
+  - `FormSection.layout?: SectionLayout`
+  - `parseFormConfig(input: unknown): FormConfig` (unchanged signature; now preserves `section.layout`)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `packages/form-builder/src/config-schema.spec.ts` (create the file with the standard header `import { describe, it, expect } from 'vitest';` and `import { parseFormConfig } from './config-schema';` if it does not exist):
+
+```ts
+describe('FormConfig grid layout', () => {
+  const gridConfig = {
+    version: 1,
+    sections: [
+      {
+        id: 's1',
+        title: 'Account',
+        rows: [{ id: 's1_row', items: [
+          { id: 'i_name', kind: 'field', key: 'name', label: 'Name', component: 'Input', dataType: 'string' },
+        ] }],
+        layout: {
+          columns: 12,
+          placements: [{ itemId: 'i_name', colStart: 1, colSpan: 6, row: 1 }],
+        },
+      },
+    ],
+  };
+
+  it('round-trips a section.layout (col/span/row survive strip-mode)', () => {
+    const parsed = parseFormConfig(gridConfig);
+    expect(parsed.sections![0]!.layout).toEqual({
+      columns: 12,
+      placements: [{ itemId: 'i_name', colStart: 1, colSpan: 6, row: 1 }],
+    });
+  });
+
+  it('rejects a placement with colSpan < 1', () => {
+    const bad = structuredClone(gridConfig);
+    bad.sections[0]!.layout!.placements[0]!.colSpan = 0;
+    expect(() => parseFormConfig(bad)).toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm -F @rfjs/form-builder vitest:run src/config-schema.spec.ts`
+Expected: FAIL — the round-trip test fails because `layout` is stripped (`parsed.sections[0].layout` is `undefined`).
+
+- [ ] **Step 3: Add the types**
+
+In `packages/form-builder/src/types.ts`, add immediately above `export interface FormRow`:
+
+```ts
+/** Explicit 12-column-grid placement of a single item (positioned by its `id`). */
+export interface GridPlacement {
+  itemId: string;   // FormItem.id this placement positions
+  colStart: number; // 1-based grid column start
+  colSpan: number;  // column span (>= 1)
+  row: number;      // 1-based grid row
+  rowSpan?: number; // optional row span (default 1)
+}
+
+/** Opt-in grid layout for a section. When present, the section renders as a
+ *  single CSS grid of `columns` columns and items are positioned by placement.
+ *  When absent, the section keeps the existing flow (rows + width) behaviour. */
+export interface SectionLayout {
+  columns: number;
+  placements: GridPlacement[];
+}
+```
+
+Then change the `FormSection` line to add the optional field:
+
+```ts
+export interface FormSection { id: string; title?: LocalizedLabel; rows: FormRow[]; columns?: 1 | 2 | 3 | 4; layout?: SectionLayout; }
+```
+
+- [ ] **Step 4: Mirror the shape into the zod schema**
+
+In `packages/form-builder/src/config-schema.ts`, add these two schemas immediately above `const formRowSchema = ...`:
+
+```ts
+const gridPlacementSchema = z.object({
+  itemId: z.string().min(1),
+  colStart: z.number().int().min(1).max(48),
+  colSpan: z.number().int().min(1).max(48),
+  row: z.number().int().min(1),
+  rowSpan: z.number().int().min(1).optional(),
+});
+const sectionLayoutSchema = z.object({
+  columns: z.number().int().min(1).max(48),
+  placements: z.array(gridPlacementSchema),
+});
+```
+
+Then add `layout` to `formSectionSchema`:
+
+```ts
+const formSectionSchema = z.object({
+  id: z.string().min(1),
+  title: localizedLabelSchema.optional(),
+  rows: z.array(formRowSchema),
+  columns: z.union([z.literal(1), z.literal(2), z.literal(3), z.literal(4)]).optional(),
+  layout: sectionLayoutSchema.optional(),
+});
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `pnpm -F @rfjs/form-builder vitest:run src/config-schema.spec.ts`
+Expected: PASS (both new tests + any pre-existing ones).
+
+- [ ] **Step 6: Build the engine + typecheck**
+
+Run: `pnpm -F @rfjs/form-builder build && pnpm -F @rfjs/form-builder check-types`
+Expected: build succeeds, no type errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/form-builder/src/types.ts packages/form-builder/src/config-schema.ts packages/form-builder/src/config-schema.spec.ts
+git commit -m "feat(form-builder): add optional grid layout to FormSection
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Renderer — `ConfigForm` grid-mode branch honoring placements
+
+**Files:**
+- Modify: `packages/form-builder-ui/src/config-form.tsx` (generalize `renderItem` to take a placement; add a grid-mode section branch)
+- Test: `packages/form-builder-ui/src/config-form.spec.tsx` (add a grid-layout rendering test)
+
+**Interfaces:**
+- Consumes: `GridPlacement`, `SectionLayout`, `FormSection.layout` from Task 1; `parseFormConfig` unchanged.
+- Produces: when a section has `layout`, each item wrapper carries `style.gridColumn = "<colStart> / span <colSpan>"` and `style.gridRow = "<row>"`, inside a section `<div data-testid="form-grid">` whose `gridTemplateColumns` is `repeat(<columns>, minmax(0, 1fr))`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `packages/form-builder-ui/src/config-form.spec.tsx`:
+
+```tsx
+describe('grid-layout sections', () => {
+  const cfg = {
+    version: 1,
+    sections: [
+      {
+        id: 's1',
+        rows: [{ id: 'r1', items: [
+          { id: 'i_a', kind: 'field', key: 'a', label: 'A', component: 'Input', dataType: 'string' },
+          { id: 'i_b', kind: 'field', key: 'b', label: 'B', component: 'Input', dataType: 'string' },
+        ] }],
+        layout: { columns: 12, placements: [
+          { itemId: 'i_a', colStart: 1, colSpan: 7, row: 1 },
+          { itemId: 'i_b', colStart: 8, colSpan: 5, row: 1 },
+        ] },
+      },
+    ],
+  };
+
+  it('renders a layout section as one grid, positioning items by placement', () => {
+    const { container } = render(<ConfigForm config={cfg as any} onSubmit={() => {}} />);
+    const grid = container.querySelector('[data-testid="form-grid"]') as HTMLElement;
+    expect(grid.style.gridTemplateColumns).toBe('repeat(12, minmax(0, 1fr))');
+    const a = container.querySelector('[data-item="i_a"]') as HTMLElement;
+    const b = container.querySelector('[data-item="i_b"]') as HTMLElement;
+    expect(a.style.gridColumn).toBe('1 / span 7');
+    expect(b.style.gridColumn).toBe('8 / span 5');
+    expect(a.style.gridRow).toBe('1');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm -F @rfjs/form-builder-ui vitest:run src/config-form.spec.tsx`
+Expected: FAIL — `[data-testid="form-grid"]` is null (no grid-mode branch yet).
+
+- [ ] **Step 3: Add a placement-style helper + a `data-item` hook to `renderItem`**
+
+In `packages/form-builder-ui/src/config-form.tsx`, just below the existing `FULL_SPAN` constant (around line 98), add:
+
+```tsx
+  // Explicit grid placement → inline grid-area style (grid-mode sections, Task 2).
+  const placementStyle = (p: { colStart: number; colSpan: number; row: number; rowSpan?: number }): React.CSSProperties => ({
+    gridColumn: `${p.colStart} / span ${p.colSpan}`,
+    gridRow: p.rowSpan ? `${p.row} / span ${p.rowSpan}` : String(p.row),
+    minWidth: 0,
+  });
+```
+
+Change the `renderItem` signature and field-branch wrapper so it accepts an optional placement. Replace the `renderItem(item, flow, cols)` signature line with:
+
+```tsx
+  function renderItem(item: FormItem, flow: 'v1' | 'section', cols: number, place?: { colStart: number; colSpan: number; row: number; rowSpan?: number }) {
+```
+
+Inside `renderItem`, the field branch builds `data-width`/`style`. Replace the field wrapper opening `<div ...>` (the one with `data-width={dataWidth}`) with one that prefers the placement style and tags the item id:
+
+```tsx
+      <div
+        key={item.key}
+        className="flex min-w-0 flex-col gap-1.5"
+        data-width={dataWidth}
+        data-item={item.id}
+        style={place ? placementStyle(place) : fieldSpanStyle(item.width, flow, cols)}
+      >
+```
+
+For the non-field branches (`divider`, `spacer`, `content`), when `place` is provided they must use the placement style instead of `FULL_SPAN`. Change each of those three `style={FULL_SPAN}` / `style={{ ...FULL_SPAN, height }}` usages to honor `place`:
+
+```tsx
+    // divider:
+      return <hr key={item.id} data-item={item.id} className="w-full border-input" style={place ? placementStyle(place) : FULL_SPAN} />;
+    // spacer:
+      return <div key={item.id} data-item={item.id} style={{ ...(place ? placementStyle(place) : FULL_SPAN), height }} />;
+    // content:
+      return (
+        <div key={item.id} data-item={item.id} className="text-sm" style={place ? placementStyle(place) : FULL_SPAN}>
+```
+
+- [ ] **Step 4: Add the grid-mode section branch**
+
+In the `sections.map((section) => { ... })` body, replace the `return ( <React.Fragment ...> ... </React.Fragment> )` so that a section WITH `layout` renders one grid. Insert this branch right after `const sectionCols = section.columns ?? 1;`:
+
+```tsx
+        if (isV2 && section.layout) {
+          const layout = section.layout;
+          const byId = new Map(layout.placements.map((p) => [p.itemId, p]));
+          const items = section.rows.flatMap((r) => r.items);
+          return (
+            <React.Fragment key={section.id}>
+              {section.title && (
+                <h3 className="font-semibold text-sm" style={{ gridColumn: '1 / -1' }}>
+                  {resolveLabel(section.title, locale)}
+                </h3>
+              )}
+              <div
+                data-testid="form-grid"
+                className="grid gap-4"
+                style={{ gridColumn: '1 / -1', gridTemplateColumns: `repeat(${layout.columns}, minmax(0, 1fr))` }}
+              >
+                {items.map((item) => renderItem(item, 'section', layout.columns, byId.get(item.id)))}
+              </div>
+            </React.Fragment>
+          );
+        }
+```
+
+(The existing flow branch below it is unchanged and handles sections without `layout`.)
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `pnpm -F @rfjs/form-builder-ui vitest:run src/config-form.spec.tsx`
+Expected: PASS, including the new `grid-layout sections` test and all pre-existing tests (flow path untouched).
+
+- [ ] **Step 6: Typecheck**
+
+Run: `pnpm -F @rfjs/form-builder-ui check-types`
+Expected: no type errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/form-builder-ui/src/config-form.tsx packages/form-builder-ui/src/config-form.spec.tsx
+git commit -m "feat(form-builder-ui): render grid-layout sections by placement
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Canvas — pure `cardsToFormConfig` / `formConfigToCards` mappers
+
+**Files:**
+- Create: `apps/web/src/tools/form-canvas/model.ts` (pure mapping functions + the canvas types, moved out of `ui.tsx`)
+- Modify: `apps/web/src/tools/form-canvas/ui.tsx` (import the moved types from `./model` — no behavior change yet)
+- Test: `apps/web/src/tools/form-canvas/model.spec.ts`
+
+**Interfaces:**
+- Consumes: `FormConfig`, `parseFormConfig` from `@rfjs/form-builder`; the existing `Card`/`Group`/`Kind`/`Component` shapes (move them into `model.ts` and re-export).
+- Produces:
+  - `cardsToFormConfig(groups: Group[], cards: Card[]): FormConfig`
+  - `formConfigToCards(config: FormConfig): { groups: Group[]; cards: Card[] }`
+  - re-exported types `Card`, `Group`, `Kind`, `Component`
+
+- [ ] **Step 1: Move the canvas types into `model.ts` and add the mappers**
+
+Create `apps/web/src/tools/form-canvas/model.ts`:
+
+```ts
+import { parseFormConfig, type FormConfig, type FormItem, type FormSection, type ScalarType } from "@rfjs/form-builder";
+
+export type Kind = "field" | "content" | "divider" | "spacer" | "ai-note";
+export type Component = "Input" | "Textarea" | "Select" | "Number" | "Switch" | "DatePicker";
+
+export interface Card {
+  id: string;
+  groupId: string;
+  kind: Kind;
+  label: string;
+  key?: string;
+  component?: Component;
+  required?: boolean;
+  placeholder?: string;
+  col: number;
+  span: number;
+  row: number;
+}
+export interface Group {
+  id: string;
+  title: string;
+  collapsed: boolean;
+}
+
+const CANVAS_COLUMNS = 12;
+
+// Component → engine dataType (controls validation/coercion downstream).
+const DATATYPE: Record<Component, ScalarType> = {
+  Input: "string",
+  Textarea: "string",
+  Select: "string",
+  Number: "numeric",
+  Switch: "boolean",
+  DatePicker: "date",
+};
+
+function cardToItem(c: Card): FormItem {
+  switch (c.kind) {
+    case "field":
+      return {
+        id: c.id,
+        kind: "field",
+        key: c.key ?? c.id,
+        label: c.label,
+        component: c.component ?? "Input",
+        dataType: DATATYPE[c.component ?? "Input"],
+        ...(c.required ? { required: true } : {}),
+        ...(c.placeholder ? { placeholder: c.placeholder } : {}),
+      };
+    case "content":
+      return { id: c.id, kind: "content", text: c.label };
+    case "ai-note":
+      return { id: c.id, kind: "ai-note", text: c.label };
+    case "divider":
+      return { id: c.id, kind: "divider" };
+    case "spacer":
+      return { id: c.id, kind: "spacer" };
+  }
+}
+
+export function cardsToFormConfig(groups: Group[], cards: Card[]): FormConfig {
+  const sections: FormSection[] = groups.map((g) => {
+    const groupCards = cards
+      .filter((c) => c.groupId === g.id)
+      .sort((a, b) => a.row - b.row || a.col - b.col);
+    return {
+      id: g.id,
+      title: g.title,
+      rows: [{ id: `${g.id}_row`, items: groupCards.map(cardToItem) }],
+      layout: {
+        columns: CANVAS_COLUMNS,
+        placements: groupCards.map((c) => ({ itemId: c.id, colStart: c.col, colSpan: c.span, row: c.row })),
+      },
+    };
+  });
+  return { version: 1, sections };
+}
+
+function labelToString(label: unknown): string {
+  if (typeof label === "string") return label;
+  if (label && typeof label === "object") return String(Object.values(label as Record<string, string>)[0] ?? "");
+  return "";
+}
+
+export function formConfigToCards(config: FormConfig): { groups: Group[]; cards: Card[] } {
+  const groups: Group[] = [];
+  const cards: Card[] = [];
+  for (const section of config.sections ?? []) {
+    groups.push({ id: section.id, title: labelToString(section.title) || "Section", collapsed: false });
+    const byId = new Map((section.layout?.placements ?? []).map((p) => [p.itemId, p]));
+    for (const item of section.rows.flatMap((r) => r.items)) {
+      const p = byId.get(item.id);
+      const base = { id: item.id, groupId: section.id, col: p?.colStart ?? 1, span: p?.colSpan ?? 6, row: p?.row ?? 1 };
+      if (item.kind === "field") {
+        cards.push({ ...base, kind: "field", label: labelToString(item.label), key: item.key, component: item.component as Component, required: item.required, placeholder: item.placeholder });
+      } else if (item.kind === "content" || item.kind === "ai-note") {
+        cards.push({ ...base, kind: item.kind, label: labelToString(item.text) });
+      } else {
+        cards.push({ ...base, kind: item.kind, label: item.kind === "divider" ? "Divider" : "Spacer" });
+      }
+    }
+  }
+  return { groups, cards };
+}
+
+// Parse JSON text → canvas model (throws on invalid FormConfig).
+export function jsonToCards(text: string): { groups: Group[]; cards: Card[] } {
+  return formConfigToCards(parseFormConfig(JSON.parse(text)));
+}
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `apps/web/src/tools/form-canvas/model.spec.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { cardsToFormConfig, formConfigToCards, type Card, type Group } from "./model";
+
+const groups: Group[] = [{ id: "g1", title: "Account", collapsed: false }];
+const cards: Card[] = [
+  { id: "c1", groupId: "g1", kind: "field", label: "Name", key: "name", component: "Input", required: true, col: 1, span: 7, row: 1 },
+  { id: "c2", groupId: "g1", kind: "field", label: "Age", key: "age", component: "Number", col: 8, span: 5, row: 1 },
+];
+
+describe("canvas <-> FormConfig", () => {
+  it("emits a FormConfig whose section.layout keeps exact col/span/row", () => {
+    const cfg = cardsToFormConfig(groups, cards);
+    expect(cfg.sections![0]!.layout).toEqual({
+      columns: 12,
+      placements: [
+        { itemId: "c1", colStart: 1, colSpan: 7, row: 1 },
+        { itemId: "c2", colStart: 8, colSpan: 5, row: 1 },
+      ],
+    });
+    expect(cfg.sections![0]!.rows[0]!.items[1]).toMatchObject({ key: "age", component: "Number", dataType: "numeric" });
+  });
+
+  it("round-trips canvas -> FormConfig -> canvas without losing placement", () => {
+    const back = formConfigToCards(cardsToFormConfig(groups, cards));
+    expect(back.cards).toHaveLength(2);
+    expect(back.cards[1]).toMatchObject({ id: "c2", col: 8, span: 5, row: 1, component: "Number" });
+  });
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails, then passes**
+
+Run: `pnpm -F web vitest:run src/tools/form-canvas/model.spec.ts`
+Expected first run: FAIL only if `model.ts` is incomplete; with Step 1 in place it should PASS. If it fails to resolve `@rfjs/form-builder` types, run `pnpm -F @rfjs/form-builder build` first.
+
+- [ ] **Step 4: Point `ui.tsx` at the moved types (no behavior change)**
+
+In `apps/web/src/tools/form-canvas/ui.tsx`, delete the local `type Kind`, `type Component`, `interface Card`, `interface Group` declarations and import them from `./model` instead:
+
+```tsx
+import type { Card, Group, Kind, Component } from "./model";
+```
+
+Leave the existing `serialize`/`parse`/`PreviewForm` as-is for now (Task 4 replaces them). Keep `COMPONENTS` (the array) local to `ui.tsx`.
+
+- [ ] **Step 5: Typecheck**
+
+Run: `pnpm -F web check-types`
+Expected: no type errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/tools/form-canvas/model.ts apps/web/src/tools/form-canvas/model.spec.ts apps/web/src/tools/form-canvas/ui.tsx
+git commit -m "feat(web): canvas <-> FormConfig mappers (model.ts)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Canvas — real `ConfigForm` preview + real `FormConfig` JSON
+
+**Files:**
+- Modify: `apps/web/src/tools/form-canvas/ui.tsx` (swap mock preview → `ConfigForm`; swap `serialize`/`applyJson` → real `FormConfig` via `model.ts`; delete the mock `PreviewForm`/`PreviewField` + the old local `serialize`/`parse`)
+- Test: `apps/web/src/tools/form-canvas/ui.spec.tsx` (create — preview renders a real control; JSON tab shows a `FormConfig`)
+
+**Interfaces:**
+- Consumes: `cardsToFormConfig`, `jsonToCards`, `formConfigToCards` from `./model` (Task 3); `ConfigForm` from `@rfjs/form-builder-ui`.
+- Produces: the `form-canvas` tool's Preview tab renders `<ConfigForm>`; JSON tab serializes a real `FormConfig` and edits rebuild the canvas via `jsonToCards`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/web/src/tools/form-canvas/ui.spec.tsx` (include the jsdom pointer/scroll shims used by the other form specs — copy the shim block from `packages/form-builder-ui/src/config-form-builder.spec.tsx` top):
+
+```tsx
+// (jsdom shims for radix pointer capture / scrollIntoView / ResizeObserver — copy from config-form-builder.spec.tsx)
+import { describe, it, expect } from "vitest";
+import { render, screen, fireEvent, within } from "@testing-library/react";
+import { FormCanvasTool } from "./ui";
+
+describe("FormCanvasTool preview", () => {
+  it("Preview tab renders the real ConfigForm with a labelled control", () => {
+    render(<FormCanvasTool />);
+    fireEvent.click(screen.getByRole("button", { name: /^preview$/i }));
+    // The seed has a "Name" field → real <Label> + a real input render.
+    expect(screen.getByText("Name")).toBeTruthy();
+    expect(screen.getByRole("button", { name: /submit/i })).toBeTruthy();
+  });
+
+  it("JSON tab shows a FormConfig (version + sections)", () => {
+    render(<FormCanvasTool />);
+    fireEvent.click(screen.getByRole("button", { name: /^json$/i }));
+    const ta = screen.getByLabelText(/config json/i) as HTMLTextAreaElement;
+    const parsed = JSON.parse(ta.value);
+    expect(parsed.version).toBe(1);
+    expect(Array.isArray(parsed.sections)).toBe(true);
+    expect(parsed.sections[0].layout.columns).toBe(12);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm -F web vitest:run src/tools/form-canvas/ui.spec.tsx`
+Expected: FAIL — the mock preview has no Submit button / no real `FormConfig` JSON yet.
+
+- [ ] **Step 3: Wire the real config + preview into `ui.tsx`**
+
+In `apps/web/src/tools/form-canvas/ui.tsx`:
+
+1. Add imports at the top:
+
+```tsx
+import { ConfigForm } from "@rfjs/form-builder-ui";
+import { cardsToFormConfig, jsonToCards } from "./model";
+```
+
+2. Delete the old local `serialize(groups, cards)` and `parse(obj)` functions and the `PreviewForm` + `PreviewField` components (they are replaced).
+
+3. Inside `FormCanvasTool`, derive the live config once per render (place near the other derived values such as `selectedCard`):
+
+```tsx
+  const formConfig = cardsToFormConfig(groups, cards);
+```
+
+4. Replace `applyJson` body with the real parser:
+
+```tsx
+  function applyJson(text: string) {
+    try {
+      const { groups: g, cards: c } = jsonToCards(text);
+      setGroups(g);
+      setCards(c);
+      setJsonError(null);
+    } catch (err) {
+      setJsonError(err instanceof Error ? err.message : "invalid config");
+    }
+  }
+```
+
+5. Replace `copyJson`'s and the textarea's serialized value to use the real config — change both `JSON.stringify(serialize(groups, cards), null, 2)` occurrences to:
+
+```tsx
+JSON.stringify(formConfig, null, 2)
+```
+
+6. Replace the Preview tab body (`tab === "preview" ? ( <PreviewForm .../> )`) with the engine renderer:
+
+```tsx
+      ) : tab === "preview" ? (
+        <div className="rounded-xl border border-border bg-card/30 p-6">
+          <ConfigForm config={formConfig} locale="en" onSubmit={() => {}} />
+        </div>
+      ) : (
+```
+
+7. Remove the now-unused `isWidePreview` / `useMediaQuery` only if they are no longer referenced (the mock preview was their sole consumer). If `useMediaQuery` becomes unused, delete it and its import-free helper to keep the file clean.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm -F web vitest:run src/tools/form-canvas/ui.spec.tsx`
+Expected: PASS — Preview shows "Name" + a Submit button; JSON is a real `FormConfig` with `sections[0].layout.columns === 12`.
+
+- [ ] **Step 5: Full typecheck + the tool registry spec (guards against regressions)**
+
+Run: `pnpm -F @rfjs/form-builder build && pnpm -F web check-types && pnpm -F web vitest:run src/tools/index.spec.ts`
+Expected: no type errors; registry spec (4 tests) green.
+
+- [ ] **Step 6: Manual visual check (optional but recommended)**
+
+Run: `pnpm --filter web exec next dev -p 3336` then open `http://localhost:3336/en/tools/form-canvas`, switch to Preview (real form with working validation on Submit) and JSON (real `FormConfig`). Drag a card, confirm Preview reflects the new layout.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web/src/tools/form-canvas/ui.tsx apps/web/src/tools/form-canvas/ui.spec.tsx
+git commit -m "feat(web): form-canvas previews real ConfigForm + emits real FormConfig
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Out of scope (follow-up plans)
+
+These are deliberately deferred — the engine already supports them; they only need canvas inspector UI:
+
+- **Inspector field config**: `conditional` (FilterMatchQuery), `validation` (min/max/length/pattern), Select/Radio `options[]` + `defaultValue`. (Cheap wins; one follow-up plan.)
+- **Localized labels + locales**: `label: string | Record<locale,string>` editing, multi-locale preview.
+- **Remote `dataSource` editing UI** in the canvas inspector + threading a `fetcher` into the preview `ConfigForm`.
+- **Overlap / rowSpan policy**: the canvas currently allows overlapping cards and has no `rowSpan`; decide and enforce a clean-model policy (schema or a normalize pass).
+- **Decide A's fate** (keep `form-builder` as the simple/linear tool vs retire it).
+
+## Self-Review notes
+
+- **Spec coverage:** Tasks 1–2 = EXTEND engine (types+schema) + renderer (the report's recommended path, steps 1–3). Task 3–4 = make the canvas real (report step 4). Behavioral subsystems (validation/conditional/dataSource) are reused unchanged — confirmed layout-independent by the review.
+- **Strip-mode guard:** Task 1 Step 1 round-trip test + Step 4 schema mirror — the report's #1 risk is covered.
+- **Backward compatibility:** grid branch is gated on `section.layout` presence; all flow tests in `config-form.spec.tsx` stay green (Task 2 Step 5).
+- **Type consistency:** `GridPlacement`/`SectionLayout`/`FormSection.layout` defined in Task 1 and consumed verbatim in Tasks 2–3; `cardsToFormConfig`/`formConfigToCards`/`jsonToCards` defined in Task 3 and consumed in Task 4.

--- a/packages/form-builder-ui/src/config-form.spec.tsx
+++ b/packages/form-builder-ui/src/config-form.spec.tsx
@@ -421,3 +421,33 @@ describe('v2 sections rendering', () => {
     expect(c.style.gridColumn).toBe('1 / -1');
   });
 });
+
+describe('grid-layout sections', () => {
+  const cfg = {
+    version: 1,
+    sections: [
+      {
+        id: 's1',
+        rows: [{ id: 'r1', items: [
+          { id: 'i_a', kind: 'field', key: 'a', label: 'A', component: 'Input', dataType: 'string' },
+          { id: 'i_b', kind: 'field', key: 'b', label: 'B', component: 'Input', dataType: 'string' },
+        ] }],
+        layout: { columns: 12, placements: [
+          { itemId: 'i_a', colStart: 1, colSpan: 7, row: 1 },
+          { itemId: 'i_b', colStart: 8, colSpan: 5, row: 1 },
+        ] },
+      },
+    ],
+  };
+
+  it('renders a layout section as one grid, positioning items by placement', () => {
+    const { container } = render(<ConfigForm config={cfg as any} onSubmit={() => {}} />);
+    const grid = container.querySelector('[data-testid="form-grid"]') as HTMLElement;
+    expect(grid.style.gridTemplateColumns).toBe('repeat(12, minmax(0, 1fr))');
+    const a = container.querySelector('[data-item="i_a"]') as HTMLElement;
+    const b = container.querySelector('[data-item="i_b"]') as HTMLElement;
+    expect(a.style.gridColumn).toBe('1 / span 7');
+    expect(b.style.gridColumn).toBe('8 / span 5');
+    expect(a.style.gridRow).toBe('1');
+  });
+});

--- a/packages/form-builder-ui/src/config-form.tsx
+++ b/packages/form-builder-ui/src/config-form.tsx
@@ -97,6 +97,13 @@ export function ConfigForm({ config, defaultValues, onSubmit, submitLabel = 'Sub
   // Items always span the full row width.
   const FULL_SPAN: React.CSSProperties = { gridColumn: '1 / -1' };
 
+  // Explicit grid placement → inline grid-area style (grid-mode sections, Task 2).
+  const placementStyle = (p: { colStart: number; colSpan: number; row: number; rowSpan?: number }): React.CSSProperties => ({
+    gridColumn: `${p.colStart} / span ${p.colSpan}`,
+    gridRow: p.rowSpan ? `${p.row} / span ${p.rowSpan}` : String(p.row),
+    minWidth: 0,
+  });
+
   // Field grid-span derived from the field's width AND the section's column count.
   // #3: columns DRIVE width — an unset width is a single cell, so a section with
   // `columns: 2` lays its fields two-per-row automatically (no per-field width
@@ -110,7 +117,7 @@ export function ConfigForm({ config, defaultValues, onSubmit, submitLabel = 'Sub
     return { gridColumn: `span ${span} / span ${span}`, minWidth: 0 };
   }
 
-  function renderItem(item: FormItem, flow: 'v1' | 'section', cols: number) {
+  function renderItem(item: FormItem, flow: 'v1' | 'section', cols: number, place?: { colStart: number; colSpan: number; row: number; rowSpan?: number }) {
     const vals = values as Record<string, unknown>;
 
     if (item.kind === 'ai-note') {
@@ -119,19 +126,19 @@ export function ConfigForm({ config, defaultValues, onSubmit, submitLabel = 'Sub
 
     if (item.kind === 'divider') {
       if (!evaluateConditional(item.conditional, vals)) return null;
-      return <hr key={item.id} className="w-full border-input" style={FULL_SPAN} />;
+      return <hr key={item.id} data-item={item.id} className="w-full border-input" style={place ? placementStyle(place) : FULL_SPAN} />;
     }
 
     if (item.kind === 'spacer') {
       if (!evaluateConditional(item.conditional, vals)) return null;
       const height = spacerHeights[item.size ?? 'md'];
-      return <div key={item.id} style={{ ...FULL_SPAN, height }} />;
+      return <div key={item.id} data-item={item.id} style={{ ...(place ? placementStyle(place) : FULL_SPAN), height }} />;
     }
 
     if (item.kind === 'content') {
       if (!evaluateConditional(item.conditional, vals)) return null;
       return (
-        <div key={item.id} className="text-sm" style={FULL_SPAN}>
+        <div key={item.id} data-item={item.id} className="text-sm" style={place ? placementStyle(place) : FULL_SPAN}>
           {item.dataSource ? (
             <DataSourceContent ds={item.dataSource} fetcher={fetcher} />
           ) : (
@@ -151,7 +158,8 @@ export function ConfigForm({ config, defaultValues, onSubmit, submitLabel = 'Sub
         key={item.key}
         className="flex min-w-0 flex-col gap-1.5"
         data-width={dataWidth}
-        style={fieldSpanStyle(item.width, flow, cols)}
+        data-item={item.id}
+        style={place ? placementStyle(place) : fieldSpanStyle(item.width, flow, cols)}
       >
         <Label htmlFor={item.key}>{resolveLabel(item.label, locale)}</Label>
         <Controller
@@ -193,6 +201,29 @@ export function ConfigForm({ config, defaultValues, onSubmit, submitLabel = 'Sub
       {sections.map((section) => {
         // Per-section column count drives the row grid (and thus field widths).
         const sectionCols = section.columns ?? 1;
+
+        if (isV2 && section.layout) {
+          const layout = section.layout;
+          const byId = new Map(layout.placements.map((p) => [p.itemId, p]));
+          const items = section.rows.flatMap((r) => r.items);
+          return (
+            <React.Fragment key={section.id}>
+              {section.title && (
+                <h3 className="font-semibold text-sm" style={{ gridColumn: '1 / -1' }}>
+                  {resolveLabel(section.title, locale)}
+                </h3>
+              )}
+              <div
+                data-testid="form-grid"
+                className="grid gap-4"
+                style={{ gridColumn: '1 / -1', gridTemplateColumns: `repeat(${layout.columns}, minmax(0, 1fr))` }}
+              >
+                {items.map((item) => renderItem(item, 'section', layout.columns, byId.get(item.id)))}
+              </div>
+            </React.Fragment>
+          );
+        }
+
         return (
           <React.Fragment key={section.id}>
             {section.title && (

--- a/packages/form-builder/src/config-schema.spec.ts
+++ b/packages/form-builder/src/config-schema.spec.ts
@@ -354,3 +354,36 @@ describe('conditional field visibility schema', () => {
     expect(FormConfigSchema.safeParse(cfg).success).toBe(false);
   });
 });
+
+describe('FormConfig grid layout', () => {
+  const gridConfig = {
+    version: 1,
+    sections: [
+      {
+        id: 's1',
+        title: 'Account',
+        rows: [{ id: 's1_row', items: [
+          { id: 'i_name', kind: 'field', key: 'name', label: 'Name', component: 'Input', dataType: 'string' },
+        ] }],
+        layout: {
+          columns: 12,
+          placements: [{ itemId: 'i_name', colStart: 1, colSpan: 6, row: 1 }],
+        },
+      },
+    ],
+  };
+
+  it('round-trips a section.layout (col/span/row survive strip-mode)', () => {
+    const parsed = parseFormConfig(gridConfig);
+    expect(parsed.sections![0]!.layout).toEqual({
+      columns: 12,
+      placements: [{ itemId: 'i_name', colStart: 1, colSpan: 6, row: 1 }],
+    });
+  });
+
+  it('rejects a placement with colSpan < 1', () => {
+    const bad = structuredClone(gridConfig);
+    bad.sections[0]!.layout!.placements[0]!.colSpan = 0;
+    expect(() => parseFormConfig(bad)).toThrow();
+  });
+});

--- a/packages/form-builder/src/config-schema.ts
+++ b/packages/form-builder/src/config-schema.ts
@@ -118,12 +118,24 @@ const formItemSchema = z.discriminatedUnion('kind', [
   spacerItemSchema,
   aiNoteItemSchema,
 ]);
+const gridPlacementSchema = z.object({
+  itemId: z.string().min(1),
+  colStart: z.number().int().min(1).max(48),
+  colSpan: z.number().int().min(1).max(48),
+  row: z.number().int().min(1),
+  rowSpan: z.number().int().min(1).optional(),
+});
+const sectionLayoutSchema = z.object({
+  columns: z.number().int().min(1).max(48),
+  placements: z.array(gridPlacementSchema),
+});
 const formRowSchema = z.object({ id: z.string().min(1), items: z.array(formItemSchema) });
 const formSectionSchema = z.object({
   id: z.string().min(1),
   title: localizedLabelSchema.optional(),
   rows: z.array(formRowSchema),
   columns: z.union([z.literal(1), z.literal(2), z.literal(3), z.literal(4)]).optional(),
+  layout: sectionLayoutSchema.optional(),
 });
 
 export const FormConfigSchema: ZodType<FormConfig> = z

--- a/packages/form-builder/src/types.ts
+++ b/packages/form-builder/src/types.ts
@@ -91,8 +91,25 @@ export interface SpacerItem { id: string; kind: 'spacer'; size?: SpacerSize; con
 export interface AiNoteItem { id: string; kind: 'ai-note'; text: string; }
 export type FormItem = FieldItem | ContentItem | DividerItem | SpacerItem | AiNoteItem;
 
+/** Explicit 12-column-grid placement of a single item (positioned by its `id`). */
+export interface GridPlacement {
+  itemId: string;   // FormItem.id this placement positions
+  colStart: number; // 1-based grid column start
+  colSpan: number;  // column span (>= 1)
+  row: number;      // 1-based grid row
+  rowSpan?: number; // optional row span (default 1)
+}
+
+/** Opt-in grid layout for a section. When present, the section renders as a
+ *  single CSS grid of `columns` columns and items are positioned by placement.
+ *  When absent, the section keeps the existing flow (rows + width) behaviour. */
+export interface SectionLayout {
+  columns: number;
+  placements: GridPlacement[];
+}
+
 export interface FormRow { id: string; items: FormItem[]; }
-export interface FormSection { id: string; title?: LocalizedLabel; rows: FormRow[]; columns?: 1 | 2 | 3 | 4; }
+export interface FormSection { id: string; title?: LocalizedLabel; rows: FormRow[]; columns?: 1 | 2 | 3 | 4; layout?: SectionLayout; }
 
 export interface FormConfig {
   version: number;


### PR DESCRIPTION
Makes the **Direction-C 2D canvas** (`form-canvas` tool) edit a *real* `FormConfig`: its Preview is now the engine's real `ConfigForm` (true validation / conditional / dataSource), its JSON is a valid `FormConfig`, with **no layout-fidelity loss**. Implements the EXTEND path from the ultracode architecture review.

## Approach
The behavioral engine (validation/conditional/dataSource/controls) is layout-independent and reused **unchanged**. Only the *layout representation* is extended:
- **Additive** `FormSection.layout?: { columns, placements: { itemId, colStart, colSpan, row, rowSpan? }[] }`. Items keep living in `rows[].items[]`, so `collectFieldItems` / validation / conditional / dataSource are untouched. Backward-compatible: configs without `layout` render exactly as before.

## What changed (6 commits)
1. **`feat(form-builder)`** — `GridPlacement`/`SectionLayout` types + zod schema mirror + round-trip test (guards strip-mode key loss).
2. **`feat(form-builder-ui)`** — `ConfigForm` grid-mode branch: a section with `layout` renders as one CSS grid of `columns`, each item positioned by `{colStart, colSpan, row}`. Flow path untouched.
3. **`feat(web)`** — `model.ts`: pure `cardsToFormConfig` / `formConfigToCards` / `jsonToCards`, mapping the canvas `{groups, cards}` ↔ `FormConfig` 1:1 (exact col/span/row).
4. **`feat(web)`** — `form-canvas` Preview → real `<ConfigForm>`; JSON tab → real `FormConfig` (edits rebuild the canvas, Zod-validated). Mock preview + old serialize/parse removed (−161 lines).
5–6. Fixes from review: unused import / stale comment; **normalize non-canvas components on JSON import** (Checkbox/Date/Email/Radio no longer emit `dataType: undefined`) + distinct rows for placement-less imports.

## Verification
- Tests green: `@rfjs/form-builder` (8 files), `@rfjs/form-builder-ui` (8 files), `web` form-canvas + registry (10 tests). `check-types` clean across all 3 packages.
- Built via subagent-driven TDD (plan in `docs/superpowers/plans/2026-06-28-form-config-grid-layout.md`); per-task reviews + a whole-branch review, all findings resolved.

## Out of scope (follow-ups, engine already supports)
Inspector UI for conditional / validation / Select options; localized labels + multi-locale preview; remote dataSource editing + `fetcher` threading; overlap/rowSpan policy. A few non-blocking Minor polish items (JSDoc wording, broader rejection-test coverage) noted for follow-up.