### PR TITLE
fix(form-canvas): click selects without moving (drag threshold + grab offset)

### DIFF
--- a/apps/web/src/tools/form-canvas/ui.spec.tsx
+++ b/apps/web/src/tools/form-canvas/ui.spec.tsx
@@ -59,3 +59,15 @@ describe("canvas no-overlap invariant", () => {
         if (out[i]!.groupId === out[j]!.groupId) expect(collides(out[i]!, out[j]!)).toBe(false);
   });
 });
+
+describe("FormCanvasTool drag threshold", () => {
+  it("a sub-threshold pointer move (a click) does not move the card", () => {
+    render(<FormCanvasTool />);
+    const card = screen.getByText("Name").closest(".cursor-grab") as HTMLElement;
+    const before = card.style.gridColumn;
+    fireEvent.pointerDown(card, { clientX: 100, clientY: 100 });
+    fireEvent.pointerMove(window, { clientX: 102, clientY: 101 }); // ~2px, below the 4px threshold
+    fireEvent.pointerUp(window, { clientX: 102, clientY: 101 });
+    expect(card.style.gridColumn).toBe(before);
+  });
+});

--- a/apps/web/src/tools/form-canvas/ui.tsx
+++ b/apps/web/src/tools/form-canvas/ui.tsx
@@ -30,6 +30,7 @@ import { resolveCards } from "./layout-grid";
 const COLS = 12;
 const ROW_H = 84;
 const GAP = 8;
+const DRAG_THRESHOLD = 4; // px the pointer must travel before a press becomes a drag (a click just selects)
 const clamp = (v: number, lo: number, hi: number) => Math.max(lo, Math.min(hi, v));
 
 const COMPONENTS: Component[] = ["Input", "Textarea", "Select", "Number", "Switch", "DatePicker"];
@@ -126,14 +127,28 @@ export function FormCanvasTool() {
     e.preventDefault();
     e.stopPropagation();
     setSelected(card.id);
+    const startX = e.clientX;
+    const startY = e.clientY;
+    // Grab offset (move): the cell under the pointer at grab time minus the card's
+    // origin, so the card follows the cursor instead of snapping its origin to it.
+    const grab = mode === "move" ? cellAt(startX, startY, card.groupId) : null;
+    const offCol = grab ? grab.col - card.col : 0;
+    const offRow = grab ? grab.row - card.row : 0;
     drag.current = { id: card.id, mode, col: card.col, span: card.span };
+    // A bare click selects but must NOT move: only treat it as a drag once the
+    // pointer travels past DRAG_THRESHOLD.
+    let active = false;
     const onMove = (ev: PointerEvent) => {
       const d = drag.current;
       if (!d) return;
+      if (!active && Math.hypot(ev.clientX - startX, ev.clientY - startY) < DRAG_THRESHOLD) return;
+      active = true;
       if (d.mode === "move") {
-        const { groupId, col, row } = cellAt(ev.clientX, ev.clientY, card.groupId);
-        setDropGroup(groupId);
-        placeDragged(d.id, { groupId, col: clamp(col, 1, COLS - card.span + 1), row });
+        const cell = cellAt(ev.clientX, ev.clientY, card.groupId);
+        const col = clamp(cell.col - offCol, 1, COLS - card.span + 1);
+        const row = clamp(cell.row - offRow, 1, 99);
+        setDropGroup(cell.groupId);
+        placeDragged(d.id, { groupId: cell.groupId, col, row });
       } else {
         const body = bodyRefs.current[card.groupId];
         if (!body) return;


### PR DESCRIPTION
## Bug
Clicking a canvas item (or the slightest jitter on a click) immediately shifted its position.

## Cause
`beginDrag` ran the placer on **every** `pointermove` (no drag threshold), and the move used `cellAt(pointer)` to snap the card's **origin to the cell under the cursor** — so grabbing a wide card's middle teleported its origin to the pointer, even for a 1px move.

## Fix (`apps/web/src/tools/form-canvas/ui.tsx`)
- **Drag threshold**: a press only becomes a drag once the pointer travels > `4px`; a click just selects.
- **Grab offset**: the card now follows the cursor by the offset where it was grabbed, instead of snapping its origin to the pointer cell (also fixes the jump-on-drag-start). Cross-group drag preserved.

## Test
Added a regression test: a sub-threshold pointer move leaves the card's `gridColumn` unchanged. Full form-canvas suite green; `check-types` clean.

Fixes the drag bug in the merged collision feature (#210). Independent of the open full-config PR (#211).