### PR TITLE
feat(form-canvas): drag-reorder groups + expand common inspector sections (badges)

### DIFF
--- a/apps/web/src/tools/form-canvas/inspector/section.tsx
+++ b/apps/web/src/tools/form-canvas/inspector/section.tsx
@@ -2,7 +2,18 @@
 import * as React from "react";
 import { ChevronDown } from "lucide-react";
 
-export function Section({ title, defaultOpen = true, children }: { title: string; defaultOpen?: boolean; children: React.ReactNode }) {
+export function Section({
+  title,
+  defaultOpen = true,
+  badge,
+  children,
+}: {
+  title: string;
+  defaultOpen?: boolean;
+  /** Optional indicator (e.g. a "has content" dot or count) shown at the header's end. */
+  badge?: React.ReactNode;
+  children: React.ReactNode;
+}) {
   const [open, setOpen] = React.useState(defaultOpen);
   return (
     <div className="rounded-lg border border-border">
@@ -13,6 +24,7 @@ export function Section({ title, defaultOpen = true, children }: { title: string
       >
         <ChevronDown className={`size-3.5 transition-transform ${open ? "" : "-rotate-90"}`} />
         {title}
+        {badge != null ? <span className="ml-auto flex items-center">{badge}</span> : null}
       </button>
       {open ? <div className="flex flex-col gap-2 border-t border-border p-3">{children}</div> : null}
     </div>

--- a/apps/web/src/tools/form-canvas/inspector/settings-panel.spec.tsx
+++ b/apps/web/src/tools/form-canvas/inspector/settings-panel.spec.tsx
@@ -27,4 +27,13 @@ describe("SettingsPanel", () => {
     render(<SettingsPanel card={ai} groups={[{ id: "g1", title: "G", collapsed: false }]} onChange={() => {}} onRemove={() => {}} />);
     expect(screen.queryByRole("button", { name: /labels/i })).toBeNull();
   });
+  it("expands Validation by default (its fields are visible without clicking)", () => {
+    render(<SettingsPanel card={field} groups={[{ id: "g1", title: "G", collapsed: false }]} onChange={() => {}} onRemove={() => {}} />);
+    expect(screen.getByLabelText(/min length/i)).toBeTruthy();
+  });
+  it("shows a count badge on Options for a Select field with options", () => {
+    const sel: Card = { ...field, component: "Select", options: [{ label: "A", value: "a" }, { label: "B", value: "b" }] };
+    render(<SettingsPanel card={sel} groups={[{ id: "g1", title: "G", collapsed: false }]} onChange={() => {}} onRemove={() => {}} />);
+    expect(screen.getByRole("button", { name: /options/i }).textContent).toContain("2");
+  });
 });

--- a/apps/web/src/tools/form-canvas/inspector/settings-panel.tsx
+++ b/apps/web/src/tools/form-canvas/inspector/settings-panel.tsx
@@ -13,6 +13,12 @@ import { INPUT_CLS } from "./constants";
 const COMPONENTS: Component[] = ["Input", "Textarea", "Select", "Number", "Switch", "DatePicker"];
 const COLS = 12;
 
+// "Has content" indicators shown on section headers.
+const Dot = () => <span className="size-1.5 rounded-full bg-[#5b8cff]" aria-label="has content" />;
+const Count = ({ n }: { n: number }) => (
+  <span className="rounded-full bg-[#5b8cff]/15 px-1.5 text-[10px] font-medium text-[#5b8cff]">{n}</span>
+);
+
 export function SettingsPanel({
   card, groups, onChange, onRemove, siblingFields = [],
 }: { card: Card | null; groups: Group[]; onChange: (p: Partial<Card>) => void; onRemove: () => void; siblingFields?: { key: string; dataType: string }[] }) {
@@ -69,18 +75,45 @@ export function SettingsPanel({
         </div>
       </Section>
 
-      {isField ? <Section title="Validation" defaultOpen={false}><ValidationSection card={card} onChange={onChange} /></Section> : null}
+      {/* Common config: expanded by default. Advanced: collapsed with a "has content" badge. */}
+      {isField ? (
+        <Section title="Validation" badge={card.validation && Object.keys(card.validation).length ? <Count n={Object.keys(card.validation).length} /> : undefined}>
+          <ValidationSection card={card} onChange={onChange} />
+        </Section>
+      ) : null}
 
-      {isField && card.component === "Select" ? <Section title="Options" defaultOpen={false}><OptionsSection card={card} onChange={onChange} /></Section> : null}
+      {isField && card.component === "Select" ? (
+        <Section title="Options" badge={card.options?.length ? <Count n={card.options.length} /> : undefined}>
+          <OptionsSection card={card} onChange={onChange} />
+        </Section>
+      ) : null}
 
-      {isField ? <Section title="AI Note" defaultOpen={false}><AiNoteSection card={card} onChange={onChange} /></Section> : null}
+      {isField ? (
+        <Section title="Conditional" badge={card.conditional ? <Dot /> : undefined}>
+          <ConditionalSection card={card} siblingFields={siblingFields} onChange={onChange} />
+        </Section>
+      ) : null}
 
-      {isField ? <Section title="Conditional" defaultOpen={false}><ConditionalSection card={card} siblingFields={siblingFields} onChange={onChange} /></Section> : null}
-      {isField && card.component === "Select" ? <Section title="Data Source" defaultOpen={false}><DataSourceSection card={card} onChange={onChange} /></Section> : null}
+      {isField && card.component === "Select" ? (
+        <Section title="Data Source" defaultOpen={false} badge={card.dataSource ? <Dot /> : undefined}>
+          <DataSourceSection card={card} onChange={onChange} />
+        </Section>
+      ) : null}
+
+      {isField ? (
+        <Section title="AI Note" defaultOpen={false} badge={card.aiNote ? <Dot /> : undefined}>
+          <AiNoteSection card={card} onChange={onChange} />
+        </Section>
+      ) : null}
+
       {card.kind === "content" ? <Section title="Content"><ContentSection card={card} onChange={onChange} /></Section> : null}
       {card.kind === "spacer" ? <Section title="Spacer"><SpacerSection card={card} onChange={onChange} /></Section> : null}
 
-      {(card.kind === "field" || card.kind === "content") ? <Section title="Labels (i18n)" defaultOpen={false}><LabelsSection card={card} onChange={onChange} /></Section> : null}
+      {(card.kind === "field" || card.kind === "content") ? (
+        <Section title="Labels (i18n)" defaultOpen={false} badge={typeof card.label === "object" ? <Dot /> : undefined}>
+          <LabelsSection card={card} onChange={onChange} />
+        </Section>
+      ) : null}
 
       <button
         type="button"

--- a/apps/web/src/tools/form-canvas/layout-grid.spec.ts
+++ b/apps/web/src/tools/form-canvas/layout-grid.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { collides, compact, resolveCollisions, resolveCards, type GridItem, type PlacedCard } from "./layout-grid";
+import { collides, compact, resolveCollisions, resolveCards, moveItem, type GridItem, type PlacedCard } from "./layout-grid";
 
 const g = (id: string, col: number, span: number, row: number): GridItem => ({ id, col, span, row });
 
@@ -62,5 +62,17 @@ describe("resolveCards (per-group orchestration)", () => {
     expect(out.find((c) => c.id === "x")!.row).toBe(2); // displaced in g2
     expect(out.find((c) => c.id === "b")!.row).toBe(1); // g1 compacted upward
     expect(out.find((c) => c.id === "b")!.groupId).toBe("g1"); // groupId preserved
+  });
+});
+
+describe("moveItem", () => {
+  it("moves an item down", () => {
+    expect(moveItem(["a", "b", "c"], 0, 2)).toEqual(["b", "c", "a"]);
+  });
+  it("moves an item up", () => {
+    expect(moveItem(["a", "b", "c"], 2, 0)).toEqual(["c", "a", "b"]);
+  });
+  it("is a no-op for an out-of-range from", () => {
+    expect(moveItem(["a", "b"], 5, 0)).toEqual(["a", "b"]);
   });
 });

--- a/apps/web/src/tools/form-canvas/layout-grid.ts
+++ b/apps/web/src/tools/form-canvas/layout-grid.ts
@@ -70,3 +70,12 @@ export function resolveCards(cards: PlacedCard[], draggedId: string, columns: nu
     return r ? { ...c, col: r.col, row: r.row } : c;
   });
 }
+
+// Move an array item from index `from` to `to` (immutable). Used for group reorder.
+export function moveItem<T>(arr: T[], from: number, to: number): T[] {
+  if (from < 0 || from >= arr.length) return arr;
+  const next = arr.slice();
+  const [m] = next.splice(from, 1) as [T];
+  next.splice(Math.max(0, Math.min(to, next.length)), 0, m);
+  return next;
+}

--- a/apps/web/src/tools/form-canvas/ui.spec.tsx
+++ b/apps/web/src/tools/form-canvas/ui.spec.tsx
@@ -71,3 +71,10 @@ describe("FormCanvasTool drag threshold", () => {
     expect(card.style.gridColumn).toBe(before);
   });
 });
+
+describe("FormCanvasTool group reorder", () => {
+  it("each group has a reorder handle", () => {
+    render(<FormCanvasTool />);
+    expect(screen.getAllByRole("button", { name: /reorder group/i }).length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/apps/web/src/tools/form-canvas/ui.tsx
+++ b/apps/web/src/tools/form-canvas/ui.tsx
@@ -17,7 +17,7 @@ import {
 import { ConfigForm } from "@rfjs/form-builder-ui";
 import type { Card, Group, Kind, Component } from "./model";
 import { cardsToFormConfig, jsonToCards, cardLabel, componentDataType } from "./model";
-import { resolveCards } from "./layout-grid";
+import { resolveCards, moveItem } from "./layout-grid";
 import { SettingsPanel } from "./inspector/settings-panel";
 
 // ---------------------------------------------------------------------------
@@ -77,6 +77,10 @@ export function FormCanvasTool() {
   const [dropGroup, setDropGroup] = React.useState<string | null>(null);
   const bodyRefs = React.useRef<Record<string, HTMLDivElement | null>>({});
   const drag = React.useRef<{ id: string; mode: "move" | "resize"; col: number; span: number } | null>(null);
+  // Group reorder (drag a group header up/down): refs to each group <section>, and the
+  // live drop indicator { dragged group id, insertion index among the current order }.
+  const groupElRefs = React.useRef<Record<string, HTMLElement | null>>({});
+  const [groupDrag, setGroupDrag] = React.useState<{ id: string; overIndex: number } | null>(null);
 
   const selectedCard = cards.find((c) => c.id === selected) ?? null;
   const siblingFields = cards
@@ -90,6 +94,49 @@ export function FormCanvasTool() {
       const patched = cs.map((c) => (c.id === id ? { ...c, ...p } : c));
       return resolveCards(patched, id, COLS) as Card[];
     });
+
+  // Drag a group header up/down to reorder the group stack. Layout is unchanged
+  // during the drag (rects stay stable); we only show an insertion indicator and
+  // reorder once on drop. A bare click is ignored (DRAG_THRESHOLD), so the collapse
+  // button still works.
+  function beginGroupReorder(e: React.PointerEvent, groupId: string) {
+    e.preventDefault();
+    e.stopPropagation();
+    const startY = e.clientY;
+    let active = false;
+    // Insertion index (0..groups.length) for a given pointer Y, from the section rects.
+    const insertionAt = (clientY: number) => {
+      let ins = groups.length;
+      for (let i = 0; i < groups.length; i++) {
+        const el = groupElRefs.current[groups[i]!.id];
+        if (!el) continue;
+        const r = el.getBoundingClientRect();
+        if (clientY < r.top + r.height / 2) {
+          ins = i;
+          break;
+        }
+      }
+      return ins;
+    };
+    const onMove = (ev: PointerEvent) => {
+      if (!active && Math.abs(ev.clientY - startY) < DRAG_THRESHOLD) return;
+      active = true;
+      setGroupDrag({ id: groupId, overIndex: insertionAt(ev.clientY) });
+    };
+    const onUp = (ev: PointerEvent) => {
+      window.removeEventListener("pointermove", onMove);
+      window.removeEventListener("pointerup", onUp);
+      if (active) {
+        const from = groups.findIndex((g) => g.id === groupId);
+        const ins = insertionAt(ev.clientY);
+        const to = ins > from ? ins - 1 : ins;
+        if (from >= 0 && from !== to) setGroups((gs) => moveItem(gs, from, to));
+      }
+      setGroupDrag(null);
+    };
+    window.addEventListener("pointermove", onMove);
+    window.addEventListener("pointerup", onUp);
+  }
 
   function updateCard(id: string, p: Partial<Card>) {
     setCards((cs) =>
@@ -288,23 +335,35 @@ export function FormCanvasTool() {
           <div className="flex flex-col gap-4 lg:flex-row lg:items-start">
             <div className="min-w-0 flex-1" onPointerDown={() => setSelected(null)}>
               <div className="flex flex-col gap-4">
-                {groups.map((group) => (
-                  <GroupFrame
-                    key={group.id}
-                    group={group}
-                    cards={cards.filter((c) => c.groupId === group.id)}
-                    selected={selected}
-                    dropOver={dropGroup === group.id}
-                    bodyRef={(el) => {
-                      bodyRefs.current[group.id] = el;
-                    }}
-                    onToggle={() =>
-                      setGroups((gs) => gs.map((g) => (g.id === group.id ? { ...g, collapsed: !g.collapsed } : g)))
-                    }
-                    onMoveStart={beginDrag}
-                    onResizeStart={beginDrag}
-                  />
+                {groups.map((group, index) => (
+                  <React.Fragment key={group.id}>
+                    {groupDrag && groupDrag.id !== group.id && groupDrag.overIndex === index ? (
+                      <div data-testid="group-drop-line" className="-my-1.5 h-0.5 rounded-full bg-[#5b8cff]" />
+                    ) : null}
+                    <GroupFrame
+                      group={group}
+                      cards={cards.filter((c) => c.groupId === group.id)}
+                      selected={selected}
+                      dropOver={dropGroup === group.id}
+                      dragging={groupDrag?.id === group.id}
+                      sectionRef={(el) => {
+                        groupElRefs.current[group.id] = el;
+                      }}
+                      bodyRef={(el) => {
+                        bodyRefs.current[group.id] = el;
+                      }}
+                      onToggle={() =>
+                        setGroups((gs) => gs.map((g) => (g.id === group.id ? { ...g, collapsed: !g.collapsed } : g)))
+                      }
+                      onReorderStart={beginGroupReorder}
+                      onMoveStart={beginDrag}
+                      onResizeStart={beginDrag}
+                    />
+                  </React.Fragment>
                 ))}
+                {groupDrag && groupDrag.overIndex === groups.length ? (
+                  <div data-testid="group-drop-line" className="-my-1.5 h-0.5 rounded-full bg-[#5b8cff]" />
+                ) : null}
               </div>
             </div>
 
@@ -383,8 +442,11 @@ function GroupFrame({
   cards,
   selected,
   dropOver,
+  dragging,
+  sectionRef,
   bodyRef,
   onToggle,
+  onReorderStart,
   onMoveStart,
   onResizeStart,
 }: {
@@ -392,8 +454,11 @@ function GroupFrame({
   cards: Card[];
   selected: string | null;
   dropOver: boolean;
+  dragging: boolean;
+  sectionRef: (el: HTMLElement | null) => void;
   bodyRef: (el: HTMLDivElement | null) => void;
   onToggle: () => void;
+  onReorderStart: (e: React.PointerEvent, groupId: string) => void;
   onMoveStart: (e: React.PointerEvent, card: Card, mode: "move") => void;
   onResizeStart: (e: React.PointerEvent, card: Card, mode: "resize") => void;
 }) {
@@ -401,11 +466,20 @@ function GroupFrame({
   const rows = Math.max(maxRow + 1, 2);
   return (
     <section
-      className={`overflow-hidden rounded-xl border bg-card/20 transition-colors ${
+      ref={sectionRef}
+      className={`overflow-hidden rounded-xl border bg-card/20 transition-[border,opacity] ${
         dropOver ? "border-[#5b8cff]/70 ring-1 ring-[#5b8cff]/40" : "border-border"
-      }`}
+      } ${dragging ? "opacity-50" : ""}`}
     >
-      <header className="flex items-center gap-2.5 border-b border-border bg-muted/40 px-3 py-2.5">
+      <header className="flex items-center gap-2 border-b border-border bg-muted/40 px-3 py-2.5">
+        <button
+          type="button"
+          aria-label="reorder group"
+          onPointerDown={(e) => onReorderStart(e, group.id)}
+          className="flex size-6 shrink-0 cursor-grab touch-none items-center justify-center rounded-md text-muted-foreground/50 hover:text-foreground active:cursor-grabbing"
+        >
+          <GripVertical className="size-4" />
+        </button>
         <button
           type="button"
           aria-label={group.collapsed ? "expand" : "collapse"}


### PR DESCRIPTION
Two form-canvas polish items.

## 1. Drag-reorder groups
Each group header gets a **grip handle**; drag it up/down to reorder the group stack. A pointer **threshold** (4px) keeps a bare click toggling collapse; during the drag an **insertion line** shows the drop spot, and the reorder happens on release via a pure `moveItem(arr, from, to)` (unit-tested). Layout stays stable during the drag (rects don't move), so targeting is reliable.

## 2. Inspector discoverability
Previously every advanced section was collapsed, so the config "looked" empty until you scrolled + expanded each. Now:
- **Common sections open by default**: Basics, Validation, Options, Conditional.
- **Advanced stay collapsed** (Data Source, AI Note, Labels) but show a **"has content" badge** — a count (Validation rules, Options) or a dot (Conditional, Data Source, AI Note, multi-locale Labels) — so set config is visible at a glance. (`Section` gained an optional `badge` prop.)

## Verification
- Full form-canvas suite: **50/50** (added: `moveItem` reorder, reorder-handle present, Validation-open-by-default, Options count badge). `check-types` clean.
- Screenshot-verified: grip handles on group headers; inspector opens common sections on select.

Builds on the merged form-canvas tool (#207–#212).