### PR TITLE
fix(web): form-builder tabs render cramped — add form-builder-ui @source

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -1,8 +1,10 @@
 @import "@rfjs/web-ui/globals.css";
 
-/* @rfjs/filter-builder-ui ships its own Tailwind classes (the filter-tree
-   editor) that this app renders via transpilePackages. Tailwind only generates
-   CSS for classes it can find by scanning source, so its src must be an
-   explicit @source — otherwise classes unique to that package (e.g. the
-   condition-row grid, the logic badges) produce no CSS. */
+/* @rfjs/filter-builder-ui and @rfjs/form-builder-ui ship their own Tailwind
+   classes (the filter-tree editor / the form builder + its tabs) rendered here
+   via transpilePackages. Tailwind only generates CSS for classes it can find by
+   scanning source, so each package src must be an explicit @source — otherwise
+   classes unique to a package (the condition-row grid, the logic badges, or the
+   form-builder's `px-3.5` tab control) produce no CSS. */
 @source "../../../../packages/filter-builder-ui/src";
+@source "../../../../packages/form-builder-ui/src";


### PR DESCRIPTION
## Bug
The form-builder tool's **Builder | Preview | JSON** tab selector rendered cramped (no padding between tabs), while the form-canvas tool's identical-looking selector was properly spaced.

## Cause
`apps/web/src/app/globals.css` only declared `@source` for `@rfjs/filter-builder-ui`, not `@rfjs/form-builder-ui`. Tailwind only generates CSS for classes it finds by scanning source. The form-builder tab buttons use `px-3.5`, a class used **only** inside `@rfjs/form-builder-ui` (form-canvas uses `px-3`, which apps/web emits). With no `@source` for that package, `px-3.5` was never generated → the tab buttons had zero horizontal padding.

## Fix
Add `@source "../../../../packages/form-builder-ui/src";` so the package's unique classes are emitted. The form-builder tabs now match the form-canvas tabs (verified by screenshot before/after). This also covers any other form-builder-ui-only classes that were silently dropped.

No code/logic change — one CSS source directive + comment.