### PR TITLE
feat(form-designer): responsive preview + live submission

### DIFF
--- a/.changeset/form-preview-enhancements.md
+++ b/.changeset/form-preview-enhancements.md
@@ -1,0 +1,10 @@
+---
+"@rfjs/form-builder": minor
+"@rfjs/form-builder-ui": minor
+---
+
+Form preview enhancements.
+
+`@rfjs/form-builder`: add `FormConfig.responsive.stackBelow` — the container-width breakpoint (px) below which the form collapses to a single column.
+
+`@rfjs/form-builder-ui`: `ConfigForm` now reflows by **container** width (ResizeObserver-driven via the new `useContainerBreakpoint` hook; configurable `stackBelow`, default 640) — grid-mode and flow layouts collapse to a single column on narrow containers, so linear forms become container-responsive too. New live `onPayloadChange` seam emits `{ data, meta: SubmissionMeta }` (validated over the currently-visible fields, matching submit).

--- a/.superpowers/sdd/task-3-report.md
+++ b/.superpowers/sdd/task-3-report.md
@@ -1,110 +1,92 @@
-# Task 3 Report: `<TagInput>` Component (`@rfjs/web-ui`)
+# Task 3 Report: ConfigForm Container-Responsive Collapse
 
 ## Status: DONE
 
-## Commits
-
-| SHA | Subject |
-|-----|---------|
-| `1e00950` | `feat(web-ui): add TagInput (options + creatable) built on command/popover` |
-
-## TDD Cycle
-
-### RED
-
-Installed `@testing-library/user-event` (not previously in web-ui):
-```
-pnpm --filter @rfjs/web-ui add -D @testing-library/user-event
-```
-
-Wrote `packages/web-ui/src/components/tag-input.spec.tsx` with 3 tests from the brief (verbatim, except `toBeInTheDocument` → `toBeDefined` — see Concerns).
-
-```
-pnpm -F @rfjs/web-ui vitest:run src/components/tag-input.spec.tsx
-# FAIL — Cannot find module './tag-input' (expected)
-```
-
-### GREEN
-
-Implemented `packages/web-ui/src/components/tag-input.tsx` composed from:
-- `Command`/`CommandList`/`CommandGroup`/`CommandItem` (`command.tsx`)
-- `Popover`/`PopoverTrigger`/`PopoverContent` (`popover.tsx`)
-
-Key design decision: dual-UI approach to satisfy both test constraints simultaneously:
-- `creatable`: inline `<input type="text">` always in DOM → `getByRole("textbox")` works without clicking
-- `options`: `PopoverTrigger` renders a `<button>` → `getByRole("button")` works; content opens in Popover
-
-```
-pnpm -F @rfjs/web-ui vitest:run src/components/tag-input.spec.tsx
-# PASS — 3/3 tests
-```
-
-### Full Suite
-
-```
-pnpm -F @rfjs/web-ui vitest:run
-# 38 passed, 16 test files, 0 failures, 0 regressions
-```
-
-## Files Changed
-
-| File | Action |
-|------|--------|
-| `packages/web-ui/src/components/tag-input.tsx` | Created |
-| `packages/web-ui/src/components/tag-input.spec.tsx` | Created |
-| `packages/web-ui/package.json` | Added `@testing-library/user-event` devDep |
-| `pnpm-lock.yaml` | Updated |
-
-Note: No `index.ts` created — the package uses wildcard exports (`"./components/*": "./src/components/*.tsx"`), so `TagInput` is auto-accessible as `@rfjs/web-ui/components/tag-input` without a barrel file.
-
-## Self-Review
-
-- **Accessibility**: Chips have `aria-label="Remove <label>"` buttons; popover trigger has `aria-label="Open tag options"`.
-- **Deduplication**: Both `handleSelect` (options path) and `handleKeyDown` (creatable path) guard `!value.includes(...)`.
-- **jsdom compatibility**: No new stubs needed — Radix Popover opened correctly with `userEvent.click` using the existing `ResizeObserver`/`scrollIntoView` stubs in `vitest.setup.ts`.
-- **No new runtime deps**: uses only `cmdk` + `radix-ui` already present.
-
-## Concerns
-
-1. **`toBeInTheDocument`**: Brief used this jest-dom matcher, but the project doesn't configure `@testing-library/jest-dom` (other tests all use `toBeDefined()`). Changed to `toBeDefined()` — semantically equivalent since RTL's `getByText` throws when not found.
-2. **No barrel export**: The brief mentioned modifying `packages/web-ui/src/index.ts`, but that file doesn't exist in this package. The wildcard exports handle discoverability automatically.
-3. **All-selected empty state**: When all options are already in `value`, the `CommandList` is empty. No `CommandEmpty` placeholder — minor UX gap, not in spec.
+**Commit:** `f1e2e2e feat(form-builder-ui): container-driven responsive collapse (ResizeObserver + stackBelow)`
 
 ---
 
-## Review Fix (2026-06-30)
+## What Was Implemented
 
-### Finding 1 — CommandInput inside Popover (remove bare always-visible input)
+### Files Modified
+- `packages/form-builder-ui/src/config-form.tsx` — implementation
+- `packages/form-builder-ui/src/config-form.spec.tsx` — new responsive tests (4 cases in `responsive container collapse` describe block)
 
-Refactored `tag-input.tsx`:
-- Removed the standalone `<input type="text">` that was always-visible for the `creatable` case.
-- `showTrigger = hasOptions || creatable` — the chevron trigger now appears whenever the popover has content (options, free-type, or both).
-- `CommandInput` (with `value`, `onValueChange`, `onKeyDown`) lives inside the `PopoverContent`'s `Command` block — the only text field is the one inside the Popover.
-- Creatable Enter handler moved to `handleInputKeyDown` on `CommandInput`'s `onKeyDown`; calls `e.preventDefault()` to prevent cmdk from also acting on the event.
-- Added `CommandEmpty` ("No options.") so the empty-list state has feedback.
-- Dropped the `options!` non-null assertion; `availableOptions` is derived from `hasOptions ? options.filter(...) : []` so the guard is implicit.
+### Implementation Details
 
-### Finding 2 — Test the remove interaction (Test 3 replaced)
+1. **Container ref + breakpoint hook** — added `rootRef` (`useRef<HTMLFormElement|null>`), `stackBelow = config.responsive?.stackBelow ?? 640`, and `narrow = useContainerBreakpoint(rootRef, stackBelow)` at the top of `ConfigForm`. Attached `ref={rootRef}` to the `<form>` element.
 
-Replaced the label-presence assertion with a real interaction test:
-- Renders with `value={['a']}` and `options={[{ label: 'Alpha', value: 'a' }]}`.
-- Clicks `aria-label="Remove Alpha"` button.
-- Asserts `onChange` was called with `[]`.
-- Renamed to "removes a chip and emits the remaining array".
+2. **Outer form grid** — replaced `className="grid grid-cols-1 gap-4 md:[…]"` (viewport-based) with `className="grid gap-4"` and moved columns to inline style: `gridTemplateColumns: narrow ? '1fr' : 'repeat(var(--form-cols), minmax(0, 1fr))'`. The `--form-cols` CSS custom property is kept.
 
-### Also (cheap)
+3. **Grid-mode section grid** (where `section.layout` exists) — `gridTemplateColumns: narrow ? '1fr' : \`repeat(${layout.columns}, minmax(0, 1fr))\``. When narrow, items are sorted by `(row, colStart)` from the placement map (copy, no mutation) before mapping so single-column stack order equals visual reading order.
 
-- Added **disabled test**: renders with `disabled` + `options`, clicks the trigger button, asserts `onChange` was never called.
-- Updated **creatable test**: clicks trigger to open Popover first, then finds the `combobox` role (`CommandInput` renders as cmdk combobox), types `custom{Enter}`.
-- All button queries use `{ name: '...' }` for specificity.
-- No new jsdom stubs needed — existing `ResizeObserver` + `scrollIntoView` stubs cover Radix + cmdk.
+4. **Flow-section row grid** — `gridTemplateColumns: narrow ? '1fr' : \`repeat(${sectionCols}, minmax(0, 1fr))\``.
 
-### Test run
+5. **Item-level style overrides** — `placementStyle` and `fieldSpanStyle` both accept an `isNarrow` boolean; when true they return `{ gridColumn: '1 / -1' }`. `renderItem` gains an `isNarrow = false` parameter, threaded through from every call site.
+
+---
+
+## TDD RED → GREEN
+
+### RED phase
+```
+pnpm -F @rfjs/form-builder build && pnpm -F @rfjs/form-builder-ui vitest:run src/config-form.spec.tsx
+```
+Result: **3 failed | 39 passed** — new responsive tests failed as expected (grid still used viewport `md:` class, not container-driven logic).
+
+### GREEN phase (after implementation)
+```
+pnpm -F @rfjs/form-builder-ui vitest:run src/config-form.spec.tsx
+```
+Result: **42 passed (42)** — all new + pre-existing tests pass.
+
+### Full regression suite
+```
+pnpm -F @rfjs/form-builder-ui vitest:run
+```
+Result: **230 passed (230)** across 10 test files. All v1/linear/existing tests remain green.
+
+---
+
+## Self-Review
+
+- **No viewport breakpoints remain** — the `md:[…]` arbitrary Tailwind variant has been fully removed. All responsiveness is now container-driven via `ResizeObserver`.
+- **No mutation of `items` array** — grid-mode sort uses `[...allItems].sort(…)`.
+- **`stackBelow` default 640** — matches spec §4 and brief.
+- **v1 back-compat** — v1 `fields[]` path does not pass `isNarrow` to `renderItem` (uses default `false`), so v1 single-column forms are completely unaffected.
+- **SSR-safe** — `useContainerBreakpoint` initialises `narrow=false`; no hydration mismatch risk.
+- **`--form-cols` custom property preserved** — kept in the inline style map for downstream CSS targeting.
+
+## Concerns
+
+None. Implementation is straightforward, no ambiguous forks encountered, all 230 tests green.
+
+---
+
+## Review Findings Fix (post-implementation)
+
+### Finding A — Orphaned-item sort fallback (Important)
+
+**Resolution:** Changed `?? 0` to `?? Number.MAX_SAFE_INTEGER` for both `row` and `colStart` fallbacks in the narrow-mode sort inside `sortedGridItems` (`config-form.tsx` line 259). Items without a placement now sort to the end rather than floating to the top before all 1-indexed placed items.
+
+**New test added:** `"orphaned items (no placement) sort after all placed items in narrow mode"` — a grid section with one placed item (row 1) and one orphan (no placement); after `fireWidth(400)` the placed item is first in the DOM.
+
+### Finding B — Wide test never exercised narrow→wide restoration (Confirmed test gap)
+
+**Resolution:** Rewrote the `"keeps multi-column layout when container is wide"` test to fire `fireWidth(400)` first (asserting `gridTemplateColumns === '1fr'`), then `fireWidth(900)` (asserting `repeat(` restored and item `gridColumn` is `'1 / span 7'`). The hook no longer bails without first crossing the narrow threshold.
+
+### Finding C — Module-level `_roCb` shared state (Minor, test hygiene)
+
+**Resolution:** Removed the module-level `_roCb` variable. `installResizeObserverMock()` now holds `roCb` as a closure variable and returns `{ fireWidth }`. All call sites inside `responsive container collapse` destructure `fireWidth` from the return value.
+
+### Test command and result
 
 ```
-pnpm -F @rfjs/web-ui vitest:run src/components/tag-input.spec.tsx
-# 4 passed (4)
-
-pnpm -F @rfjs/web-ui vitest:run
-# Test Files  16 passed (16) | Tests  39 passed (39)
+pnpm -F @rfjs/form-builder-ui vitest:run src/config-form.spec.tsx
 ```
+Result: **43 passed (43)** — 1 new test added (Finding A); Finding B and C were existing-test changes only.
+
+```
+pnpm -F @rfjs/form-builder-ui vitest:run
+```
+Result: **231 passed (231)** across 10 test files. No regressions.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -42,6 +42,7 @@
     "@tailwindcss/postcss": "^4.3.0",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^25.9.3",
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",

--- a/apps/web/src/tools/form-designer/responsive-preview.spec.tsx
+++ b/apps/web/src/tools/form-designer/responsive-preview.spec.tsx
@@ -9,7 +9,7 @@ if (typeof Element !== "undefined") {
 }
 
 import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { ResponsivePreview } from "./responsive-preview";
 
@@ -25,7 +25,7 @@ describe("ResponsivePreview", () => {
     expect(onWidthChange).toHaveBeenCalledWith(375);
   });
 
-  it("number input clamps to [min,max]", async () => {
+  it("number input clamps to max when above range", async () => {
     const onWidthChange = vi.fn();
     render(
       <ResponsivePreview width={500} min={320} max={1280} onWidthChange={onWidthChange}>
@@ -36,6 +36,18 @@ describe("ResponsivePreview", () => {
     await userEvent.clear(num);
     await userEvent.type(num, "99999");
     expect(onWidthChange).toHaveBeenLastCalledWith(1280);
+  });
+
+  it("number input clamps to min when below range", () => {
+    const onWidthChange = vi.fn();
+    render(
+      <ResponsivePreview width={500} min={320} max={1280} onWidthChange={onWidthChange}>
+        <div />
+      </ResponsivePreview>,
+    );
+    const num = screen.getByRole("spinbutton");
+    fireEvent.change(num, { target: { value: "10" } });
+    expect(onWidthChange).toHaveBeenLastCalledWith(320);
   });
 
   it("renders children inside a width-constrained frame", () => {
@@ -82,7 +94,7 @@ describe("ResponsivePreview", () => {
     expect(onWidthChange).toHaveBeenCalledWith(1440);
   });
 
-  it("range slider clamps value to [min, max]", async () => {
+  it("range slider clamps value to max when above range", () => {
     const onWidthChange = vi.fn();
     render(
       <ResponsivePreview width={500} min={320} max={1280} onWidthChange={onWidthChange}>
@@ -90,7 +102,20 @@ describe("ResponsivePreview", () => {
       </ResponsivePreview>,
     );
     const slider = screen.getByRole("slider");
-    expect(slider).toBeDefined();
+    fireEvent.change(slider, { target: { value: "99999" } });
+    expect(onWidthChange).toHaveBeenLastCalledWith(1280);
+  });
+
+  it("range slider clamps value to min when below range", () => {
+    const onWidthChange = vi.fn();
+    render(
+      <ResponsivePreview width={500} min={320} max={1280} onWidthChange={onWidthChange}>
+        <div />
+      </ResponsivePreview>,
+    );
+    const slider = screen.getByRole("slider");
+    fireEvent.change(slider, { target: { value: "10" } });
+    expect(onWidthChange).toHaveBeenLastCalledWith(320);
   });
 
   it("displays current width label", () => {
@@ -102,13 +127,23 @@ describe("ResponsivePreview", () => {
     expect(screen.getByText(/640/)).toBeDefined();
   });
 
-  it("compact mode renders without errors", () => {
+  it("compact mode uses xs size on preset buttons", () => {
     render(
       <ResponsivePreview width={375} onWidthChange={() => {}} compact>
         <div data-testid="compact-child" />
       </ResponsivePreview>,
     );
-    expect(screen.getByTestId("rp-frame")).toBeDefined();
-    expect(screen.getByTestId("compact-child")).toBeDefined();
+    const mobileBtn = screen.getByRole("button", { name: /mobile/i });
+    expect(mobileBtn.getAttribute("data-size")).toBe("xs");
+  });
+
+  it("non-compact mode uses sm size on preset buttons", () => {
+    render(
+      <ResponsivePreview width={375} onWidthChange={() => {}}>
+        <div />
+      </ResponsivePreview>,
+    );
+    const mobileBtn = screen.getByRole("button", { name: /mobile/i });
+    expect(mobileBtn.getAttribute("data-size")).toBe("sm");
   });
 });

--- a/apps/web/src/tools/form-designer/responsive-preview.spec.tsx
+++ b/apps/web/src/tools/form-designer/responsive-preview.spec.tsx
@@ -146,4 +146,14 @@ describe("ResponsivePreview", () => {
     const mobileBtn = screen.getByRole("button", { name: /mobile/i });
     expect(mobileBtn.getAttribute("data-size")).toBe("sm");
   });
+
+  it("rp-frame has a visible border class to show device-width boundary", () => {
+    render(
+      <ResponsivePreview width={400} onWidthChange={() => {}}>
+        <div />
+      </ResponsivePreview>,
+    );
+    const frame = screen.getByTestId("rp-frame");
+    expect(frame.className).toMatch(/border/);
+  });
 });

--- a/apps/web/src/tools/form-designer/responsive-preview.spec.tsx
+++ b/apps/web/src/tools/form-designer/responsive-preview.spec.tsx
@@ -1,0 +1,114 @@
+// jsdom shim for pointer events used by the drag handle
+if (typeof Element !== "undefined") {
+  if (!Element.prototype.setPointerCapture) {
+    Element.prototype.setPointerCapture = () => {};
+  }
+  if (!Element.prototype.releasePointerCapture) {
+    Element.prototype.releasePointerCapture = () => {};
+  }
+}
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ResponsivePreview } from "./responsive-preview";
+
+describe("ResponsivePreview", () => {
+  it("preset button sets width", async () => {
+    const onWidthChange = vi.fn();
+    render(
+      <ResponsivePreview width={1100} onWidthChange={onWidthChange}>
+        <div>form</div>
+      </ResponsivePreview>,
+    );
+    await userEvent.click(screen.getByRole("button", { name: /mobile/i }));
+    expect(onWidthChange).toHaveBeenCalledWith(375);
+  });
+
+  it("number input clamps to [min,max]", async () => {
+    const onWidthChange = vi.fn();
+    render(
+      <ResponsivePreview width={500} min={320} max={1280} onWidthChange={onWidthChange}>
+        <div />
+      </ResponsivePreview>,
+    );
+    const num = screen.getByRole("spinbutton");
+    await userEvent.clear(num);
+    await userEvent.type(num, "99999");
+    expect(onWidthChange).toHaveBeenLastCalledWith(1280);
+  });
+
+  it("renders children inside a width-constrained frame", () => {
+    render(
+      <ResponsivePreview width={400} onWidthChange={() => {}}>
+        <div data-testid="kid" />
+      </ResponsivePreview>,
+    );
+    const frame = screen.getByTestId("rp-frame");
+    expect(frame.style.width).toBe("400px");
+    expect(screen.getByTestId("kid")).toBeDefined();
+  });
+
+  it("tablet preset calls onWidthChange with 768", async () => {
+    const onWidthChange = vi.fn();
+    render(
+      <ResponsivePreview width={375} onWidthChange={onWidthChange}>
+        <div />
+      </ResponsivePreview>,
+    );
+    await userEvent.click(screen.getByRole("button", { name: /tablet/i }));
+    expect(onWidthChange).toHaveBeenCalledWith(768);
+  });
+
+  it("desktop preset calls onWidthChange with max (default 1280)", async () => {
+    const onWidthChange = vi.fn();
+    render(
+      <ResponsivePreview width={375} onWidthChange={onWidthChange}>
+        <div />
+      </ResponsivePreview>,
+    );
+    await userEvent.click(screen.getByRole("button", { name: /desktop/i }));
+    expect(onWidthChange).toHaveBeenCalledWith(1280);
+  });
+
+  it("desktop preset uses custom max when provided", async () => {
+    const onWidthChange = vi.fn();
+    render(
+      <ResponsivePreview width={375} max={1440} onWidthChange={onWidthChange}>
+        <div />
+      </ResponsivePreview>,
+    );
+    await userEvent.click(screen.getByRole("button", { name: /desktop/i }));
+    expect(onWidthChange).toHaveBeenCalledWith(1440);
+  });
+
+  it("range slider clamps value to [min, max]", async () => {
+    const onWidthChange = vi.fn();
+    render(
+      <ResponsivePreview width={500} min={320} max={1280} onWidthChange={onWidthChange}>
+        <div />
+      </ResponsivePreview>,
+    );
+    const slider = screen.getByRole("slider");
+    expect(slider).toBeDefined();
+  });
+
+  it("displays current width label", () => {
+    render(
+      <ResponsivePreview width={640} onWidthChange={() => {}}>
+        <div />
+      </ResponsivePreview>,
+    );
+    expect(screen.getByText(/640/)).toBeDefined();
+  });
+
+  it("compact mode renders without errors", () => {
+    render(
+      <ResponsivePreview width={375} onWidthChange={() => {}} compact>
+        <div data-testid="compact-child" />
+      </ResponsivePreview>,
+    );
+    expect(screen.getByTestId("rp-frame")).toBeDefined();
+    expect(screen.getByTestId("compact-child")).toBeDefined();
+  });
+});

--- a/apps/web/src/tools/form-designer/responsive-preview.tsx
+++ b/apps/web/src/tools/form-designer/responsive-preview.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+import * as React from "react";
+import { Button } from "@rfjs/web-ui/components/button";
+import { Input } from "@rfjs/web-ui/components/input";
+import { cn } from "@rfjs/web-ui/lib/utils";
+
+// ---------------------------------------------------------------------------
+// ResponsivePreview
+// A width-constrained frame for previewing a form at device widths.
+// ---------------------------------------------------------------------------
+
+export interface ResponsivePreviewProps {
+  children: React.ReactNode;
+  width: number;
+  onWidthChange: (w: number) => void;
+  min?: number;
+  max?: number;
+  compact?: boolean;
+}
+
+const MOBILE_WIDTH = 375;
+const TABLET_WIDTH = 768;
+const DEFAULT_MAX = 1280;
+const DEFAULT_MIN = 320;
+
+export function ResponsivePreview({
+  children,
+  width,
+  onWidthChange,
+  min = DEFAULT_MIN,
+  max = DEFAULT_MAX,
+  compact = false,
+}: ResponsivePreviewProps): JSX.Element {
+  const clamp = (v: number) => Math.max(min, Math.min(max, v));
+
+  const PRESETS = [
+    { label: "Mobile", value: MOBILE_WIDTH },
+    { label: "Tablet", value: TABLET_WIDTH },
+    { label: "Desktop", value: max },
+  ] as const;
+
+  // Drag handle: right edge of the frame
+  const frameRef = React.useRef<HTMLDivElement>(null);
+  const dragRef = React.useRef<{ startX: number; startWidth: number } | null>(null);
+
+  function beginDrag(e: React.PointerEvent<HTMLDivElement>) {
+    e.preventDefault();
+    e.stopPropagation();
+    dragRef.current = { startX: e.clientX, startWidth: width };
+    (e.currentTarget as HTMLDivElement).setPointerCapture(e.pointerId);
+
+    const onMove = (ev: PointerEvent) => {
+      if (!dragRef.current) return;
+      const delta = ev.clientX - dragRef.current.startX;
+      onWidthChange(clamp(dragRef.current.startWidth + delta));
+    };
+    const onUp = () => {
+      dragRef.current = null;
+      window.removeEventListener("pointermove", onMove);
+      window.removeEventListener("pointerup", onUp);
+    };
+    window.addEventListener("pointermove", onMove);
+    window.addEventListener("pointerup", onUp);
+  }
+
+  function handleNumberInput(e: React.ChangeEvent<HTMLInputElement>) {
+    const raw = parseInt(e.target.value, 10);
+    if (!isNaN(raw)) {
+      onWidthChange(clamp(raw));
+    }
+  }
+
+  function handleNumberBlur(e: React.FocusEvent<HTMLInputElement>) {
+    const raw = parseInt(e.target.value, 10);
+    if (isNaN(raw)) {
+      onWidthChange(clamp(width));
+    } else {
+      onWidthChange(clamp(raw));
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      {/* Controls row */}
+      <div
+        className={cn(
+          "flex flex-wrap items-center gap-2",
+          compact && "gap-1",
+        )}
+      >
+        {/* Device presets */}
+        {PRESETS.map((preset) => (
+          <Button
+            key={preset.label}
+            type="button"
+            variant="outline"
+            size={compact ? "sm" : "sm"}
+            onClick={() => onWidthChange(clamp(preset.value))}
+            aria-pressed={width === preset.value}
+            className={cn(
+              "font-mono text-xs",
+              width === preset.value && "border-blue-500 text-blue-600",
+            )}
+          >
+            {preset.label}
+          </Button>
+        ))}
+
+        <div className="flex items-center gap-2">
+          {/* Range slider */}
+          <input
+            type="range"
+            role="slider"
+            min={min}
+            max={max}
+            value={width}
+            onChange={(e) => onWidthChange(clamp(parseInt(e.target.value, 10)))}
+            className={cn(
+              "w-28 accent-blue-500",
+              compact && "w-20",
+            )}
+            aria-label="Preview width"
+          />
+
+          {/* Number input (spinbutton) */}
+          <Input
+            type="number"
+            role="spinbutton"
+            min={min}
+            max={max}
+            value={width}
+            onChange={handleNumberInput}
+            onBlur={handleNumberBlur}
+            className={cn(
+              "w-20 font-mono text-xs",
+              compact && "w-16",
+            )}
+            aria-label="Preview width in pixels"
+          />
+
+          {/* Current-width label */}
+          <span className={cn("font-mono text-xs text-muted-foreground", compact && "text-[11px]")}>
+            {width}px
+          </span>
+        </div>
+      </div>
+
+      {/* Preview frame with right-drag handle */}
+      <div className="relative overflow-hidden">
+        {/* The constrained frame */}
+        <div
+          ref={frameRef}
+          data-testid="rp-frame"
+          style={{ width: `${width}px`, maxWidth: "100%", margin: "0 auto" }}
+        >
+          {children}
+        </div>
+
+        {/* Right-edge drag handle — positioned over the right border of the frame */}
+        <div
+          aria-label="Resize width"
+          onPointerDown={beginDrag}
+          style={{
+            position: "absolute",
+            top: 0,
+            bottom: 0,
+            // offset to align with the right edge of the frame (centered in parent)
+            right: `calc(50% - ${Math.min(width, 9999) / 2}px - 4px)`,
+          }}
+          className="flex w-3 cursor-col-resize touch-none items-center justify-center"
+        >
+          <div className="h-10 w-1 rounded-full bg-border hover:bg-blue-400 transition-colors" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/tools/form-designer/responsive-preview.tsx
+++ b/apps/web/src/tools/form-designer/responsive-preview.tsx
@@ -31,7 +31,7 @@ export function ResponsivePreview({
   min = DEFAULT_MIN,
   max = DEFAULT_MAX,
   compact = false,
-}: ResponsivePreviewProps): JSX.Element {
+}: ResponsivePreviewProps): React.JSX.Element {
   const clamp = (v: number) => Math.max(min, Math.min(max, v));
 
   const PRESETS = [

--- a/apps/web/src/tools/form-designer/responsive-preview.tsx
+++ b/apps/web/src/tools/form-designer/responsive-preview.tsx
@@ -41,7 +41,6 @@ export function ResponsivePreview({
   ] as const;
 
   // Drag handle: right edge of the frame
-  const frameRef = React.useRef<HTMLDivElement>(null);
   const dragRef = React.useRef<{ startX: number; startWidth: number } | null>(null);
 
   function beginDrag(e: React.PointerEvent<HTMLDivElement>) {
@@ -95,7 +94,7 @@ export function ResponsivePreview({
             key={preset.label}
             type="button"
             variant="outline"
-            size={compact ? "sm" : "sm"}
+            size={compact ? "xs" : "sm"}
             onClick={() => onWidthChange(clamp(preset.value))}
             aria-pressed={width === preset.value}
             className={cn(
@@ -111,7 +110,6 @@ export function ResponsivePreview({
           {/* Range slider */}
           <input
             type="range"
-            role="slider"
             min={min}
             max={max}
             value={width}
@@ -126,7 +124,6 @@ export function ResponsivePreview({
           {/* Number input (spinbutton) */}
           <Input
             type="number"
-            role="spinbutton"
             min={min}
             max={max}
             value={width}
@@ -150,7 +147,6 @@ export function ResponsivePreview({
       <div className="relative overflow-hidden">
         {/* The constrained frame */}
         <div
-          ref={frameRef}
           data-testid="rp-frame"
           style={{ width: `${width}px`, maxWidth: "100%", margin: "0 auto" }}
         >

--- a/apps/web/src/tools/form-designer/responsive-preview.tsx
+++ b/apps/web/src/tools/form-designer/responsive-preview.tsx
@@ -148,6 +148,7 @@ export function ResponsivePreview({
         {/* The constrained frame */}
         <div
           data-testid="rp-frame"
+          className={cn("rounded-lg border border-border bg-background p-4 shadow-sm")}
           style={{ width: `${width}px`, maxWidth: "100%", margin: "0 auto" }}
         >
           {children}

--- a/apps/web/src/tools/form-designer/submission-panel.spec.tsx
+++ b/apps/web/src/tools/form-designer/submission-panel.spec.tsx
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { SubmissionPanel } from "./submission-panel";
+import type { SubmissionMeta } from "@rfjs/form-builder-ui";
+
+describe("SubmissionPanel", () => {
+  it("renders data and meta; shows valid state", () => {
+    const meta: SubmissionMeta = { valid: true, errors: {}, visibleKeys: ["name"] };
+    render(
+      <SubmissionPanel
+        payload={{ data: { name: "Ann" }, meta }}
+      />,
+    );
+    expect(screen.getByText(/"name": "Ann"/)).toBeDefined();
+    expect(screen.getByText(/valid/i)).toBeDefined();
+  });
+
+  it("shows invalid + errors", () => {
+    const meta: SubmissionMeta = { valid: false, errors: { name: "Required" }, visibleKeys: [] };
+    render(
+      <SubmissionPanel
+        payload={{ data: {}, meta }}
+      />,
+    );
+    expect(screen.getByText(/Required/)).toBeDefined();
+  });
+
+  it("renders empty-state when payload is null", () => {
+    render(<SubmissionPanel payload={null} />);
+    expect(screen.getByText(/fill the form/i)).toBeDefined();
+  });
+});

--- a/apps/web/src/tools/form-designer/submission-panel.spec.tsx
+++ b/apps/web/src/tools/form-designer/submission-panel.spec.tsx
@@ -19,7 +19,7 @@ describe("SubmissionPanel", () => {
     const meta: SubmissionMeta = { valid: false, errors: { name: "Required" }, visibleKeys: [] };
     render(
       <SubmissionPanel
-        payload={{ data: {}, meta }}
+        payload={{ data: { name: "filled" }, meta }}
       />,
     );
     expect(screen.getByText(/Required/)).toBeDefined();
@@ -28,5 +28,59 @@ describe("SubmissionPanel", () => {
   it("renders empty-state when payload is null", () => {
     render(<SubmissionPanel payload={null} />);
     expect(screen.getByText(/fill the form/i)).toBeDefined();
+  });
+
+  it("translates 'Expected string, received undefined' error to 'Required' when errors are shown", () => {
+    // name is filled (form has data) → errors list is shown → "Required" should appear
+    const meta: SubmissionMeta = {
+      valid: false,
+      errors: { email: "Expected string, received undefined" },
+      visibleKeys: ["name", "email"],
+    };
+    render(
+      <SubmissionPanel
+        payload={{ data: { name: "Ann", email: undefined }, meta }}
+      />,
+    );
+    // Should NOT show the raw zod message
+    expect(screen.queryByText(/Expected string, received undefined/)).toBeNull();
+    // Should show the friendly label instead
+    expect(screen.getByText(/Required/)).toBeDefined();
+  });
+
+  it("shows calm Incomplete state when valid=false and all data values are empty/undefined", () => {
+    const meta: SubmissionMeta = {
+      valid: false,
+      errors: { name: "Expected string, received undefined", email: "Expected string, received undefined" },
+      visibleKeys: [],
+    };
+    render(
+      <SubmissionPanel
+        payload={{ data: {}, meta }}
+      />,
+    );
+    // Should show the amber Incomplete message, not red "Invalid"
+    expect(screen.getByText(/incomplete/i)).toBeDefined();
+    // Should include the count of required fields (2)
+    expect(screen.getByText(/2 required field/i)).toBeDefined();
+    // Should NOT show "Invalid"
+    expect(screen.queryByText(/^Invalid$/i)).toBeNull();
+  });
+
+  it("shows red Invalid badge when valid=false but form has actual data", () => {
+    const meta: SubmissionMeta = {
+      valid: false,
+      errors: { email: "Invalid email format" },
+      visibleKeys: ["name", "email"],
+    };
+    render(
+      <SubmissionPanel
+        payload={{ data: { name: "Ann", email: "not-an-email" }, meta }}
+      />,
+    );
+    // Has real data → real validation failure → show Invalid
+    expect(screen.getByText("Invalid")).toBeDefined();
+    // Friendly error message shown
+    expect(screen.getByText(/Invalid email format/)).toBeDefined();
   });
 });

--- a/apps/web/src/tools/form-designer/submission-panel.tsx
+++ b/apps/web/src/tools/form-designer/submission-panel.tsx
@@ -14,6 +14,17 @@ export interface SubmissionPanelProps {
   compact?: boolean;
 }
 
+/** Translate raw zod type messages to a user-friendly label. */
+function friendlyError(msg: string): string {
+  if (/received undefined/i.test(msg)) return "Required";
+  return msg;
+}
+
+/** Returns true when every value in data is null/undefined/empty-string. */
+function isAllEmpty(data: Record<string, unknown>): boolean {
+  return Object.values(data).every((v) => v === undefined || v === null || v === "");
+}
+
 export function SubmissionPanel({ payload, compact = false }: SubmissionPanelProps): React.JSX.Element {
   if (payload === null) {
     return (
@@ -33,6 +44,11 @@ export function SubmissionPanel({ payload, compact = false }: SubmissionPanelPro
   const { data, meta } = payload;
   const { valid, errors, visibleKeys, schemaVersion } = meta;
 
+  // When the form is invalid but completely untouched/empty, show a neutral Incomplete state
+  // instead of the alarming red Invalid badge + raw error dump.
+  const errorCount = Object.keys(errors).length;
+  const showIncomplete = !valid && errorCount > 0 && isAllEmpty(data);
+
   return (
     <div className={cn("flex flex-col gap-4", compact && "gap-2")}>
       {/* Metadata Block */}
@@ -46,28 +62,39 @@ export function SubmissionPanel({ payload, compact = false }: SubmissionPanelPro
           Metadata
         </h3>
 
-        {/* Valid Badge */}
+        {/* Status Badge */}
         <div className={cn("flex items-center gap-2", compact && "mb-2")}>
-          <span
-            className={cn(
-              "inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium",
-              valid
-                ? "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200"
-                : "bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200",
-            )}
-          >
-            {valid ? "Valid" : "Invalid"}
-          </span>
+          {showIncomplete ? (
+            <span
+              className={cn(
+                "inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium",
+                "bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200",
+              )}
+            >
+              {`Incomplete — ${errorCount} required field${errorCount === 1 ? "" : "s"} not yet filled`}
+            </span>
+          ) : (
+            <span
+              className={cn(
+                "inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium",
+                valid
+                  ? "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200"
+                  : "bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200",
+              )}
+            >
+              {valid ? "Valid" : "Invalid"}
+            </span>
+          )}
         </div>
 
-        {/* Errors List */}
-        {Object.keys(errors).length > 0 && (
+        {/* Errors List — only shown when NOT in the calm Incomplete state */}
+        {!showIncomplete && errorCount > 0 && (
           <div className={cn("mb-3 space-y-1", compact && "mb-2 space-y-0.5")}>
             <p className="text-xs font-medium text-muted-foreground">Errors:</p>
             <ul className="space-y-0.5 text-xs">
               {Object.entries(errors).map(([key, error]) => (
                 <li key={key} className="text-red-600 dark:text-red-400">
-                  <span className="font-mono font-medium">{key}</span>: {error}
+                  <span className="font-mono font-medium">{key}</span>: {friendlyError(error)}
                 </li>
               ))}
             </ul>

--- a/apps/web/src/tools/form-designer/submission-panel.tsx
+++ b/apps/web/src/tools/form-designer/submission-panel.tsx
@@ -14,7 +14,7 @@ export interface SubmissionPanelProps {
   compact?: boolean;
 }
 
-export function SubmissionPanel({ payload, compact = false }: SubmissionPanelProps): JSX.Element {
+export function SubmissionPanel({ payload, compact = false }: SubmissionPanelProps): React.JSX.Element {
   if (payload === null) {
     return (
       <div

--- a/apps/web/src/tools/form-designer/submission-panel.tsx
+++ b/apps/web/src/tools/form-designer/submission-panel.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import * as React from "react";
+import type { SubmissionMeta } from "@rfjs/form-builder-ui";
+import { cn } from "@rfjs/web-ui/lib/utils";
+
+// ---------------------------------------------------------------------------
+// SubmissionPanel
+// Displays submission payload (data + meta) or an empty state when null.
+// ---------------------------------------------------------------------------
+
+export interface SubmissionPanelProps {
+  payload: { data: Record<string, unknown>; meta: SubmissionMeta } | null;
+  compact?: boolean;
+}
+
+export function SubmissionPanel({ payload, compact = false }: SubmissionPanelProps): JSX.Element {
+  if (payload === null) {
+    return (
+      <div
+        className={cn(
+          "flex h-full items-center justify-center rounded-lg border border-dashed border-border bg-muted/30 p-4",
+          compact && "p-2",
+        )}
+      >
+        <p className={cn("text-sm text-muted-foreground", compact && "text-xs")}>
+          Fill the form
+        </p>
+      </div>
+    );
+  }
+
+  const { data, meta } = payload;
+  const { valid, errors, visibleKeys, schemaVersion } = meta;
+
+  return (
+    <div className={cn("flex flex-col gap-4", compact && "gap-2")}>
+      {/* Metadata Block */}
+      <div
+        className={cn(
+          "rounded-lg border border-border bg-card p-4",
+          compact && "p-3",
+        )}
+      >
+        <h3 className={cn("mb-3 font-semibold text-foreground", compact && "mb-2 text-sm")}>
+          Metadata
+        </h3>
+
+        {/* Valid Badge */}
+        <div className={cn("flex items-center gap-2", compact && "mb-2")}>
+          <span
+            className={cn(
+              "inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium",
+              valid
+                ? "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200"
+                : "bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200",
+            )}
+          >
+            {valid ? "Valid" : "Invalid"}
+          </span>
+        </div>
+
+        {/* Errors List */}
+        {Object.keys(errors).length > 0 && (
+          <div className={cn("mb-3 space-y-1", compact && "mb-2 space-y-0.5")}>
+            <p className="text-xs font-medium text-muted-foreground">Errors:</p>
+            <ul className="space-y-0.5 text-xs">
+              {Object.entries(errors).map(([key, error]) => (
+                <li key={key} className="text-red-600 dark:text-red-400">
+                  <span className="font-mono font-medium">{key}</span>: {error}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {/* Visible Keys */}
+        {visibleKeys.length > 0 && (
+          <div className={cn("mb-3 space-y-1", compact && "mb-2 space-y-0.5")}>
+            <p className="text-xs font-medium text-muted-foreground">Visible Keys:</p>
+            <p className={cn("font-mono text-xs text-foreground", compact && "text-[11px]")}>
+              {visibleKeys.join(", ")}
+            </p>
+          </div>
+        )}
+
+        {/* Schema Version */}
+        {schemaVersion !== undefined && (
+          <div className="space-y-1">
+            <p className="text-xs font-medium text-muted-foreground">Schema Version:</p>
+            <p className={cn("font-mono text-xs text-foreground", compact && "text-[11px]")}>
+              {schemaVersion}
+            </p>
+          </div>
+        )}
+      </div>
+
+      {/* Data Block */}
+      <div
+        className={cn(
+          "rounded-lg border border-border bg-card p-4",
+          compact && "p-3",
+        )}
+      >
+        <h3 className={cn("mb-3 font-semibold text-foreground", compact && "mb-2 text-sm")}>
+          Data
+        </h3>
+        <pre
+          className={cn(
+            "overflow-auto rounded bg-muted p-2 font-mono text-xs text-foreground",
+            compact && "text-[10px]",
+          )}
+        >
+          {JSON.stringify(data, null, 2)}
+        </pre>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/tools/form-designer/ui.spec.tsx
+++ b/apps/web/src/tools/form-designer/ui.spec.tsx
@@ -98,11 +98,35 @@ describe("FormDesignerTool preview tab integration", () => {
     expect(screen.getByRole("button", { name: /^mobile$/i })).toBeTruthy();
     expect(screen.getByRole("button", { name: /^tablet$/i })).toBeTruthy();
     expect(screen.getByRole("button", { name: /^desktop$/i })).toBeTruthy();
-    // SubmissionPanel is mounted: shows empty state ("Fill the form") before onPayloadChange fires,
-    // or the "Metadata" heading after the initial payload is emitted. Either proves the panel is present.
-    const hasPanel =
-      screen.queryByText(/fill the form/i) !== null ||
-      screen.queryByText(/metadata/i) !== null;
-    expect(hasPanel).toBe(true);
+    // SubmissionPanel is mounted inside a collapsed "Submission" section —
+    // the section toggle button is always present even when collapsed.
+    expect(screen.getByRole("button", { name: /submission/i })).toBeTruthy();
+  });
+
+  it("Preview tab uses vertical stack layout (no lg:flex-row)", () => {
+    render(<FormDesignerTool />);
+    fireEvent.click(screen.getByRole("button", { name: /^preview$/i }));
+    // The preview tab wrapper must NOT have lg:flex-row — find the rp-frame and walk up
+    const frame = screen.getByTestId("rp-frame");
+    // Walk up to the direct parent of ResponsivePreview root and check no lg:flex-row in the chain
+    let el: HTMLElement | null = frame.parentElement;
+    let foundFlexRow = false;
+    while (el && !el.classList.contains("form-designer-root")) {
+      if (el.className.includes("lg:flex-row")) {
+        foundFlexRow = true;
+        break;
+      }
+      el = el.parentElement;
+    }
+    expect(foundFlexRow).toBe(false);
+  });
+
+  it("Preview tab wraps SubmissionPanel in a collapsible Submission section (collapsed by default)", () => {
+    render(<FormDesignerTool />);
+    fireEvent.click(screen.getByRole("button", { name: /^preview$/i }));
+    // "Submission" section header should be present
+    expect(screen.getByRole("button", { name: /submission/i })).toBeTruthy();
+    // Section is collapsed by default: the inner panel content (Metadata heading) is NOT in the DOM
+    expect(screen.queryByText(/^metadata$/i)).toBeNull();
   });
 });

--- a/apps/web/src/tools/form-designer/ui.spec.tsx
+++ b/apps/web/src/tools/form-designer/ui.spec.tsx
@@ -78,3 +78,31 @@ describe("FormDesignerTool group reorder", () => {
     expect(screen.getAllByRole("button", { name: /reorder group/i }).length).toBeGreaterThanOrEqual(2);
   });
 });
+
+describe("FormDesignerTool canvas collapsible sections", () => {
+  it("Canvas tab has two independent collapsible sections: Editor and Live Preview", () => {
+    render(<FormDesignerTool />);
+    // Canvas is the default tab — both section headers should be present
+    expect(screen.getByRole("button", { name: /editor/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /live preview/i })).toBeTruthy();
+    // Live Preview is collapsed by default: Mobile preset button is inside its content → not in DOM
+    expect(screen.queryByRole("button", { name: /^mobile$/i })).toBeNull();
+  });
+});
+
+describe("FormDesignerTool preview tab integration", () => {
+  it("Preview tab renders ResponsivePreview with device controls + a submission panel", () => {
+    render(<FormDesignerTool />);
+    fireEvent.click(screen.getByRole("button", { name: /^preview$/i }));
+    // Device preset buttons from ResponsivePreview
+    expect(screen.getByRole("button", { name: /^mobile$/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /^tablet$/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /^desktop$/i })).toBeTruthy();
+    // SubmissionPanel is mounted: shows empty state ("Fill the form") before onPayloadChange fires,
+    // or the "Metadata" heading after the initial payload is emitted. Either proves the panel is present.
+    const hasPanel =
+      screen.queryByText(/fill the form/i) !== null ||
+      screen.queryByText(/metadata/i) !== null;
+    expect(hasPanel).toBe(true);
+  });
+});

--- a/apps/web/src/tools/form-designer/ui.tsx
+++ b/apps/web/src/tools/form-designer/ui.tsx
@@ -23,11 +23,15 @@ import {
 } from "lucide-react";
 
 import { ConfigForm } from "@rfjs/form-builder-ui";
+import type { SubmissionMeta } from "@rfjs/form-builder-ui";
 import type { Card, Group, Kind, Component } from "./model";
 import { cardsToFormConfig, jsonToCards, cardLabel, componentDataType, formConfigToCards } from "./model";
 import { SAMPLE_CONFIG, sampleFetcher, sampleUploader } from "../form-builder/sample";
 import { resolveCards, moveItem } from "./layout-grid";
 import { SettingsPanel } from "./inspector/settings-panel";
+import { Section } from "./inspector/section";
+import { ResponsivePreview } from "./responsive-preview";
+import { SubmissionPanel } from "./submission-panel";
 
 // ---------------------------------------------------------------------------
 // Direction C (hybrid) — "A structure + C drag freedom", now with a builder
@@ -115,6 +119,9 @@ export function FormDesignerTool() {
   const [selected, setSelected] = React.useState<string | null>(null);
   const [tab, setTab] = React.useState<"canvas" | "preview" | "json">("canvas");
   const [jsonError, setJsonError] = React.useState<string | null>(null);
+  const [payload, setPayload] = React.useState<{ data: Record<string, unknown>; meta: SubmissionMeta } | null>(null);
+  const [previewW, setPreviewW] = React.useState(1100);
+  const [canvasW, setCanvasW] = React.useState(390);
   const [copied, setCopied] = React.useState(false);
   const [dropGroup, setDropGroup] = React.useState<string | null>(null);
   const bodyRefs = React.useRef<Record<string, HTMLDivElement | null>>({});
@@ -128,7 +135,9 @@ export function FormDesignerTool() {
   const siblingFields = cards
     .filter((c) => c.kind === "field" && c.id !== selectedCard?.id && c.key)
     .map((c) => ({ key: c.key!, dataType: componentDataType(c.component) }));
-  const formConfig = cardsToFormConfig(groups, cards);
+  // Memoize to keep a stable reference: onPayloadChange fires on config changes,
+  // so an unstable formConfig would create an infinite re-render loop.
+  const formConfig = React.useMemo(() => cardsToFormConfig(groups, cards), [groups, cards]);
 
   // Apply a drag/resize patch to the dragged card, then resolve overlaps (push + compact up).
   const placeDragged = (id: string, p: Partial<Card>) =>
@@ -385,78 +394,108 @@ export function FormDesignerTool() {
             </div>
           </div>
 
-          {/* Canvas + inspector (RWD: stacks below lg) */}
-          <div className="flex flex-col gap-4 lg:flex-row lg:items-start">
-            <div className="min-w-0 flex-1" onPointerDown={() => setSelected(null)}>
-              <div className="flex flex-col gap-4">
-                {groups.map((group, index) => (
-                  <React.Fragment key={group.id}>
-                    {groupDrag && groupDrag.id !== group.id && groupDrag.overIndex === index ? (
-                      <div data-testid="group-drop-line" className="-my-1.5 h-0.5 rounded-full bg-[#5b8cff]" />
-                    ) : null}
-                    <GroupFrame
-                      group={group}
-                      cards={cards.filter((c) => c.groupId === group.id)}
-                      selected={selected}
-                      dropOver={dropGroup === group.id}
-                      dragging={groupDrag?.id === group.id}
-                      sectionRef={(el) => {
-                        groupElRefs.current[group.id] = el;
-                      }}
-                      bodyRef={(el) => {
-                        bodyRefs.current[group.id] = el;
-                      }}
-                      onToggle={() =>
-                        setGroups((gs) => gs.map((g) => (g.id === group.id ? { ...g, collapsed: !g.collapsed } : g)))
-                      }
-                      onReorderStart={beginGroupReorder}
-                      onMoveStart={beginDrag}
-                      onResizeStart={beginDrag}
-                    />
-                  </React.Fragment>
-                ))}
-                {groupDrag && groupDrag.overIndex === groups.length ? (
-                  <div data-testid="group-drop-line" className="-my-1.5 h-0.5 rounded-full bg-[#5b8cff]" />
-                ) : null}
+          {/* Section 1: Editor (default expanded) */}
+          <Section title="Editor" defaultOpen={true}>
+            {/* Canvas + inspector (RWD: stacks below lg) */}
+            <div className="flex flex-col gap-4 lg:flex-row lg:items-start">
+              <div className="min-w-0 flex-1" onPointerDown={() => setSelected(null)}>
+                <div className="flex flex-col gap-4">
+                  {groups.map((group, index) => (
+                    <React.Fragment key={group.id}>
+                      {groupDrag && groupDrag.id !== group.id && groupDrag.overIndex === index ? (
+                        <div data-testid="group-drop-line" className="-my-1.5 h-0.5 rounded-full bg-[#5b8cff]" />
+                      ) : null}
+                      <GroupFrame
+                        group={group}
+                        cards={cards.filter((c) => c.groupId === group.id)}
+                        selected={selected}
+                        dropOver={dropGroup === group.id}
+                        dragging={groupDrag?.id === group.id}
+                        sectionRef={(el) => {
+                          groupElRefs.current[group.id] = el;
+                        }}
+                        bodyRef={(el) => {
+                          bodyRefs.current[group.id] = el;
+                        }}
+                        onToggle={() =>
+                          setGroups((gs) => gs.map((g) => (g.id === group.id ? { ...g, collapsed: !g.collapsed } : g)))
+                        }
+                        onReorderStart={beginGroupReorder}
+                        onMoveStart={beginDrag}
+                        onResizeStart={beginDrag}
+                      />
+                    </React.Fragment>
+                  ))}
+                  {groupDrag && groupDrag.overIndex === groups.length ? (
+                    <div data-testid="group-drop-line" className="-my-1.5 h-0.5 rounded-full bg-[#5b8cff]" />
+                  ) : null}
+                </div>
               </div>
-            </div>
 
-            <aside className="shrink-0 lg:w-[420px]">
-              {/* Mobile: full-screen sheet when a card is selected; Desktop: inline column. */}
-              <div
-                className={
-                  selectedCard
-                    ? "fixed inset-0 z-30 overflow-y-auto bg-background p-4 lg:static lg:z-auto lg:bg-transparent lg:p-0"
-                    : "hidden lg:block"
-                }
-              >
-                {selectedCard ? (
-                  <button
-                    type="button"
-                    onClick={() => setSelected(null)}
-                    className="mb-3 text-xs text-muted-foreground hover:text-foreground lg:hidden"
-                  >
-                    ← Back to canvas
-                  </button>
-                ) : null}
-                <SettingsPanel
-                  card={selectedCard}
-                  groups={groups}
-                  siblingFields={siblingFields}
-                  onChange={(p) => selectedCard && updateCard(selectedCard.id, p)}
-                  onRemove={() => {
-                    if (!selectedCard) return;
-                    setCards((cs) => resolveCards(cs.filter((c) => c.id !== selectedCard.id) as Card[], "", COLS) as Card[]);
-                    setSelected(null);
-                  }}
+              <aside className="shrink-0 lg:w-[420px]">
+                {/* Mobile: full-screen sheet when a card is selected; Desktop: inline column. */}
+                <div
+                  className={
+                    selectedCard
+                      ? "fixed inset-0 z-30 overflow-y-auto bg-background p-4 lg:static lg:z-auto lg:bg-transparent lg:p-0"
+                      : "hidden lg:block"
+                  }
+                >
+                  {selectedCard ? (
+                    <button
+                      type="button"
+                      onClick={() => setSelected(null)}
+                      className="mb-3 text-xs text-muted-foreground hover:text-foreground lg:hidden"
+                    >
+                      ← Back to canvas
+                    </button>
+                  ) : null}
+                  <SettingsPanel
+                    card={selectedCard}
+                    groups={groups}
+                    siblingFields={siblingFields}
+                    onChange={(p) => selectedCard && updateCard(selectedCard.id, p)}
+                    onRemove={() => {
+                      if (!selectedCard) return;
+                      setCards((cs) => resolveCards(cs.filter((c) => c.id !== selectedCard.id) as Card[], "", COLS) as Card[]);
+                      setSelected(null);
+                    }}
+                  />
+                </div>
+              </aside>
+            </div>
+          </Section>
+
+          {/* Section 2: Live Preview (default collapsed) */}
+          <Section title="Live Preview" defaultOpen={false}>
+            <div className="flex flex-col gap-4">
+              <ResponsivePreview compact width={canvasW} onWidthChange={setCanvasW}>
+                <ConfigForm
+                  config={formConfig}
+                  locale="en"
+                  fetcher={sampleFetcher}
+                  uploadHandler={sampleUploader}
+                  onPayloadChange={setPayload}
+                  onSubmit={() => {}}
                 />
-              </div>
-            </aside>
-          </div>
+              </ResponsivePreview>
+              <SubmissionPanel compact payload={payload} />
+            </div>
+          </Section>
         </>
       ) : tab === "preview" ? (
-        <div className="rounded-xl border border-border bg-card/30 p-6">
-          <ConfigForm config={formConfig} locale="en" fetcher={sampleFetcher} uploadHandler={sampleUploader} onSubmit={() => {}} />
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-start">
+          <ResponsivePreview width={previewW} onWidthChange={setPreviewW}>
+            <ConfigForm
+              config={formConfig}
+              locale="en"
+              fetcher={sampleFetcher}
+              uploadHandler={sampleUploader}
+              onPayloadChange={setPayload}
+              onSubmit={() => {}}
+            />
+          </ResponsivePreview>
+          <SubmissionPanel payload={payload} />
         </div>
       ) : (
         <div className="flex flex-col gap-2">

--- a/apps/web/src/tools/form-designer/ui.tsx
+++ b/apps/web/src/tools/form-designer/ui.tsx
@@ -484,7 +484,7 @@ export function FormDesignerTool() {
           </Section>
         </>
       ) : tab === "preview" ? (
-        <div className="flex flex-col gap-4 lg:flex-row lg:items-start">
+        <div className="flex flex-col gap-4">
           <ResponsivePreview width={previewW} onWidthChange={setPreviewW}>
             <ConfigForm
               config={formConfig}
@@ -495,7 +495,9 @@ export function FormDesignerTool() {
               onSubmit={() => {}}
             />
           </ResponsivePreview>
-          <SubmissionPanel payload={payload} />
+          <Section title="Submission" defaultOpen={false}>
+            <SubmissionPanel payload={payload} />
+          </Section>
         </div>
       ) : (
         <div className="flex flex-col gap-2">

--- a/docs/superpowers/plans/2026-06-30-form-designer-preview-enhancements.md
+++ b/docs/superpowers/plans/2026-06-30-form-designer-preview-enhancements.md
@@ -1,0 +1,443 @@
+# Form Designer Preview 強化 實作計劃
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 讓 form-designer 產出的表單依「容器寬」真正響應式 reflow,並提供裝置/手動寬度的預覽、Canvas 內可收合的即時預覽、以及即時(watch 驅動)的送出資料 Submission 面板。
+
+**Architecture:** `@rfjs/form-builder-ui` 的 `ConfigForm` 改用 ResizeObserver 量容器寬、依可配置門檻 `stackBelow`(預設 640)塌縮;新增 `onPayloadChange` seam 即時吐出 `{data, meta}`。`apps/web` form-designer 新增共用 `<ResponsivePreview>` 與 `<SubmissionPanel>`,Preview 頁籤用完整版、Canvas 頁改成 Editor / Live Preview 兩段獨立收合。
+
+**Tech Stack:** TypeScript、zod v4、React、react-hook-form、ResizeObserver、Vitest、Tailwind v4、`@rfjs/web-ui`。
+
+完整設計見 spec:`docs/superpowers/specs/2026-06-30-form-designer-preview-enhancements-design.md`。建立在 #216(已 merge,main `42b26e6`)之上。
+
+## Global Constraints
+
+- 測試:Vitest,`*.spec.ts(x)` 同層;每包 `pnpm -F <pkg> vitest:run <path>`。
+- fresh worktree 先 `pnpm install` + `pnpm build:packages`;改 `@rfjs/form-builder` 後要 `pnpm -F @rfjs/form-builder build` 再跑 UI 測試。
+- 門檻 `stackBelow` **預設 640**;來源 `config.responsive?.stackBelow`。
+- reflow 一律由**容器寬**(ResizeObserver)驅動,不用 viewport media query、不用 iframe。SSR/未量到前 = 寬版(`narrow=false`)。
+- `dataType` enum 不新增成員;`responsive` 為 additive optional。
+- Submission 面板放響應式框**外**;即時(watch),不靠 Submit。
+- ② 動作/按鈕模型不在本計劃;`onPayloadChange` 的 `meta` 預留給它擴充。
+- commit/PR 英文(conventional,結尾 `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`);本計劃/spec 繁中。
+- HOLD PR —— 使用者自行 merge。
+
+---
+
+## Task 1: 引擎 `FormConfig.responsive.stackBelow`
+
+**Files:**
+- Modify: `packages/form-builder/src/types.ts`
+- Modify: `packages/form-builder/src/config-schema.ts`
+- Test: `packages/form-builder/src/config-schema.spec.ts`
+
+**Interfaces:**
+- Produces:`FormConfig.responsive?: { stackBelow?: number }`;schema 驗證並 round-trip。
+
+- [ ] **Step 1: 寫失敗測試**
+```ts
+it("accepts and round-trips responsive.stackBelow", () => {
+  const cfg = { version: 1, sections: [{ id: "s", title: "S", rows: [] }], responsive: { stackBelow: 540 } };
+  const parsed = formConfigSchema.parse(cfg as any);
+  expect(parsed.responsive?.stackBelow).toBe(540);
+  expect(JSON.parse(JSON.stringify(parsed))).toEqual(cfg);
+});
+it("allows omitting responsive", () => {
+  expect(formConfigSchema.safeParse({ version: 1, sections: [{ id: "s", title: "S", rows: [] }] }).success).toBe(true);
+});
+```
+
+- [ ] **Step 2: 跑測試確認失敗**
+Run: `pnpm -F @rfjs/form-builder vitest:run src/config-schema.spec.ts`
+Expected: FAIL(`responsive` 被 strip / 不認得)。
+
+- [ ] **Step 3: 實作**
+- `types.ts`:`FormConfig` interface 加 `responsive?: { stackBelow?: number };`
+- `config-schema.ts`:`FormConfigSchema` 物件加 `responsive: z.object({ stackBelow: z.number().positive().optional() }).optional(),`
+
+- [ ] **Step 4: 跑測試確認通過 + 全包**
+Run: `pnpm -F @rfjs/form-builder vitest:run` → PASS。然後 `pnpm -F @rfjs/form-builder build`(產 dist 供下游)。
+
+- [ ] **Step 5: Commit**
+```bash
+git add packages/form-builder/src/types.ts packages/form-builder/src/config-schema.ts packages/form-builder/src/config-schema.spec.ts
+git commit -m "feat(form-builder): add FormConfig.responsive.stackBelow"
+```
+
+---
+
+## Task 2: `useContainerBreakpoint` hook
+
+**Files:**
+- Create: `packages/form-builder-ui/src/use-container-breakpoint.ts`
+- Test: `packages/form-builder-ui/src/use-container-breakpoint.spec.ts`
+
+**Interfaces:**
+- Produces:`useContainerBreakpoint(ref: React.RefObject<HTMLElement>, breakpoint: number): boolean`(容器寬 < breakpoint → true;SSR/未量到 → false;只在跨門檻時更新 state)。
+
+- [ ] **Step 1: 寫失敗測試**
+```tsx
+import { renderHook, act } from "@testing-library/react";
+import * as React from "react";
+import { useContainerBreakpoint } from "./use-container-breakpoint";
+
+// 可控 ResizeObserver mock:捕捉 callback,讓測試手動觸發
+let cb: (e: any[]) => void;
+beforeEach(() => {
+  cb = () => {};
+  (globalThis as any).ResizeObserver = class {
+    constructor(c: any) { cb = c; }
+    observe() {} disconnect() {}
+  };
+});
+
+it("starts false (SSR-safe) and flips when width < breakpoint", () => {
+  const ref = { current: document.createElement("div") } as React.RefObject<HTMLElement>;
+  const { result } = renderHook(() => useContainerBreakpoint(ref, 640));
+  expect(result.current).toBe(false);
+  act(() => cb([{ contentRect: { width: 500 } }]));
+  expect(result.current).toBe(true);
+  act(() => cb([{ contentRect: { width: 800 } }]));
+  expect(result.current).toBe(false);
+});
+```
+
+- [ ] **Step 2: 跑測試確認失敗**
+Run: `pnpm -F @rfjs/form-builder-ui vitest:run src/use-container-breakpoint.spec.ts`
+Expected: FAIL(模組不存在)。
+
+- [ ] **Step 3: 實作**
+```ts
+import * as React from "react";
+export function useContainerBreakpoint(ref: React.RefObject<HTMLElement>, breakpoint: number): boolean {
+  const [narrow, setNarrow] = React.useState(false);
+  React.useEffect(() => {
+    const el = ref.current;
+    if (!el || typeof ResizeObserver === "undefined") return;
+    const ro = new ResizeObserver((entries) => {
+      const w = entries[0]?.contentRect?.width ?? el.clientWidth;
+      setNarrow((prev) => (prev === w < breakpoint ? prev : w < breakpoint));
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [ref, breakpoint]);
+  return narrow;
+}
+```
+
+- [ ] **Step 4: 跑測試確認通過**
+Run: `pnpm -F @rfjs/form-builder-ui vitest:run src/use-container-breakpoint.spec.ts` → PASS。
+
+- [ ] **Step 5: Commit**
+```bash
+git add packages/form-builder-ui/src/use-container-breakpoint.ts packages/form-builder-ui/src/use-container-breakpoint.spec.ts
+git commit -m "feat(form-builder-ui): add useContainerBreakpoint (ResizeObserver, SSR-safe)"
+```
+
+---
+
+## Task 3: ConfigForm 容器響應式塌縮(R)
+
+**Files:**
+- Modify: `packages/form-builder-ui/src/config-form.tsx`
+- Test: `packages/form-builder-ui/src/config-form.spec.tsx`
+
+**Interfaces:**
+- Consumes:Task 1 `config.responsive.stackBelow`、Task 2 `useContainerBreakpoint`。
+- Produces:ConfigForm 在容器寬 < `stackBelow` 時:外層 grid、grid-mode section grid、flow section grid 皆塌成單欄;grid-mode items 以 (row, colStart) 順序堆疊、`gridColumn` 收為 `1 / -1`。
+
+- [ ] **Step 1: 寫失敗測試**(用可控 ResizeObserver mock,如 Task 2)
+```tsx
+it("collapses grid-mode section to single column when container is narrow", () => {
+  // render 一個含 layout.placements 的 section(2 個 items:colStart 1/7,colSpan 6)
+  // 觸發 ResizeObserver width=400(<640)
+  // 斷言:section grid 的 inline gridTemplateColumns === "1fr",且兩個 item 的 gridColumn === "1 / -1"
+});
+it("keeps multi-column when wide (>= stackBelow)", () => {
+  // width=900 → gridTemplateColumns 含 "repeat(", item 維持 placement 的 span
+});
+it("honors config.responsive.stackBelow override", () => {
+  // stackBelow=480;width=520 → 仍寬版(不塌);width=400 → 塌
+});
+```
+(用 `data-testid="form-grid"`(config-form.tsx 既有,line 263)定位 section grid;item 用 `data-key`/`data-testid` 取 inline style。)
+
+- [ ] **Step 2: 跑測試確認失敗**
+Run: `pnpm -F @rfjs/form-builder build && pnpm -F @rfjs/form-builder-ui vitest:run src/config-form.spec.tsx`
+Expected: FAIL(目前用 `md:` 視窗、內層寫死,不依容器塌)。
+
+- [ ] **Step 3: 實作 config-form.tsx**
+- 取得門檻與 narrow:
+```ts
+const rootRef = React.useRef<HTMLFormElement | null>(null);
+const stackBelow = config.responsive?.stackBelow ?? 640;
+const narrow = useContainerBreakpoint(rootRef as React.RefObject<HTMLElement>, stackBelow);
+```
+- `<form ref={rootRef} …>`。
+- 外層 grid(目前 `className="grid grid-cols-1 gap-4 md:[grid-template-columns:repeat(var(--form-cols),minmax(0,1fr))]"`,line 243):移除 `md:[…]`,className 留 `"grid gap-4"`,改 inline:
+```ts
+style={{ gridTemplateColumns: narrow ? "1fr" : "repeat(var(--form-cols), minmax(0, 1fr))", ["--form-cols" as any]: String(columns) }}
+```
+- grid-mode section grid(line 265):`gridTemplateColumns: narrow ? "1fr" : \`repeat(${layout.columns}, minmax(0, 1fr))\``。並於 narrow 時依 placement 排序 items 後再 map:
+```ts
+const ordered = narrow
+  ? [...items].sort((a, b) => { const pa = byId.get(a.id), pb = byId.get(b.id);
+      return (pa?.row ?? 0) - (pb?.row ?? 0) || (pa?.colStart ?? 0) - (pb?.colStart ?? 0); })
+  : items;
+```
+- flow section grid(line 286):`gridTemplateColumns: narrow ? "1fr" : \`repeat(${sectionCols}, minmax(0, 1fr))\``。
+- `renderItem` / `placementStyle`(line 137-141)與 `fieldSpanStyle`:narrow 時忽略 placement 與 span,套 `{ gridColumn: "1 / -1" }`(把 `narrow` 傳進 renderItem,或在呼叫端覆寫 style)。
+
+- [ ] **Step 4: 跑測試確認通過 + 回歸**
+Run: `pnpm -F @rfjs/form-builder-ui vitest:run`
+Expected: 新測試 PASS;既有 config-form / form-builder 測試全綠(線性表單寬版仍多欄)。
+
+- [ ] **Step 5: Commit**
+```bash
+git add packages/form-builder-ui/src/config-form.tsx packages/form-builder-ui/src/config-form.spec.tsx
+git commit -m "feat(form-builder-ui): container-driven responsive collapse (ResizeObserver + stackBelow)"
+```
+
+---
+
+## Task 4: ConfigForm `computePayload` + `onPayloadChange`(①)
+
+**Files:**
+- Modify: `packages/form-builder-ui/src/config-form.tsx`
+- Modify: `packages/form-builder-ui/src/config-form-builder.tsx`
+- Test: `packages/form-builder-ui/src/config-form.spec.tsx`
+
+**Interfaces:**
+- Produces:
+```ts
+export interface SubmissionMeta { valid: boolean; errors: Record<string, string>; visibleKeys: string[]; schemaVersion?: number; }
+// ConfigFormProps 加:
+onPayloadChange?: (p: { data: Record<string, unknown>; meta: SubmissionMeta }) => void;
+```
+  `computePayload(values, config) => Record<string, unknown>`(由現有 submit handler 抽出);`ConfigFormBuilder` 轉發 `onPayloadChange`。
+
+- [ ] **Step 1: 寫失敗測試**
+```tsx
+it("emits live payload (data + meta) on value change without submit", async () => {
+  const onPayloadChange = vi.fn();
+  // render ConfigForm(含一個 required Name)+ onPayloadChange
+  // 在 Name 輸入 "Ann"
+  // 斷言:onPayloadChange 最後一次的 arg.data.name === "Ann";arg.meta.valid 為 true/false 隨驗證
+});
+it("excludes conditionally-hidden fields from payload + visibleKeys", async () => {
+  // 一個 conditional 欄位被隱藏 → data 不含其 key、meta.visibleKeys 不含它
+});
+it("meta.valid false + errors when required empty", () => {
+  // 未填 required → meta.valid === false 且 errors 含該 key
+});
+```
+
+- [ ] **Step 2: 跑測試確認失敗**
+Run: `pnpm -F @rfjs/form-builder-ui vitest:run src/config-form.spec.tsx`
+Expected: FAIL(無 `onPayloadChange`)。
+
+- [ ] **Step 3: 實作**
+- 把目前 submit handler(line 233-241)建 `out` 的邏輯抽成模組層純函式 `computePayload(values: Record<string, unknown>, config: FormConfig): Record<string, unknown>`(保留 conditional 過濾與形狀);`onSubmit` 改呼叫 `onSubmit(computePayload(all, config))`。
+- 加 prop `onPayloadChange?`;用 `useWatch({ control })` 取即時值,`React.useEffect` 在值變動時:
+```ts
+const data = computePayload(values, config);
+const parsed = schema.safeParse(data); // schema = configToZod(config),沿用 resolver 已建的
+const errors: Record<string,string> = {};
+if (!parsed.success) for (const i of parsed.error.issues) { const k = String(i.path[0]); if (k && !errors[k]) errors[k] = i.message; }
+onPayloadChange?.({ data, meta: { valid: parsed.success, errors, visibleKeys: Object.keys(data), schemaVersion: config.version } });
+```
+- `config-form-builder.tsx`:`ConfigFormBuilderProps` 加 `onPayloadChange?`,在預覽 `<ConfigForm>` 轉發(比照 `fetcher`)。export `SubmissionMeta` 於 `index.ts`。
+
+- [ ] **Step 4: 跑測試確認通過 + 全包**
+Run: `pnpm -F @rfjs/form-builder-ui vitest:run` → PASS(含回歸)。
+
+- [ ] **Step 5: Commit**
+```bash
+git add packages/form-builder-ui/src/config-form.tsx packages/form-builder-ui/src/config-form-builder.tsx packages/form-builder-ui/src/config-form.spec.tsx packages/form-builder-ui/src/index.ts
+git commit -m "feat(form-builder-ui): live onPayloadChange seam (data + submission meta)"
+```
+
+---
+
+## Task 5: `<ResponsivePreview>` 元件
+
+**Files:**
+- Create: `apps/web/src/tools/form-designer/responsive-preview.tsx`
+- Create: `apps/web/src/tools/form-designer/responsive-preview.spec.tsx`
+
+**Interfaces:**
+- Produces:
+```ts
+export interface ResponsivePreviewProps {
+  children: React.ReactNode; width: number; onWidthChange: (w: number) => void;
+  min?: number; max?: number; compact?: boolean;
+}
+export function ResponsivePreview(props: ResponsivePreviewProps): JSX.Element;
+```
+
+- [ ] **Step 1: 寫失敗測試**
+```tsx
+it("preset button sets width", async () => {
+  const onWidthChange = vi.fn();
+  render(<ResponsivePreview width={1100} onWidthChange={onWidthChange}><div>form</div></ResponsivePreview>);
+  await userEvent.click(screen.getByRole("button", { name: /mobile/i }));
+  expect(onWidthChange).toHaveBeenCalledWith(375);
+});
+it("number input clamps to [min,max]", async () => {
+  const onWidthChange = vi.fn();
+  render(<ResponsivePreview width={500} min={320} max={1280} onWidthChange={onWidthChange}><div/></ResponsivePreview>);
+  const num = screen.getByRole("spinbutton");
+  await userEvent.clear(num); await userEvent.type(num, "99999");
+  expect(onWidthChange).toHaveBeenLastCalledWith(1280);
+});
+it("renders children inside a width-constrained frame", () => {
+  render(<ResponsivePreview width={400} onWidthChange={()=>{}}><div data-testid="kid"/></ResponsivePreview>);
+  const frame = screen.getByTestId("rp-frame");
+  expect(frame.style.width).toBe("400px");
+  expect(screen.getByTestId("kid")).toBeDefined();
+});
+```
+
+- [ ] **Step 2: 跑測試確認失敗**
+Run: `pnpm -F web vitest:run src/tools/form-designer/responsive-preview.spec.tsx`
+Expected: FAIL(模組不存在)。
+
+- [ ] **Step 3: 實作**
+- 裝置預設鈕(Mobile 375 / Tablet 768 / Desktop = `max ?? 1280`);range(min..max)+ number(`role=spinbutton`);兩者夾值 `Math.max(min, Math.min(max, w))` 後 `onWidthChange`。
+- 框:`<div data-testid="rp-frame" style={{ width: width+"px", maxWidth:"100%", margin:"0 auto" }}>{children}</div>`,右緣可拖曳把手(pointerdown/move 算寬、夾值、`onWidthChange`)。
+- 顯示當前寬度標籤;`compact` 時縮小控制列/間距。用 `@rfjs/web-ui` 既有 Button/Input 與 `cn()`(對齊 design system)。
+
+- [ ] **Step 4: 跑測試確認通過**
+Run: `pnpm -F web vitest:run src/tools/form-designer/responsive-preview.spec.tsx` → PASS。
+
+- [ ] **Step 5: Commit**
+```bash
+git add apps/web/src/tools/form-designer/responsive-preview.tsx apps/web/src/tools/form-designer/responsive-preview.spec.tsx
+git commit -m "feat(web): ResponsivePreview (device presets + manual width + drag)"
+```
+
+---
+
+## Task 6: `<SubmissionPanel>` 元件
+
+**Files:**
+- Create: `apps/web/src/tools/form-designer/submission-panel.tsx`
+- Create: `apps/web/src/tools/form-designer/submission-panel.spec.tsx`
+
+**Interfaces:**
+- Consumes:Task 4 的 payload 形狀 `{ data; meta: SubmissionMeta }`(從 `@rfjs/form-builder-ui` import 型別)。
+- Produces:`SubmissionPanel({ payload, compact? })` —— 即時呈現 `meta` + `data`(格式化 JSON),`meta.valid` 顯示有效/無效 + errors。
+
+- [ ] **Step 1: 寫失敗測試**
+```tsx
+it("renders data and meta; shows valid state", () => {
+  render(<SubmissionPanel payload={{ data: { name: "Ann" }, meta: { valid: true, errors: {}, visibleKeys: ["name"] } }} />);
+  expect(screen.getByText(/"name": "Ann"/)).toBeDefined();
+  expect(screen.getByText(/valid/i)).toBeDefined();
+});
+it("shows invalid + errors", () => {
+  render(<SubmissionPanel payload={{ data: {}, meta: { valid: false, errors: { name: "Required" }, visibleKeys: [] } }} />);
+  expect(screen.getByText(/Required/)).toBeDefined();
+});
+it("renders empty-state when payload is null", () => {
+  render(<SubmissionPanel payload={null} />);
+  expect(screen.getByText(/fill the form/i)).toBeDefined();
+});
+```
+
+- [ ] **Step 2: 跑測試確認失敗**
+Run: `pnpm -F web vitest:run src/tools/form-designer/submission-panel.spec.tsx`
+Expected: FAIL(模組不存在)。
+
+- [ ] **Step 3: 實作**
+- Props `{ payload: { data: Record<string,unknown>; meta: SubmissionMeta } | null; compact?: boolean }`。
+- 兩個區塊:**Metadata**(valid badge、errors 清單、visibleKeys/schemaVersion)、**Data**(`<pre>{JSON.stringify(data, null, 2)}</pre>`)。`payload==null` → 空狀態文案(含 "fill the form")。用 web-ui 樣式/`cn()`。
+
+- [ ] **Step 4: 跑測試確認通過**
+Run: `pnpm -F web vitest:run src/tools/form-designer/submission-panel.spec.tsx` → PASS。
+
+- [ ] **Step 5: Commit**
+```bash
+git add apps/web/src/tools/form-designer/submission-panel.tsx apps/web/src/tools/form-designer/submission-panel.spec.tsx
+git commit -m "feat(web): SubmissionPanel (live data + submission meta)"
+```
+
+---
+
+## Task 7: form-designer 整合(Preview 頁籤 + Canvas 兩段收合)
+
+**Files:**
+- Modify: `apps/web/src/tools/form-designer/ui.tsx`
+- Test: `apps/web/src/tools/form-designer/ui.spec.tsx`
+
+**Interfaces:**
+- Consumes:Task 3/4(ConfigForm 響應式 + `onPayloadChange`)、Task 5(`ResponsivePreview`)、Task 6(`SubmissionPanel`)。
+
+- [ ] **Step 1: 寫失敗測試**
+```tsx
+it("Canvas tab has two independent collapsible sections: Editor and Live Preview", () => {
+  // render 工具(canvas tab)→ 找到 "Editor" 與 "Live Preview" 兩個可收合標題;Live Preview 預設收合
+});
+it("Preview tab renders ResponsivePreview with device controls + a submission panel", () => {
+  // 切到 preview tab → 出現裝置鈕(Mobile/Tablet/Desktop)與 submission 區塊
+});
+```
+(沿用 `ui.spec.tsx` 既有 render helper;斷言用 role/text。)
+
+- [ ] **Step 2: 跑測試確認失敗**
+Run: `pnpm -F web vitest:run src/tools/form-designer/ui.spec.tsx`
+Expected: FAIL。
+
+- [ ] **Step 3: 實作**
+- 加狀態:`const [payload, setPayload] = React.useState<…|null>(null);` 與 `const [previewW, setPreviewW] = React.useState(1100);`、`const [canvasW, setCanvasW] = React.useState(390);`。
+- **Preview 頁籤**(目前 line 457-459):
+```tsx
+<div className="flex flex-col gap-4 lg:flex-row lg:items-start">
+  <ResponsivePreview width={previewW} onWidthChange={setPreviewW}>
+    <ConfigForm config={formConfig} locale="en" fetcher={sampleFetcher} uploadHandler={sampleUploader}
+      onPayloadChange={setPayload} onSubmit={() => {}} />
+  </ResponsivePreview>
+  <SubmissionPanel payload={payload} />
+</div>
+```
+- **Canvas 頁**(目前 line 347-455):外層改兩個獨立 Collapsible 區塊(用 `@rfjs/web-ui` collapsible,或沿用工具現有的 section 收合元件):
+  1. **Editor**(預設展開):內含現有 grid + `aside` inspector(原 line 388-454 內容)。
+  2. **Live Preview**(預設收合):
+```tsx
+<ResponsivePreview compact width={canvasW} onWidthChange={setCanvasW}>
+  <ConfigForm config={formConfig} locale="en" fetcher={sampleFetcher} uploadHandler={sampleUploader} onPayloadChange={setPayload} onSubmit={() => {}} />
+</ResponsivePreview>
+<SubmissionPanel compact payload={payload} />
+```
+- 兩個 Collapsible 各自獨立開合(非手風琴)。
+
+- [ ] **Step 4: 跑測試 + 型別**
+Run: `pnpm -F web vitest:run src/tools/form-designer && pnpm -F web check-types`
+Expected: PASS、exit 0。
+
+- [ ] **Step 5: 瀏覽器截圖驗證**
+啟動 `pnpm --filter web exec next dev -p 3362`,開 `/en/tools/form-designer`:
+- Preview 頁籤拖到 375 / 768 / 1280,截圖確認塌縮(<640 單欄)與 SubmissionPanel 即時更新。
+- Canvas 頁展開 Live Preview、收合 Editor,截圖確認兩段獨立收合。
+
+- [ ] **Step 6: Commit**
+```bash
+git add apps/web/src/tools/form-designer/ui.tsx apps/web/src/tools/form-designer/ui.spec.tsx
+git commit -m "feat(web): wire responsive preview + live submission into form-designer (two-collapsible Canvas)"
+```
+
+---
+
+## 收尾
+- [ ] 全量回歸:`pnpm -F @rfjs/form-builder vitest:run && pnpm -F @rfjs/form-builder-ui vitest:run && pnpm -F web vitest:run src/tools/form-designer && pnpm -F web check-types`
+- [ ] changeset:`@rfjs/form-builder` minor(新增 `responsive`)、`@rfjs/form-builder-ui` minor(`onPayloadChange`/`useContainerBreakpoint`/容器響應式;**private 但仍記 changelog**)。
+- [ ] 開 PR(英文)。標題:`feat(form-designer): responsive preview + live submission`。內文連結 spec/plan、說明 R(容器響應式,form-builder 線性表單一併受益)/ P / ① 與 ②(動作模型)延後。**等使用者「merged」。**
+
+## Self-Review 對照(spec → task)
+- §4 R:`responsive.stackBelow` → Task 1;`useContainerBreakpoint` → Task 2;ConfigForm 塌縮 + 堆疊序 + 移除 `md:` → Task 3;form-builder v1 回歸 → Task 3 Step 4。✅
+- §5 P:`ResponsivePreview` → Task 5;Preview 頁籤 + Canvas 兩段收合 → Task 7。✅
+- §6 ①:`computePayload` + `onPayloadChange` + `SubmissionMeta` → Task 4;Submission 面板(框外)→ Task 6 + Task 7。✅
+- §7 契約:`responsive`、`onPayloadChange`、`SubmissionMeta` → Task 1/4。✅
+- §9 測試:各 Task 的 TDD + 收尾全量 + Task 7 截圖。✅
+- §10 擴充點(②接同一 seam):不寫 code,計劃不堵死(`meta` 物件可擴充)。✅
+- §11 風險:SSR 寬版預設(Task 2/3 行為)、堆疊序(Task 3 排序)、v1 回歸(Task 3 Step 4)。✅

--- a/docs/superpowers/specs/2026-06-30-form-designer-preview-enhancements-design.md
+++ b/docs/superpowers/specs/2026-06-30-form-designer-preview-enhancements-design.md
@@ -1,0 +1,145 @@
+# Form Designer — Preview 強化設計
+
+**日期:** 2026-06-30
+**狀態:** 已核可(實作前)— 經 brainstorming 收斂、mockup 驗證。
+**前置:** 建立在 #216(form rich inputs,已 merge 到 `main` `42b26e6`)之上。
+**負責範圍:** `@rfjs/form-builder`(引擎 schema)、`@rfjs/form-builder-ui`(ConfigForm renderer + 新 hook)、`apps/web` 的 `form-designer` tool。
+
+## 1. 目標與背景
+
+form-designer 主打 **2D 版面**,但目前產出的表單在窄寬**不會 reflow**:`ConfigForm` 的外層 grid 用 `md:` **視窗** media query 塌縮(`config-form.tsx:243`),而 section / grid-mode 內層 grid 是**寫死的 inline `gridTemplateColumns`**(`config-form.tsx:265,286`),完全不塌。因此「把預覽容器縮窄」看不到真實手機版面,且實際部署的表單在手機上會爆版。
+
+本功能解決兩件事:
+- **R(真正的響應式)**:讓 `ConfigForm` 依**容器寬**塌縮(連帶讓 form-builder 線性表單也受益)。
+- **P(預覽檢視器)**:Preview 頁籤的裝置/手動寬度預覽、Canvas 頁的可收合即時預覽、以及**即時送出資料(Submission)面板**。
+
+**②「可配置按鈕/動作模型」(送 API、reset/clear、可自訂 metadata 信封)不在本 spec** —— 它是 rich-inputs spec §11 延後的「Action button」,獨立成下一個 feature。本 spec 的 Submission 面板只顯示引擎內建的 payload + 基本 metadata,並預留 seam 供 ② 接入。
+
+## 2. 範圍
+
+- **R**:`ConfigForm` 改用 ResizeObserver 量容器寬、依可配置門檻 `stackBelow`(預設 640)塌縮。
+- **P-1**:共用元件 `<ResponsivePreview>`(裝置預設 + 手動寬度 + 拖曳把手)。
+- **P-2**:Preview 頁籤用完整版 `<ResponsivePreview>`;Canvas 頁改成**兩個獨立可收合區塊**(Editor[grid+inspector] / Live Preview)。
+- **P-3(①)**:即時 **Submission 面板**(watch 驅動,不需按 Submit),呈現 `{ data, meta }`。
+
+### 不做 / 延後(擴充點見 §10)
+② 動作/按鈕模型與可自訂 metadata 信封;per-section 門檻覆寫;多階斷點。
+
+## 3. 鎖定決策
+
+| 主題 | 決策 |
+|---|---|
+| reflow 機制 | **ResizeObserver 量容器寬**(非純 CSS `@container`)→ 門檻可配置 |
+| 門檻 | `FormConfig.responsive.stackBelow`,**預設 640**,可每表單覆寫 |
+| 塌縮規則 | 容器寬 < `stackBelow` → 全部單欄;grid-mode(絕對定位)依 (row, colStart) 順序堆疊;flow grid / v1 → 單欄 |
+| form-builder 線性表單 | **一併變容器響應式**(同一個 ConfigForm 改動;加 v1 回歸) |
+| Submission 面板 | **即時**(watch),非 Submit 觸發;呈現 `data` + 內建 `meta`;面板在響應式框**外** |
+| metadata | 本 spec = 引擎內建(valid/errors/visibleKeys/schemaVersion);可自訂信封 = ② |
+| Canvas 版面 | 兩個獨立 Collapsible:Editor[grid+inspector] / Live Preview;預設 Editor 開、Preview 收 |
+| Submit 按鈕 | 保留(互動真實感),但 payload 顯示不靠它 |
+
+## 4. R — 容器響應式(`@rfjs/form-builder-ui`)
+
+### 新 hook:`use-container-breakpoint.ts`
+```ts
+// 量 ref 元素的 inline-size,回傳是否窄於門檻;ResizeObserver 驅動,SSR 安全
+// (未量到前回 false → 預設寬版)。只在跨越門檻時才更新 state(避免每像素 re-render)。
+export function useContainerBreakpoint(ref: React.RefObject<HTMLElement>, breakpoint: number): boolean;
+```
+- 用既有的 ResizeObserver(form-builder-ui 的 `vitest.setup.ts` 已有 stub,#216 加的);無 `window`/SSR 時回 `false`。
+
+### `config-form.tsx` 改動
+- 在表單根 `<form>` 掛 `ref`;`const narrow = useContainerBreakpoint(rootRef, stackBelow)`,其中 `stackBelow = config.responsive?.stackBelow ?? 640`。
+- **外層 grid**(目前 `className="grid grid-cols-1 ... md:[grid-template-columns:repeat(var(--form-cols)...]"`,line 243):移除 `md:` 視窗變體,改成依 `narrow` 決定 `gridTemplateColumns`(narrow → `1fr`,否則 `repeat(var(--form-cols)…)`,以 inline style 設定)。
+- **grid-mode section grid**(line 265)與 **flow section grid**(line 286):narrow → `gridTemplateColumns: '1fr'`,且各 item 不套用 placement 的 `gridColumn`(改 `1 / -1`)。
+- **堆疊順序**:單欄時 DOM 順序即視覺順序。確保 grid-mode 的 items 以 **(row, colStart)** 排序輸出(若目前非此序,於 narrow 時 render 前排序;或在 `formConfigToCards`/`cardsToFormConfig` 端保證序)。
+- 影響:form-builder 線性表單(v1 `fields[]`、flow sections)一併走容器塌縮 → 需 v1 視覺回歸。
+
+### 引擎 schema(`@rfjs/form-builder`)
+- `types.ts`:`FormConfig` 加 `responsive?: { stackBelow?: number }`。
+- `config-schema.ts`:`responsive: z.object({ stackBelow: z.number().positive().optional() }).optional()`(additive,strip-safe,round-trip)。
+
+## 5. P — ResponsivePreview 檢視器 + Canvas 版面(`apps/web` form-designer)
+
+### `responsive-preview.tsx`(新)
+```ts
+export interface ResponsivePreviewProps {
+  children: React.ReactNode;          // 內含 <ConfigForm>
+  width: number; onWidthChange: (w: number) => void;
+  min?: number; max?: number;         // 預設 320 / 1280
+  compact?: boolean;                  // Canvas 內嵌精簡模式
+}
+```
+- 渲染:裝置預設分段鈕(手機 375 / 平板 768 / 桌機=max)、寬度 range + 數字輸入(夾值)、置中的框 `style={{ width }}`、框右緣可拖曳把手、寬度標籤。
+- 框把 `children` 包在 `width` 受限的容器裡 → `ConfigForm` 的 ResizeObserver 量到較小容器 → 依 `stackBelow` 塌縮(**不需 iframe**)。
+
+### Preview 頁籤(`ui.tsx`,目前 line 457-459)
+- 換成 `<ResponsivePreview>` 完整版,內含 `<ConfigForm … onPayloadChange={setPayload}>`,旁/下放 **Submission 面板**(§6)。
+
+### Canvas 頁(`ui.tsx`,目前 line 347-455)
+- 外層改成**兩個獨立 Collapsible 區塊**(用 `@rfjs/web-ui` 既有 collapsible/disclosure,或既有的 section 收合樣式):
+  1. **Editor**:展開時維持現有 grid(左)+ `aside` inspector(`lg:w-[420px]`,line 424)並排;收合時只剩標題列(inspector 跟著收)。
+  2. **Live Preview**:`<ResponsivePreview compact>` + Submission 面板(精簡);預設**收合**。
+- 兩者獨立收合(非手風琴)。預設:Editor 開、Live Preview 收。
+
+## 6. ① 即時 Submission 面板
+
+### ConfigForm seam
+- 把目前 submit handler(`config-form.tsx:233-241`)裡建 `out`(payload + conditional 過濾)的邏輯抽成純函式 `computePayload(values, config) → Record<string, unknown>`,供 `onSubmit` 與即時檢視共用。
+- 新增選填 prop `onPayloadChange?(p: { data: Record<string, unknown>; meta: SubmissionMeta }): void`;以 RHF `watch()` 訂閱值變動(rAF/debounce),每次算出 `data = computePayload(values, config)` 與 `meta`,呼叫 `onPayloadChange`。
+```ts
+export interface SubmissionMeta {
+  valid: boolean;                       // zod safeParse 結果
+  errors: Record<string, string>;       // key → 第一個錯誤訊息
+  visibleKeys: string[];                // 目前可見(未被 conditional 隱藏)欄位
+  schemaVersion?: number;               // config.version
+}
+```
+
+### 面板(form-designer)
+- 在 `<ResponsivePreview>` **框外**渲染一個可收合面板,即時顯示 `meta` + `data`(格式化 JSON;失敗時 `meta.valid=false` + errors)。Preview 頁籤=並排/下方;Canvas Live Preview=精簡(可收合)。
+- 因為在框外,所以不會被當表單內容一起塌縮。
+
+## 7. 資料 / 型別契約
+
+- `FormConfig.responsive?: { stackBelow?: number }`(預設 640)。
+- `ConfigForm` 新 prop `onPayloadChange?`;`ConfigFormBuilder` 比照 `fetcher` 轉發(讓 form-builder 也能用)。
+- `SubmissionMeta`(見上)。② 之後**擴充** `meta`(加 formId/timestamp/自訂信封)與 action 結果,沿用同一個 `onPayloadChange` seam。
+
+## 8. 檔案 / 元件
+
+- 新:`packages/form-builder-ui/src/use-container-breakpoint.ts`(+ spec)。
+- 改:`packages/form-builder-ui/src/config-form.tsx`(ref + narrow 塌縮、`computePayload` 抽取、`onPayloadChange` + watch);`config-form-builder.tsx`(轉發 `onPayloadChange`)。
+- 改:`packages/form-builder/src/types.ts` + `config-schema.ts`(`responsive` 欄位)。
+- 新:`apps/web/src/tools/form-designer/responsive-preview.tsx`、`submission-panel.tsx`(或合一)(+ spec)。
+- 改:`apps/web/src/tools/form-designer/ui.tsx`(Preview 頁籤用 ResponsivePreview + Submission;Canvas 頁兩段式 Collapsible)。
+
+## 9. 測試策略
+
+- `useContainerBreakpoint`:mock ResizeObserver,斷言跨 `stackBelow` 時 boolean 翻轉、SSR/未量到回 false。
+- `ResponsivePreview`:preset 設寬、range/數字輸入更新、拖曳更新、min/max 夾值。
+- `onPayloadChange`:render 表單 → 改值(fireEvent)→ 斷言 callback 收到更新的 `data`;隱藏 conditional 欄位 → 斷言該 key 不在 `data`/`visibleKeys`;非法值 → `meta.valid=false` + errors。
+- `computePayload`:純函式單元測試(conditional 過濾、dataType 形狀)。
+- reflow:jsdom 驗不了版面 → **結構斷言**(narrow 時 grid style = `1fr`、placement gridColumn 收為 `1/-1`)+ **headless 截圖** 375/768/1280。
+- form-builder v1 回歸:既有測試 + 寬版仍多欄、`md:`→容器驅動沒破壞線性表單。
+
+## 10. 延後 — 擴充點(本 spec 零程式碼)
+
+- **② 動作/按鈕模型**:`onPayloadChange` 的 `meta` 預留擴充;action 結果與可自訂 metadata 信封走同一 seam。
+- **per-section 門檻覆寫** / **多階斷點**:`responsive` 目前只放 form-level `stackBelow`;日後可加 `section.responsive` 或斷點陣列。
+
+## 11. 風險與緩解
+
+| 嚴重度 | 風險 | 緩解 |
+|---|---|---|
+| Medium | 從 `md:` 視窗 CSS 改成 JS(ResizeObserver)驅動 → SSR/無 JS 時恆為寬版(行為變更) | 這幾個 app 皆 client-side;文件註明;寬版為安全預設 |
+| Medium | ResizeObserver 抖動/迴圈 | hook 只在跨門檻翻 state;rAF 包裹;單一門檻無需遲滯 |
+| Medium | grid-mode 單欄堆疊順序錯亂 | 以 (row, colStart) 排序輸出 items;加 round-trip/結構測試 |
+| Low | form-builder 線性表單視覺退化 | v1 截圖回歸(寬/窄)後再合併 |
+
+## 12. 開放問題 — 已解決
+1. reflow 機制 → A2 ResizeObserver(門檻可配置)。
+2. 門檻 → `stackBelow` 預設 640、可配置。
+3. form-builder 線性表單 → 一併容器響應式。
+4. Submission → 即時(watch),非 Submit 觸發;`{data, meta}`,metadata 內建版(可自訂信封屬 ②)。
+5. Canvas 版面 → Editor / Live Preview 兩段獨立收合。

--- a/packages/form-builder-ui/src/config-form-builder.tsx
+++ b/packages/form-builder-ui/src/config-form-builder.tsx
@@ -3,6 +3,7 @@
 import * as React from 'react';
 import { Copy, Check } from 'lucide-react';
 import type { FormConfig, FormItem, ItemKind, DataSourceFetcher, UploadHandler, SignatureTransport } from '@rfjs/form-builder';
+import type { SubmissionMeta } from './config-form';
 import { parseFormConfig, normalizeToSections, makeItem } from '@rfjs/form-builder';
 
 import { useConfigBuilder } from './use-config-builder';
@@ -72,9 +73,14 @@ export interface ConfigFormBuilderProps {
    * Memoize with `useCallback` to avoid unnecessary session restarts.
    */
   signatureTransport?: SignatureTransport;
+  /**
+   * Live payload change callback forwarded to the preview `<ConfigForm>`.
+   * Fires on every value change with the current data and `SubmissionMeta`.
+   */
+  onPayloadChange?: (p: { data: Record<string, unknown>; meta: SubmissionMeta }) => void;
 }
 
-export function ConfigFormBuilder({ initialConfig = EMPTY, onChange, locale = 'en', locales = ['en'], fetcher, uploadHandler, signatureTransport }: ConfigFormBuilderProps) {
+export function ConfigFormBuilder({ initialConfig = EMPTY, onChange, locale = 'en', locales = ['en'], fetcher, uploadHandler, signatureTransport, onPayloadChange }: ConfigFormBuilderProps) {
   const builder = useConfigBuilder(initialConfig, onChange);
 
   // The form is "empty" only when no items exist at all (covers both v1 fields[] and v2 sections[]).
@@ -167,7 +173,7 @@ export function ConfigFormBuilder({ initialConfig = EMPTY, onChange, locale = 'e
       {!hasItems ? (
         <p className="py-4 text-center text-sm text-muted-foreground">Preview will appear here once you add fields</p>
       ) : (
-        <ConfigForm config={builder.config} locale={locale} fetcher={fetcher} uploadHandler={uploadHandler} signatureTransport={signatureTransport} onSubmit={() => {}} />
+        <ConfigForm config={builder.config} locale={locale} fetcher={fetcher} uploadHandler={uploadHandler} signatureTransport={signatureTransport} onSubmit={() => {}} onPayloadChange={onPayloadChange} />
       )}
     </div>
   );

--- a/packages/form-builder-ui/src/config-form.spec.tsx
+++ b/packages/form-builder-ui/src/config-form.spec.tsx
@@ -769,6 +769,34 @@ describe('onPayloadChange', () => {
     });
   });
 
+  it('reports meta.valid=true when a hidden required field is empty (excluded from meta validation, consistent with submit)', async () => {
+    const onPayloadChange = vi.fn();
+    const cfg: FormConfig = {
+      version: 1,
+      fields: [
+        { key: 'role', label: 'Role', component: 'Input', dataType: 'string' },
+        {
+          key: 'adminCode',
+          label: 'Admin Code',
+          component: 'Input',
+          dataType: 'string',
+          required: true,
+          conditional: {
+            logic: 'and',
+            filters: [{ field: 'role', dataType: 'string', operator: 'eq', value: 'admin' }],
+          },
+        },
+      ],
+    };
+    render(<ConfigForm config={cfg} onSubmit={() => {}} onPayloadChange={onPayloadChange} />);
+    // role !== 'admin' → adminCode is hidden; even though it's required, the form would submit
+    // → meta.valid must be true (no visible required fields are failing)
+    await waitFor(() => expect(onPayloadChange).toHaveBeenCalled());
+    const lastCall = onPayloadChange.mock.calls.at(-1)![0];
+    expect(lastCall.meta.valid).toBe(true);
+    expect(lastCall.meta.visibleKeys).not.toContain('adminCode');
+  });
+
   it('reports meta.valid=false and errors when a required field is empty', async () => {
     const onPayloadChange = vi.fn();
     const cfg: FormConfig = {

--- a/packages/form-builder-ui/src/config-form.spec.tsx
+++ b/packages/form-builder-ui/src/config-form.spec.tsx
@@ -5,21 +5,25 @@ import type { FormConfig, DataSource, UploadHandler, FileRef, SignatureTransport
 
 // ---------------------------------------------------------------------------
 // Controllable ResizeObserver mock (used by responsive tests below).
-// Re-set per describe block via `beforeEach` so other tests are unaffected.
+// installResizeObserverMock() registers a beforeEach that installs the mock
+// and returns a fireWidth helper — the callback is a closure inside the
+// function so no module-level state leaks between describe blocks.
 // ---------------------------------------------------------------------------
-let _roCb: (entries: any[]) => void = () => {};
 function installResizeObserverMock() {
+  let roCb: (entries: any[]) => void = () => {};
   beforeEach(() => {
-    _roCb = () => {};
+    roCb = () => {};
     (globalThis as any).ResizeObserver = class {
-      constructor(cb: any) { _roCb = cb; }
+      constructor(cb: any) { roCb = cb; }
       observe() {}
       disconnect() {}
     };
   });
-}
-function fireWidth(width: number) {
-  act(() => _roCb([{ contentRect: { width } }]));
+  return {
+    fireWidth(width: number) {
+      act(() => roCb([{ contentRect: { width } }]));
+    },
+  };
 }
 
 
@@ -722,7 +726,7 @@ describe('Signature field submit gating', () => {
 // ---------------------------------------------------------------------------
 
 describe('responsive container collapse', () => {
-  installResizeObserverMock();
+  const { fireWidth } = installResizeObserverMock();
 
   const gridCfg = {
     version: 1,
@@ -755,12 +759,15 @@ describe('responsive container collapse', () => {
 
   it('keeps multi-column layout when container is wide (>= default stackBelow 640)', () => {
     const { container } = render(<ConfigForm config={gridCfg} onSubmit={() => {}} />);
-    // trigger wide width (>= 640 — default stackBelow)
-    fireWidth(900);
+    // First go narrow to confirm collapsed state…
+    fireWidth(400);
     const grid = container.querySelector('[data-testid="form-grid"]') as HTMLElement;
+    expect(grid.style.gridTemplateColumns).toBe('1fr');
+    // …then fire a wide width to confirm restoration.
+    fireWidth(900);
     expect(grid.style.gridTemplateColumns).toContain('repeat(');
     const a = container.querySelector('[data-item="i_a"]') as HTMLElement;
-    // in wide mode the placement span is preserved
+    // in wide mode the placement span is restored
     expect(a.style.gridColumn).toBe('1 / span 7');
   });
 
@@ -803,5 +810,34 @@ describe('responsive container collapse', () => {
     expect(form.style.gridTemplateColumns).toBe('1fr');
     const row = container.querySelector('[data-testid="form-row"]') as HTMLElement;
     expect(row.style.gridTemplateColumns).toBe('1fr');
+  });
+
+  it('orphaned items (no placement) sort after all placed items in narrow mode', () => {
+    const orphanCfg = {
+      version: 1,
+      sections: [
+        {
+          id: 's1',
+          rows: [
+            { id: 'r1', items: [
+              { id: 'placed', kind: 'field', key: 'placed', label: 'Placed', component: 'Input', dataType: 'string' },
+            ] },
+            { id: 'r2', items: [
+              { id: 'orphan', kind: 'field', key: 'orphan', label: 'Orphan', component: 'Input', dataType: 'string' },
+            ] },
+          ],
+          // Only 'placed' has a placement; 'orphan' has none.
+          layout: { columns: 12, placements: [
+            { itemId: 'placed', colStart: 1, colSpan: 12, row: 1 },
+          ] },
+        },
+      ],
+    } as any as FormConfig;
+    const { container } = render(<ConfigForm config={orphanCfg} onSubmit={() => {}} />);
+    fireWidth(400); // go narrow → sort kicks in
+    const items = container.querySelectorAll('[data-item]');
+    // placed item (row 1) must appear before orphan (MAX_SAFE_INTEGER fallback)
+    expect(items[0]!.getAttribute('data-item')).toBe('placed');
+    expect(items[1]!.getAttribute('data-item')).toBe('orphan');
   });
 });

--- a/packages/form-builder-ui/src/config-form.spec.tsx
+++ b/packages/form-builder-ui/src/config-form.spec.tsx
@@ -722,6 +722,69 @@ describe('Signature field submit gating', () => {
 });
 
 // ---------------------------------------------------------------------------
+// onPayloadChange — live payload seam
+// ---------------------------------------------------------------------------
+
+describe('onPayloadChange', () => {
+  it('emits live payload (data + meta) on value change without submit', async () => {
+    const onPayloadChange = vi.fn();
+    const cfg: FormConfig = {
+      version: 1,
+      fields: [{ key: 'name', label: 'Name', component: 'Input', dataType: 'string', required: true }],
+    };
+    render(<ConfigForm config={cfg} onSubmit={() => {}} onPayloadChange={onPayloadChange} />);
+    fireEvent.change(screen.getByRole('textbox', { name: 'Name' }), { target: { value: 'Ann' } });
+    await waitFor(() => {
+      const lastCall = onPayloadChange.mock.calls.at(-1)![0];
+      expect(lastCall.data.name).toBe('Ann');
+      expect(lastCall.meta.visibleKeys).toContain('name');
+    });
+  });
+
+  it('excludes conditionally-hidden fields from payload data and visibleKeys', async () => {
+    const onPayloadChange = vi.fn();
+    const cfg: FormConfig = {
+      version: 1,
+      fields: [
+        { key: 'role', label: 'Role', component: 'Input', dataType: 'string' },
+        {
+          key: 'secret',
+          label: 'Secret',
+          component: 'Input',
+          dataType: 'string',
+          conditional: {
+            logic: 'and',
+            filters: [{ field: 'role', dataType: 'string', operator: 'eq', value: 'admin' }],
+          },
+        },
+      ],
+    };
+    render(<ConfigForm config={cfg} onSubmit={() => {}} onPayloadChange={onPayloadChange} />);
+    // role !== 'admin' → secret is hidden
+    fireEvent.change(screen.getByRole('textbox', { name: 'Role' }), { target: { value: 'user' } });
+    await waitFor(() => {
+      const lastCall = onPayloadChange.mock.calls.at(-1)![0];
+      expect(Object.keys(lastCall.data)).not.toContain('secret');
+      expect(lastCall.meta.visibleKeys).not.toContain('secret');
+    });
+  });
+
+  it('reports meta.valid=false and errors when a required field is empty', async () => {
+    const onPayloadChange = vi.fn();
+    const cfg: FormConfig = {
+      version: 1,
+      fields: [{ key: 'name', label: 'Name', component: 'Input', dataType: 'string', required: true }],
+    };
+    render(<ConfigForm config={cfg} onSubmit={() => {}} onPayloadChange={onPayloadChange} />);
+    // Trigger a re-render by typing then clearing — or just wait for the initial emit
+    await waitFor(() => expect(onPayloadChange).toHaveBeenCalled());
+    const lastCall = onPayloadChange.mock.calls.at(-1)![0];
+    expect(lastCall.meta.valid).toBe(false);
+    expect(lastCall.meta.errors).toHaveProperty('name');
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Responsive collapse (container-driven via ResizeObserver)
 // ---------------------------------------------------------------------------
 

--- a/packages/form-builder-ui/src/config-form.spec.tsx
+++ b/packages/form-builder-ui/src/config-form.spec.tsx
@@ -1,7 +1,26 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import { ConfigForm } from './config-form';
 import type { FormConfig, DataSource, UploadHandler, FileRef, SignatureTransport } from '@rfjs/form-builder';
+
+// ---------------------------------------------------------------------------
+// Controllable ResizeObserver mock (used by responsive tests below).
+// Re-set per describe block via `beforeEach` so other tests are unaffected.
+// ---------------------------------------------------------------------------
+let _roCb: (entries: any[]) => void = () => {};
+function installResizeObserverMock() {
+  beforeEach(() => {
+    _roCb = () => {};
+    (globalThis as any).ResizeObserver = class {
+      constructor(cb: any) { _roCb = cb; }
+      observe() {}
+      disconnect() {}
+    };
+  });
+}
+function fireWidth(width: number) {
+  act(() => _roCb([{ contentRect: { width } }]));
+}
 
 
 const baseConfig: FormConfig = {
@@ -695,5 +714,94 @@ describe('Signature field submit gating', () => {
 
     // Submit must no longer be disabled — pendingCaptures cleared on config change
     await waitFor(() => expect(submitBtn.hasAttribute('disabled')).toBe(false));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Responsive collapse (container-driven via ResizeObserver)
+// ---------------------------------------------------------------------------
+
+describe('responsive container collapse', () => {
+  installResizeObserverMock();
+
+  const gridCfg = {
+    version: 1,
+    sections: [
+      {
+        id: 's1',
+        rows: [{ id: 'r1', items: [
+          { id: 'i_a', kind: 'field', key: 'a', label: 'A', component: 'Input', dataType: 'string' },
+          { id: 'i_b', kind: 'field', key: 'b', label: 'B', component: 'Input', dataType: 'string' },
+        ] }],
+        layout: { columns: 12, placements: [
+          { itemId: 'i_a', colStart: 1, colSpan: 7, row: 1 },
+          { itemId: 'i_b', colStart: 8, colSpan: 5, row: 1 },
+        ] },
+      },
+    ],
+  } as any as FormConfig;
+
+  it('collapses grid-mode section to single column when container is narrow', () => {
+    const { container } = render(<ConfigForm config={gridCfg} onSubmit={() => {}} />);
+    // trigger narrow width (< default 640)
+    fireWidth(400);
+    const grid = container.querySelector('[data-testid="form-grid"]') as HTMLElement;
+    expect(grid.style.gridTemplateColumns).toBe('1fr');
+    const a = container.querySelector('[data-item="i_a"]') as HTMLElement;
+    const b = container.querySelector('[data-item="i_b"]') as HTMLElement;
+    expect(a.style.gridColumn).toBe('1 / -1');
+    expect(b.style.gridColumn).toBe('1 / -1');
+  });
+
+  it('keeps multi-column layout when container is wide (>= default stackBelow 640)', () => {
+    const { container } = render(<ConfigForm config={gridCfg} onSubmit={() => {}} />);
+    // trigger wide width (>= 640 — default stackBelow)
+    fireWidth(900);
+    const grid = container.querySelector('[data-testid="form-grid"]') as HTMLElement;
+    expect(grid.style.gridTemplateColumns).toContain('repeat(');
+    const a = container.querySelector('[data-item="i_a"]') as HTMLElement;
+    // in wide mode the placement span is preserved
+    expect(a.style.gridColumn).toBe('1 / span 7');
+  });
+
+  it('honors config.responsive.stackBelow override (480)', () => {
+    const cfg: FormConfig = {
+      ...(gridCfg as any),
+      responsive: { stackBelow: 480 },
+    } as any;
+    const { container } = render(<ConfigForm config={cfg} onSubmit={() => {}} />);
+    // width=520 — above the 480 threshold → wide, multi-column preserved
+    fireWidth(520);
+    const grid1 = container.querySelector('[data-testid="form-grid"]') as HTMLElement;
+    expect(grid1.style.gridTemplateColumns).toContain('repeat(');
+    // width=400 — below 480 threshold → narrow, collapsed
+    fireWidth(400);
+    const grid2 = container.querySelector('[data-testid="form-grid"]') as HTMLElement;
+    expect(grid2.style.gridTemplateColumns).toBe('1fr');
+  });
+
+  it('collapses outer form grid and flow-section rows when narrow', () => {
+    const flowCfg: FormConfig = {
+      version: 1,
+      columns: 2,
+      sections: [
+        {
+          id: 's1',
+          columns: 2,
+          rows: [
+            { id: 'r1', items: [
+              { id: 'f1', kind: 'field', key: 'x', label: 'X', component: 'Input', dataType: 'string' },
+              { id: 'f2', kind: 'field', key: 'y', label: 'Y', component: 'Input', dataType: 'string' },
+            ] },
+          ],
+        },
+      ],
+    } as any;
+    const { container } = render(<ConfigForm config={flowCfg} onSubmit={() => {}} />);
+    fireWidth(300);
+    const form = container.querySelector('form') as HTMLElement;
+    expect(form.style.gridTemplateColumns).toBe('1fr');
+    const row = container.querySelector('[data-testid="form-row"]') as HTMLElement;
+    expect(row.style.gridTemplateColumns).toBe('1fr');
   });
 });

--- a/packages/form-builder-ui/src/config-form.tsx
+++ b/packages/form-builder-ui/src/config-form.tsx
@@ -18,6 +18,11 @@ import {
   type UploadHandler,
   type SignatureTransport,
 } from '@rfjs/form-builder';
+import { useDataSource } from './use-data-source';
+import { useContainerBreakpoint } from './use-container-breakpoint';
+import { Label } from '@rfjs/web-ui/components/label';
+import { Button } from '@rfjs/web-ui/components/button';
+import { FieldControl } from './field-control';
 
 // ---------------------------------------------------------------------------
 // SubmissionMeta — shape of the meta object emitted by onPayloadChange.
@@ -44,12 +49,6 @@ export function computePayload(
   );
   return Object.fromEntries(Object.entries(values).filter(([k]) => visibleKeys.has(k)));
 }
-import { useDataSource } from './use-data-source';
-import { useContainerBreakpoint } from './use-container-breakpoint';
-import { Label } from '@rfjs/web-ui/components/label';
-import { Button } from '@rfjs/web-ui/components/button';
-
-import { FieldControl } from './field-control';
 
 // Stable style constant — outside the component so it's never recreated on render.
 const FULL_SPAN: React.CSSProperties = { gridColumn: '1 / -1' };
@@ -174,16 +173,17 @@ export function ConfigForm({ config, defaultValues, onSubmit, submitLabel = 'Sub
   const watchedValues = useWatch({ control });
   const onPayloadChangeRef = React.useRef(onPayloadChange);
   onPayloadChangeRef.current = onPayloadChange;
-  // schemaRef lets the effect read the latest schema without rebuilding on every render.
-  const schemaRef = React.useRef(configToZod(config));
-  React.useEffect(() => {
-    schemaRef.current = configToZod(config);
-  }, [config]);
-
   React.useEffect(() => {
     if (!onPayloadChangeRef.current) return;
-    const data = computePayload(watchedValues as Record<string, unknown>, config);
-    const parsed = schemaRef.current.safeParse(data);
+    const vals = watchedValues as Record<string, unknown>;
+    const data = computePayload(vals, config);
+    // Build visible-only schema — mirrors the resolver so meta.valid reflects actual
+    // submittability: hidden required fields are excluded, just as the resolver excludes them.
+    const visibleFieldItems = collectFieldItems(config).filter((f) =>
+      evaluateConditional(f.conditional, vals),
+    );
+    const visibleConfig: FormConfig = { version: config.version, fields: visibleFieldItems };
+    const parsed = configToZod(visibleConfig).safeParse(data);
     const errors: Record<string, string> = {};
     if (!parsed.success) {
       for (const issue of parsed.error.issues) {

--- a/packages/form-builder-ui/src/config-form.tsx
+++ b/packages/form-builder-ui/src/config-form.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import * as React from 'react';
-import { Controller, useForm, type Resolver } from 'react-hook-form';
+import { Controller, useForm, useWatch, type Resolver } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import {
   configToZod,
@@ -18,6 +18,32 @@ import {
   type UploadHandler,
   type SignatureTransport,
 } from '@rfjs/form-builder';
+
+// ---------------------------------------------------------------------------
+// SubmissionMeta — shape of the meta object emitted by onPayloadChange.
+// ---------------------------------------------------------------------------
+export interface SubmissionMeta {
+  valid: boolean;
+  errors: Record<string, string>;
+  visibleKeys: string[];
+  schemaVersion?: number;
+}
+
+// ---------------------------------------------------------------------------
+// computePayload — pure function: strips conditionally-hidden field values
+// from the raw RHF values object (same logic as the submit handler).
+// ---------------------------------------------------------------------------
+export function computePayload(
+  values: Record<string, unknown>,
+  config: FormConfig,
+): Record<string, unknown> {
+  const visibleKeys = new Set(
+    collectFieldItems(config)
+      .filter((f) => evaluateConditional(f.conditional, values))
+      .map((f) => f.key),
+  );
+  return Object.fromEntries(Object.entries(values).filter(([k]) => visibleKeys.has(k)));
+}
 import { useDataSource } from './use-data-source';
 import { useContainerBreakpoint } from './use-container-breakpoint';
 import { Label } from '@rfjs/web-ui/components/label';
@@ -80,9 +106,17 @@ export interface ConfigFormProps {
    * Memoize with `useCallback` to avoid unnecessary session restarts.
    */
   signatureTransport?: SignatureTransport;
+  /**
+   * Called on every form value change (live, no submit required) with the current
+   * payload (conditionally-hidden fields excluded) and a `SubmissionMeta` object
+   * containing the zod validation result, per-field errors, visible keys, and the
+   * config's schema version.
+   * Only wired up (and triggers an effect) when provided.
+   */
+  onPayloadChange?: (p: { data: Record<string, unknown>; meta: SubmissionMeta }) => void;
 }
 
-export function ConfigForm({ config, defaultValues, onSubmit, submitLabel = 'Submit', locale = 'en', fetcher, uploadHandler, signatureTransport }: ConfigFormProps) {
+export function ConfigForm({ config, defaultValues, onSubmit, submitLabel = 'Submit', locale = 'en', fetcher, uploadHandler, signatureTransport, onPayloadChange }: ConfigFormProps) {
   // Container ref for ResizeObserver-driven responsive collapse.
   const rootRef = React.useRef<HTMLFormElement>(null);
   const stackBelow = config.responsive?.stackBelow ?? 640;
@@ -134,6 +168,39 @@ export function ConfigForm({ config, defaultValues, onSubmit, submitLabel = 'Sub
 
   // Subscribe to all form values to decide which items to RENDER (live show/hide).
   const values = watch();
+
+  // Live-payload seam: compute and emit payload + meta on every value change.
+  // useWatch gives a stable reference to the latest values for the effect.
+  const watchedValues = useWatch({ control });
+  const onPayloadChangeRef = React.useRef(onPayloadChange);
+  onPayloadChangeRef.current = onPayloadChange;
+  // schemaRef lets the effect read the latest schema without rebuilding on every render.
+  const schemaRef = React.useRef(configToZod(config));
+  React.useEffect(() => {
+    schemaRef.current = configToZod(config);
+  }, [config]);
+
+  React.useEffect(() => {
+    if (!onPayloadChangeRef.current) return;
+    const data = computePayload(watchedValues as Record<string, unknown>, config);
+    const parsed = schemaRef.current.safeParse(data);
+    const errors: Record<string, string> = {};
+    if (!parsed.success) {
+      for (const issue of parsed.error.issues) {
+        const k = String(issue.path[0]);
+        if (k && !errors[k]) errors[k] = issue.message;
+      }
+    }
+    onPayloadChangeRef.current({
+      data,
+      meta: {
+        valid: parsed.success,
+        errors,
+        visibleKeys: Object.keys(data),
+        schemaVersion: config.version,
+      },
+    });
+  }, [watchedValues, config]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const spacerHeights: Record<string, number> = { sm: 8, md: 16, lg: 32 };
 
@@ -269,14 +336,7 @@ export function ConfigForm({ config, defaultValues, onSubmit, submitLabel = 'Sub
     <form
       ref={rootRef}
       onSubmit={handleSubmit((all) => {
-        // Strip hidden fields' values from the submit payload.
-        const visibleKeys = new Set(
-          collectFieldItems(config)
-            .filter((f) => evaluateConditional(f.conditional, all as Record<string, unknown>))
-            .map((f) => f.key),
-        );
-        const out = Object.fromEntries(Object.entries(all).filter(([k]) => visibleKeys.has(k)));
-        onSubmit(out as Record<string, unknown>);
+        onSubmit(computePayload(all as Record<string, unknown>, config));
       })}
       className="grid gap-4"
       style={{

--- a/packages/form-builder-ui/src/config-form.tsx
+++ b/packages/form-builder-ui/src/config-form.tsx
@@ -25,6 +25,9 @@ import { Button } from '@rfjs/web-ui/components/button';
 
 import { FieldControl } from './field-control';
 
+// Stable style constant — outside the component so it's never recreated on render.
+const FULL_SPAN: React.CSSProperties = { gridColumn: '1 / -1' };
+
 interface DataSourceContentProps {
   ds: DataSource;
   fetcher?: DataSourceFetcher;
@@ -81,9 +84,9 @@ export interface ConfigFormProps {
 
 export function ConfigForm({ config, defaultValues, onSubmit, submitLabel = 'Submit', locale = 'en', fetcher, uploadHandler, signatureTransport }: ConfigFormProps) {
   // Container ref for ResizeObserver-driven responsive collapse.
-  const rootRef = React.useRef<HTMLFormElement | null>(null);
+  const rootRef = React.useRef<HTMLFormElement>(null);
   const stackBelow = config.responsive?.stackBelow ?? 640;
-  const narrow = useContainerBreakpoint(rootRef as React.RefObject<HTMLElement>, stackBelow);
+  const narrow = useContainerBreakpoint(rootRef, stackBelow);
 
   // Keep the latest config reachable inside the stable resolver without re-creating it.
   const configRef = React.useRef(config);
@@ -136,14 +139,13 @@ export function ConfigForm({ config, defaultValues, onSubmit, submitLabel = 'Sub
 
   // Span styles are applied INLINE, not via Tailwind `col-span-*` utilities —
   // those aren't reliably emitted for this package. Inline is guaranteed.
-  // Items always span the full row width.
-  const FULL_SPAN: React.CSSProperties = { gridColumn: '1 / -1' };
+  // Items always span the full row width. (FULL_SPAN is module-level — see above.)
 
   // Explicit grid placement → inline grid-area style (grid-mode sections, Task 2).
   // When narrow, collapse to full width (no placement).
-  const placementStyle = (p: { colStart: number; colSpan: number; row: number; rowSpan?: number }, isNarrow: boolean): React.CSSProperties =>
-    isNarrow
-      ? { gridColumn: '1 / -1', minWidth: 0 }
+  const placementStyle = (p: { colStart: number; colSpan: number; row: number; rowSpan?: number }): React.CSSProperties =>
+    narrow
+      ? { ...FULL_SPAN, minWidth: 0 }
       : {
           gridColumn: `${p.colStart} / span ${p.colSpan}`,
           gridRow: p.rowSpan ? `${p.row} / span ${p.rowSpan}` : String(p.row),
@@ -155,8 +157,8 @@ export function ConfigForm({ config, defaultValues, onSubmit, submitLabel = 'Sub
   // `columns: 2` lays its fields two-per-row automatically (no per-field width
   // needed). 'half' ≈ half the row; 'full' spans the whole row. `flow: 'v1'`
   // keeps the legacy behaviour (unset = full) for back-compat with `fields[]`.
-  function fieldSpanStyle(width: FieldWidth | undefined, flow: 'v1' | 'section', cols: number, isNarrow = false): React.CSSProperties {
-    if (isNarrow) return FULL_SPAN;
+  function fieldSpanStyle(width: FieldWidth | undefined, flow: 'v1' | 'section', cols: number): React.CSSProperties {
+    if (narrow) return FULL_SPAN;
     if (flow === 'v1') return { gridColumn: (width ?? 'full') === 'full' ? '1 / -1' : undefined };
     if (width === 'full') return FULL_SPAN;
     const cells = width === 'half' ? Math.max(1, Math.ceil(cols / 2)) : 1;
@@ -164,7 +166,7 @@ export function ConfigForm({ config, defaultValues, onSubmit, submitLabel = 'Sub
     return { gridColumn: `span ${span} / span ${span}`, minWidth: 0 };
   }
 
-  function renderItem(item: FormItem, flow: 'v1' | 'section', cols: number, place?: { colStart: number; colSpan: number; row: number; rowSpan?: number }, isNarrow = false) {
+  function renderItem(item: FormItem, flow: 'v1' | 'section', cols: number, place?: { colStart: number; colSpan: number; row: number; rowSpan?: number }) {
     const vals = values as Record<string, unknown>;
 
     if (item.kind === 'ai-note') {
@@ -173,19 +175,19 @@ export function ConfigForm({ config, defaultValues, onSubmit, submitLabel = 'Sub
 
     if (item.kind === 'divider') {
       if (!evaluateConditional(item.conditional, vals)) return null;
-      return <hr key={item.id} data-item={item.id} className="w-full border-input" style={place ? placementStyle(place, isNarrow) : FULL_SPAN} />;
+      return <hr key={item.id} data-item={item.id} className="w-full border-input" style={place ? placementStyle(place) : FULL_SPAN} />;
     }
 
     if (item.kind === 'spacer') {
       if (!evaluateConditional(item.conditional, vals)) return null;
       const height = spacerHeights[item.size ?? 'md'];
-      return <div key={item.id} data-item={item.id} style={{ ...(place ? placementStyle(place, isNarrow) : FULL_SPAN), height }} />;
+      return <div key={item.id} data-item={item.id} style={{ ...(place ? placementStyle(place) : FULL_SPAN), height }} />;
     }
 
     if (item.kind === 'content') {
       if (!evaluateConditional(item.conditional, vals)) return null;
       return (
-        <div key={item.id} data-item={item.id} className="text-sm" style={place ? placementStyle(place, isNarrow) : FULL_SPAN}>
+        <div key={item.id} data-item={item.id} className="text-sm" style={place ? placementStyle(place) : FULL_SPAN}>
           {item.dataSource ? (
             <DataSourceContent ds={item.dataSource} fetcher={fetcher} />
           ) : (
@@ -206,7 +208,7 @@ export function ConfigForm({ config, defaultValues, onSubmit, submitLabel = 'Sub
         className="flex min-w-0 flex-col gap-1.5"
         data-width={dataWidth}
         data-item={item.id}
-        style={place ? placementStyle(place, isNarrow) : fieldSpanStyle(item.width, flow, cols, isNarrow)}
+        style={place ? placementStyle(place) : fieldSpanStyle(item.width, flow, cols)}
       >
         <Label htmlFor={item.key}>{resolveLabel(item.label, locale)}</Label>
         <Controller
@@ -239,6 +241,30 @@ export function ConfigForm({ config, defaultValues, onSubmit, submitLabel = 'Sub
   // Use the first section's columns for the overall form grid (v1 back-compat).
   const columns = config.columns ?? sections[0]?.columns ?? 1;
 
+  // Pre-sort grid-mode section items once per config+narrow change rather than
+  // on every keystroke. `watch()` causes re-renders on every field change, so
+  // the sort cost is proportional to input frequency without this memo.
+  const sortedGridItems = React.useMemo(() => {
+    const result = new Map<string, FormItem[]>();
+    for (const section of sections) {
+      if (section.layout) {
+        const byId = new Map(section.layout.placements.map((p) => [p.itemId, p]));
+        const allItems = section.rows.flatMap((r) => r.items);
+        result.set(
+          section.id,
+          narrow
+            ? [...allItems].sort((a, b) => {
+                const pa = byId.get(a.id);
+                const pb = byId.get(b.id);
+                return (pa?.row ?? Number.MAX_SAFE_INTEGER) - (pb?.row ?? Number.MAX_SAFE_INTEGER) || (pa?.colStart ?? Number.MAX_SAFE_INTEGER) - (pb?.colStart ?? Number.MAX_SAFE_INTEGER);
+              })
+            : allItems,
+        );
+      }
+    }
+    return result;
+  }, [config, narrow]); // eslint-disable-line react-hooks/exhaustive-deps
+
   return (
     <form
       ref={rootRef}
@@ -255,7 +281,7 @@ export function ConfigForm({ config, defaultValues, onSubmit, submitLabel = 'Sub
       className="grid gap-4"
       style={{
         gridTemplateColumns: narrow ? '1fr' : 'repeat(var(--form-cols), minmax(0, 1fr))',
-        ['--form-cols' as any]: String(columns),
+        ...(!narrow && { ['--form-cols' as any]: String(columns) }),
       }}
       data-columns={columns}
     >
@@ -266,16 +292,9 @@ export function ConfigForm({ config, defaultValues, onSubmit, submitLabel = 'Sub
         if (isV2 && section.layout) {
           const layout = section.layout;
           const byId = new Map(layout.placements.map((p) => [p.itemId, p]));
-          const allItems = section.rows.flatMap((r) => r.items);
-          // When narrow: sort items by (row, colStart) so visual reading order is preserved
-          // in single-column stack. Always sort a copy — never mutate.
-          const items = narrow
-            ? [...allItems].sort((a, b) => {
-                const pa = byId.get(a.id);
-                const pb = byId.get(b.id);
-                return (pa?.row ?? 0) - (pb?.row ?? 0) || (pa?.colStart ?? 0) - (pb?.colStart ?? 0);
-              })
-            : allItems;
+          // Sorted order is pre-computed in sortedGridItems (memoized) to avoid re-sorting
+          // on every keystroke (watch() re-renders on each field change).
+          const items = sortedGridItems.get(section.id) ?? section.rows.flatMap((r) => r.items);
           return (
             <React.Fragment key={section.id}>
               {section.title && (
@@ -291,7 +310,7 @@ export function ConfigForm({ config, defaultValues, onSubmit, submitLabel = 'Sub
                   gridTemplateColumns: narrow ? '1fr' : `repeat(${layout.columns}, minmax(0, 1fr))`,
                 }}
               >
-                {items.map((item) => renderItem(item, 'section', layout.columns, byId.get(item.id), narrow))}
+                {items.map((item) => renderItem(item, 'section', layout.columns, byId.get(item.id)))}
               </div>
             </React.Fragment>
           );
@@ -315,7 +334,7 @@ export function ConfigForm({ config, defaultValues, onSubmit, submitLabel = 'Sub
                     gridTemplateColumns: narrow ? '1fr' : `repeat(${sectionCols}, minmax(0, 1fr))`,
                   }}
                 >
-                  {row.items.map((item) => renderItem(item, 'section', sectionCols, undefined, narrow))}
+                  {row.items.map((item) => renderItem(item, 'section', sectionCols))}
                 </div>
               ) : (
                 // v1 implicit section: render items FLAT into the outer grid (unchanged v1 behavior).

--- a/packages/form-builder-ui/src/config-form.tsx
+++ b/packages/form-builder-ui/src/config-form.tsx
@@ -19,6 +19,7 @@ import {
   type SignatureTransport,
 } from '@rfjs/form-builder';
 import { useDataSource } from './use-data-source';
+import { useContainerBreakpoint } from './use-container-breakpoint';
 import { Label } from '@rfjs/web-ui/components/label';
 import { Button } from '@rfjs/web-ui/components/button';
 
@@ -79,6 +80,11 @@ export interface ConfigFormProps {
 }
 
 export function ConfigForm({ config, defaultValues, onSubmit, submitLabel = 'Submit', locale = 'en', fetcher, uploadHandler, signatureTransport }: ConfigFormProps) {
+  // Container ref for ResizeObserver-driven responsive collapse.
+  const rootRef = React.useRef<HTMLFormElement | null>(null);
+  const stackBelow = config.responsive?.stackBelow ?? 640;
+  const narrow = useContainerBreakpoint(rootRef as React.RefObject<HTMLElement>, stackBelow);
+
   // Keep the latest config reachable inside the stable resolver without re-creating it.
   const configRef = React.useRef(config);
   configRef.current = config;
@@ -134,18 +140,23 @@ export function ConfigForm({ config, defaultValues, onSubmit, submitLabel = 'Sub
   const FULL_SPAN: React.CSSProperties = { gridColumn: '1 / -1' };
 
   // Explicit grid placement → inline grid-area style (grid-mode sections, Task 2).
-  const placementStyle = (p: { colStart: number; colSpan: number; row: number; rowSpan?: number }): React.CSSProperties => ({
-    gridColumn: `${p.colStart} / span ${p.colSpan}`,
-    gridRow: p.rowSpan ? `${p.row} / span ${p.rowSpan}` : String(p.row),
-    minWidth: 0,
-  });
+  // When narrow, collapse to full width (no placement).
+  const placementStyle = (p: { colStart: number; colSpan: number; row: number; rowSpan?: number }, isNarrow: boolean): React.CSSProperties =>
+    isNarrow
+      ? { gridColumn: '1 / -1', minWidth: 0 }
+      : {
+          gridColumn: `${p.colStart} / span ${p.colSpan}`,
+          gridRow: p.rowSpan ? `${p.row} / span ${p.rowSpan}` : String(p.row),
+          minWidth: 0,
+        };
 
   // Field grid-span derived from the field's width AND the section's column count.
   // #3: columns DRIVE width — an unset width is a single cell, so a section with
   // `columns: 2` lays its fields two-per-row automatically (no per-field width
   // needed). 'half' ≈ half the row; 'full' spans the whole row. `flow: 'v1'`
   // keeps the legacy behaviour (unset = full) for back-compat with `fields[]`.
-  function fieldSpanStyle(width: FieldWidth | undefined, flow: 'v1' | 'section', cols: number): React.CSSProperties {
+  function fieldSpanStyle(width: FieldWidth | undefined, flow: 'v1' | 'section', cols: number, isNarrow = false): React.CSSProperties {
+    if (isNarrow) return FULL_SPAN;
     if (flow === 'v1') return { gridColumn: (width ?? 'full') === 'full' ? '1 / -1' : undefined };
     if (width === 'full') return FULL_SPAN;
     const cells = width === 'half' ? Math.max(1, Math.ceil(cols / 2)) : 1;
@@ -153,7 +164,7 @@ export function ConfigForm({ config, defaultValues, onSubmit, submitLabel = 'Sub
     return { gridColumn: `span ${span} / span ${span}`, minWidth: 0 };
   }
 
-  function renderItem(item: FormItem, flow: 'v1' | 'section', cols: number, place?: { colStart: number; colSpan: number; row: number; rowSpan?: number }) {
+  function renderItem(item: FormItem, flow: 'v1' | 'section', cols: number, place?: { colStart: number; colSpan: number; row: number; rowSpan?: number }, isNarrow = false) {
     const vals = values as Record<string, unknown>;
 
     if (item.kind === 'ai-note') {
@@ -162,19 +173,19 @@ export function ConfigForm({ config, defaultValues, onSubmit, submitLabel = 'Sub
 
     if (item.kind === 'divider') {
       if (!evaluateConditional(item.conditional, vals)) return null;
-      return <hr key={item.id} data-item={item.id} className="w-full border-input" style={place ? placementStyle(place) : FULL_SPAN} />;
+      return <hr key={item.id} data-item={item.id} className="w-full border-input" style={place ? placementStyle(place, isNarrow) : FULL_SPAN} />;
     }
 
     if (item.kind === 'spacer') {
       if (!evaluateConditional(item.conditional, vals)) return null;
       const height = spacerHeights[item.size ?? 'md'];
-      return <div key={item.id} data-item={item.id} style={{ ...(place ? placementStyle(place) : FULL_SPAN), height }} />;
+      return <div key={item.id} data-item={item.id} style={{ ...(place ? placementStyle(place, isNarrow) : FULL_SPAN), height }} />;
     }
 
     if (item.kind === 'content') {
       if (!evaluateConditional(item.conditional, vals)) return null;
       return (
-        <div key={item.id} data-item={item.id} className="text-sm" style={place ? placementStyle(place) : FULL_SPAN}>
+        <div key={item.id} data-item={item.id} className="text-sm" style={place ? placementStyle(place, isNarrow) : FULL_SPAN}>
           {item.dataSource ? (
             <DataSourceContent ds={item.dataSource} fetcher={fetcher} />
           ) : (
@@ -195,7 +206,7 @@ export function ConfigForm({ config, defaultValues, onSubmit, submitLabel = 'Sub
         className="flex min-w-0 flex-col gap-1.5"
         data-width={dataWidth}
         data-item={item.id}
-        style={place ? placementStyle(place) : fieldSpanStyle(item.width, flow, cols)}
+        style={place ? placementStyle(place, isNarrow) : fieldSpanStyle(item.width, flow, cols, isNarrow)}
       >
         <Label htmlFor={item.key}>{resolveLabel(item.label, locale)}</Label>
         <Controller
@@ -230,6 +241,7 @@ export function ConfigForm({ config, defaultValues, onSubmit, submitLabel = 'Sub
 
   return (
     <form
+      ref={rootRef}
       onSubmit={handleSubmit((all) => {
         // Strip hidden fields' values from the submit payload.
         const visibleKeys = new Set(
@@ -240,8 +252,11 @@ export function ConfigForm({ config, defaultValues, onSubmit, submitLabel = 'Sub
         const out = Object.fromEntries(Object.entries(all).filter(([k]) => visibleKeys.has(k)));
         onSubmit(out as Record<string, unknown>);
       })}
-      className="grid grid-cols-1 gap-4 md:[grid-template-columns:repeat(var(--form-cols),minmax(0,1fr))]"
-      style={{ '--form-cols': String(columns) } as React.CSSProperties}
+      className="grid gap-4"
+      style={{
+        gridTemplateColumns: narrow ? '1fr' : 'repeat(var(--form-cols), minmax(0, 1fr))',
+        ['--form-cols' as any]: String(columns),
+      }}
       data-columns={columns}
     >
       {sections.map((section) => {
@@ -251,7 +266,16 @@ export function ConfigForm({ config, defaultValues, onSubmit, submitLabel = 'Sub
         if (isV2 && section.layout) {
           const layout = section.layout;
           const byId = new Map(layout.placements.map((p) => [p.itemId, p]));
-          const items = section.rows.flatMap((r) => r.items);
+          const allItems = section.rows.flatMap((r) => r.items);
+          // When narrow: sort items by (row, colStart) so visual reading order is preserved
+          // in single-column stack. Always sort a copy — never mutate.
+          const items = narrow
+            ? [...allItems].sort((a, b) => {
+                const pa = byId.get(a.id);
+                const pb = byId.get(b.id);
+                return (pa?.row ?? 0) - (pb?.row ?? 0) || (pa?.colStart ?? 0) - (pb?.colStart ?? 0);
+              })
+            : allItems;
           return (
             <React.Fragment key={section.id}>
               {section.title && (
@@ -262,9 +286,12 @@ export function ConfigForm({ config, defaultValues, onSubmit, submitLabel = 'Sub
               <div
                 data-testid="form-grid"
                 className="grid gap-4"
-                style={{ gridColumn: '1 / -1', gridTemplateColumns: `repeat(${layout.columns}, minmax(0, 1fr))` }}
+                style={{
+                  gridColumn: '1 / -1',
+                  gridTemplateColumns: narrow ? '1fr' : `repeat(${layout.columns}, minmax(0, 1fr))`,
+                }}
               >
-                {items.map((item) => renderItem(item, 'section', layout.columns, byId.get(item.id)))}
+                {items.map((item) => renderItem(item, 'section', layout.columns, byId.get(item.id), narrow))}
               </div>
             </React.Fragment>
           );
@@ -283,9 +310,12 @@ export function ConfigForm({ config, defaultValues, onSubmit, submitLabel = 'Sub
                   key={row.id}
                   data-testid="form-row"
                   className="grid gap-4"
-                  style={{ gridColumn: '1 / -1', gridTemplateColumns: `repeat(${sectionCols}, minmax(0, 1fr))` }}
+                  style={{
+                    gridColumn: '1 / -1',
+                    gridTemplateColumns: narrow ? '1fr' : `repeat(${sectionCols}, minmax(0, 1fr))`,
+                  }}
                 >
-                  {row.items.map((item) => renderItem(item, 'section', sectionCols))}
+                  {row.items.map((item) => renderItem(item, 'section', sectionCols, undefined, narrow))}
                 </div>
               ) : (
                 // v1 implicit section: render items FLAT into the outer grid (unchanged v1 behavior).

--- a/packages/form-builder-ui/src/index.ts
+++ b/packages/form-builder-ui/src/index.ts
@@ -7,4 +7,5 @@ export * from './item-editor';
 export * from './section-arranger';
 export * from './use-config-builder';
 export * from './use-data-source';
+export * from './use-container-breakpoint';
 export * from './use-signature-capture';

--- a/packages/form-builder-ui/src/index.ts
+++ b/packages/form-builder-ui/src/index.ts
@@ -7,5 +7,4 @@ export * from './item-editor';
 export * from './section-arranger';
 export * from './use-config-builder';
 export * from './use-data-source';
-export * from './use-container-breakpoint';
 export * from './use-signature-capture';

--- a/packages/form-builder-ui/src/index.ts
+++ b/packages/form-builder-ui/src/index.ts
@@ -6,5 +6,6 @@ export * from './field-row';
 export * from './item-editor';
 export * from './section-arranger';
 export * from './use-config-builder';
+export * from './use-container-breakpoint';
 export * from './use-data-source';
 export * from './use-signature-capture';

--- a/packages/form-builder-ui/src/use-container-breakpoint.spec.ts
+++ b/packages/form-builder-ui/src/use-container-breakpoint.spec.ts
@@ -1,3 +1,4 @@
+import { it, expect, beforeEach } from "vitest";
 import { renderHook, act } from "@testing-library/react";
 import * as React from "react";
 import { useContainerBreakpoint } from "./use-container-breakpoint";

--- a/packages/form-builder-ui/src/use-container-breakpoint.spec.ts
+++ b/packages/form-builder-ui/src/use-container-breakpoint.spec.ts
@@ -1,0 +1,27 @@
+import { renderHook, act } from "@testing-library/react";
+import * as React from "react";
+import { useContainerBreakpoint } from "./use-container-breakpoint";
+
+// Controllable ResizeObserver mock: captures the callback so the test can fire
+// width changes manually. Overrides the no-op stub from vitest.setup.ts.
+let cb: (e: any[]) => void;
+beforeEach(() => {
+  cb = () => {};
+  (globalThis as any).ResizeObserver = class {
+    constructor(c: any) {
+      cb = c;
+    }
+    observe() {}
+    disconnect() {}
+  };
+});
+
+it("starts false (SSR-safe) and flips when width < breakpoint", () => {
+  const ref = { current: document.createElement("div") } as React.RefObject<HTMLElement>;
+  const { result } = renderHook(() => useContainerBreakpoint(ref, 640));
+  expect(result.current).toBe(false);
+  act(() => cb([{ contentRect: { width: 500 } }]));
+  expect(result.current).toBe(true);
+  act(() => cb([{ contentRect: { width: 800 } }]));
+  expect(result.current).toBe(false);
+});

--- a/packages/form-builder-ui/src/use-container-breakpoint.ts
+++ b/packages/form-builder-ui/src/use-container-breakpoint.ts
@@ -1,7 +1,7 @@
 import * as React from "react";
 
 export function useContainerBreakpoint(
-  ref: React.RefObject<HTMLElement>,
+  ref: React.RefObject<Element>,
   breakpoint: number,
 ): boolean {
   const [narrow, setNarrow] = React.useState(false);
@@ -10,8 +10,8 @@ export function useContainerBreakpoint(
     const el = ref.current;
     if (!el || typeof ResizeObserver === "undefined") return;
     const ro = new ResizeObserver((entries) => {
-      const w = entries[0]?.contentRect?.width ?? el.clientWidth;
-      setNarrow((prev) => (prev === w < breakpoint ? prev : w < breakpoint));
+      const w = entries[0]?.contentRect.width ?? 0;
+      setNarrow(w < breakpoint);
     });
     ro.observe(el);
     return () => ro.disconnect();

--- a/packages/form-builder-ui/src/use-container-breakpoint.ts
+++ b/packages/form-builder-ui/src/use-container-breakpoint.ts
@@ -1,0 +1,21 @@
+import * as React from "react";
+
+export function useContainerBreakpoint(
+  ref: React.RefObject<HTMLElement>,
+  breakpoint: number,
+): boolean {
+  const [narrow, setNarrow] = React.useState(false);
+
+  React.useEffect(() => {
+    const el = ref.current;
+    if (!el || typeof ResizeObserver === "undefined") return;
+    const ro = new ResizeObserver((entries) => {
+      const w = entries[0]?.contentRect?.width ?? el.clientWidth;
+      setNarrow((prev) => (prev === w < breakpoint ? prev : w < breakpoint));
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [ref, breakpoint]);
+
+  return narrow;
+}

--- a/packages/form-builder-ui/src/use-container-breakpoint.ts
+++ b/packages/form-builder-ui/src/use-container-breakpoint.ts
@@ -1,7 +1,7 @@
 import * as React from "react";
 
 export function useContainerBreakpoint(
-  ref: React.RefObject<Element>,
+  ref: React.RefObject<HTMLElement | null>,
   breakpoint: number,
 ): boolean {
   const [narrow, setNarrow] = React.useState(false);

--- a/packages/form-builder/src/config-schema.spec.ts
+++ b/packages/form-builder/src/config-schema.spec.ts
@@ -485,3 +485,16 @@ describe('FileUpload/Signature components', () => {
     }).success).toBe(false);
   });
 });
+
+describe('FormConfig responsive', () => {
+  it('accepts and round-trips responsive.stackBelow', () => {
+    const cfg = { version: 1, sections: [{ id: 's', title: 'S', rows: [] }], responsive: { stackBelow: 540 } };
+    const parsed = formConfigSchema.parse(cfg as any);
+    expect(parsed.responsive?.stackBelow).toBe(540);
+    expect(JSON.parse(JSON.stringify(parsed))).toEqual(cfg);
+  });
+
+  it('allows omitting responsive', () => {
+    expect(formConfigSchema.safeParse({ version: 1, sections: [{ id: 's', title: 'S', rows: [] }] }).success).toBe(true);
+  });
+});

--- a/packages/form-builder/src/config-schema.ts
+++ b/packages/form-builder/src/config-schema.ts
@@ -173,6 +173,7 @@ export const FormConfigSchema: ZodType<FormConfig> = z
     fields: z.array(fieldConfigSchema).optional(),
     sections: z.array(formSectionSchema).optional(),
     columns: z.union([z.literal(1), z.literal(2), z.literal(3), z.literal(4)]).optional(),
+    responsive: z.object({ stackBelow: z.number().positive().optional() }).optional(),
   })
   .refine(
     (c) => c.fields !== undefined || c.sections !== undefined,

--- a/packages/form-builder/src/types.ts
+++ b/packages/form-builder/src/types.ts
@@ -127,6 +127,7 @@ export interface FormConfig {
   fields?: FieldConfig[];          // v1 (back-compat)
   sections?: FormSection[];        // v2
   columns?: 1 | 2 | 3 | 4;        // v1 grid (back-compat)
+  responsive?: { stackBelow?: number };
 }
 
 // --- File / Signature transport types ---

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -272,6 +272,9 @@ importers:
       '@testing-library/react':
         specifier: ^16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/node':
         specifier: ^25.9.3
         version: 25.9.3


### PR DESCRIPTION
Makes form-designer's forms genuinely responsive and adds a live preview/submission surface. Built on #216 (merged). Implemented via subagent-driven TDD (7 tasks) with per-task + a final opus whole-branch review.

Spec: `docs/superpowers/specs/2026-06-30-form-designer-preview-enhancements-design.md`
Plan: `docs/superpowers/plans/2026-06-30-form-designer-preview-enhancements.md`

## R — container-driven responsive reflow
- New `useContainerBreakpoint` (ResizeObserver, SSR-safe → wide until measured).
- `FormConfig.responsive.stackBelow` (px, **default 640**, per-form configurable).
- `ConfigForm` reflows by **container width** (not viewport, no iframe): outer / grid-mode / flow grids collapse to a single column below the threshold; grid-mode items stack in `(row, colStart)` reading order.
- Bonus: **form-builder linear forms become container-responsive too** (v1 preserved when wide).

## P — preview viewer
- New `<ResponsivePreview>`: device presets (Mobile/Tablet/Desktop) + manual width (slider/number/drag handle).
- **Preview tab** uses it full-size; **Canvas tab** gains two independent collapsibles — **Editor** (grid + inspector, default open) and **Live Preview** (compact, default collapsed; unmounts when collapsed).

## ① — live submission
- `ConfigForm` gains an `onPayloadChange({ data, meta })` seam (watch-driven, no Submit click).
- `meta` (`SubmissionMeta`) is validated over the **currently-visible** fields, so `meta.valid` matches actual submittability (hidden-required fields don't false-fail).
- New `<SubmissionPanel>` renders metadata + data live, outside the responsive frame.

## Testing
TDD throughout; per-task review caught + fixed: multi-value zod edges, orphan stack order, a `meta.valid` false-negative, a `compact` dead-branch, an **infinite re-render** (memoized `formConfig`), and accumulated **check-types** errors. Green: `@rfjs/form-builder` 165, `@rfjs/form-builder-ui` 235, `apps/web` form-designer 73; `web` + `form-builder-ui` check-types clean. Canvas two-collapsible verified rendering in the real app.

## Deferred (non-blocking, recorded)
First-paint multi-col flash for one frame in a narrow container (accepted SSR-wide-default tradeoff); number-input clamps on each keystroke (presets/slider/blur mitigate); a couple of test-hygiene notes. **② configurable button/action model** (send-to-API, reset/clear, metadata envelope) is a separate follow-up spec — `onPayloadChange` is its stepping stone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)