### PR TITLE
feat(bpmn): add @rfjs/bpmn headless viewer + apps/web bpmn-viewer tool

### DIFF
--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -34,3 +34,7 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# playwright
+/test-results/
+/playwright-report/

--- a/apps/web/e2e/bpmn-viewer.e2e.ts
+++ b/apps/web/e2e/bpmn-viewer.e2e.ts
@@ -1,0 +1,24 @@
+import { test, expect } from "@playwright/test";
+
+const URL = "/en/tools/bpmn-viewer";
+
+test("renders the default BPMN diagram as SVG", async ({ page }) => {
+  await page.goto(URL);
+  // bpmn-js renders SVG inside .djs-container; the default sample has at least one shape.
+  const shapes = page.locator(".djs-container svg .djs-element");
+  await expect(shapes.first()).toBeVisible({ timeout: 15_000 });
+});
+
+test("keeps the bpmn.io attribution badge visible (license)", async ({ page }) => {
+  await page.goto(URL);
+  await expect(page.locator(".bjs-powered-by")).toBeVisible({ timeout: 15_000 });
+});
+
+test("shows an error panel for invalid pasted XML", async ({ page }) => {
+  await page.goto(URL);
+  await page.getByLabel(/paste bpmn xml/i).fill("not really xml <<<");
+  await page.getByRole("button", { name: /^render$/i }).click();
+  // Next.js also has a hidden route-announcer div[role="alert"]; target the
+  // visible error paragraph specifically.
+  await expect(page.locator('p[role="alert"]')).toBeVisible({ timeout: 15_000 });
+});

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -2,7 +2,7 @@ import createNextIntlPlugin from "next-intl/plugin";
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  transpilePackages: ["@rfjs/web-ui", "@rfjs/web-core", "@rfjs/filter-builder-ui", "@rfjs/form-builder-ui"],
+  transpilePackages: ["@rfjs/web-ui", "@rfjs/web-core", "@rfjs/filter-builder-ui", "@rfjs/form-builder-ui", "@rfjs/bpmn"],
 };
 
 const withNextIntl = createNextIntlPlugin("./src/i18n/request.ts");

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,7 +10,8 @@
     "lint": "eslint . --max-warnings 0",
     "check-types": "tsc --noEmit",
     "test": "vitest run",
-    "vitest:run": "vitest run"
+    "vitest:run": "vitest run",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@rfjs/bpmn": "workspace:*",
@@ -57,6 +58,7 @@
     "tailwindcss": "^4.3.0",
     "typescript": "6.0.3",
     "typescript-eslint": "^8.61.0",
-    "vitest": "^4.1.8"
+    "vitest": "^4.1.8",
+    "@playwright/test": "^1.49.0"
   }
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,6 +13,7 @@
     "vitest:run": "vitest run"
   },
   "dependencies": {
+    "@rfjs/bpmn": "workspace:*",
     "@rfjs/filter-builder": "workspace:*",
     "@rfjs/filter-builder-ui": "workspace:*",
     "@rfjs/form-builder": "workspace:*",

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
   },
   projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
   webServer: {
-    command: `next dev --port ${E2E_PORT}`,
+    command: `pnpm exec next dev --port ${E2E_PORT}`,
     url: `http://localhost:${E2E_PORT}`,
     reuseExistingServer: !process.env.CI,
     timeout: 120_000,

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig, devices } from "@playwright/test";
+
+// Use a dedicated port for e2e so it doesn't collide with any
+// concurrently-running dev servers (web defaults to 3000).
+const E2E_PORT = process.env.E2E_PORT ? Number(process.env.E2E_PORT) : 3002;
+
+export default defineConfig({
+  testDir: "./e2e",
+  testMatch: "**/*.e2e.ts",
+  fullyParallel: true,
+  retries: 0,
+  reporter: "list",
+  use: {
+    baseURL: `http://localhost:${E2E_PORT}`,
+    trace: "on-first-retry",
+  },
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+  webServer: {
+    command: `next dev --port ${E2E_PORT}`,
+    url: `http://localhost:${E2E_PORT}`,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -97,6 +97,7 @@
     "object-utils": { "description": "Object manipulation utilities (flatten, paths, merge)." },
     "pg-toolkit": { "description": "PostgreSQL admin utilities (seed history, DB/schema creation)." },
     "retry": { "description": "Retry helper with configurable delay." },
+    "bpmn": { "description": "Render read-only BPMN 2.0 process diagrams from XML in React." },
     "tpl-toolkit": { "description": "Shared config factories for rfjs project templates." }
   }
 }

--- a/apps/web/src/messages/zh-TW.json
+++ b/apps/web/src/messages/zh-TW.json
@@ -97,6 +97,7 @@
     "object-utils": { "description": "物件操作工具(壓平、路徑、合併)。" },
     "pg-toolkit": { "description": "PostgreSQL 管理工具(seed 歷史、建立 DB/schema)。" },
     "retry": { "description": "可設定延遲的重試工具。" },
+    "bpmn": { "description": "在 React 中從 XML 渲染唯讀的 BPMN 2.0 流程圖。" },
     "tpl-toolkit": { "description": "rfjs 專案範本的共用設定工廠。" }
   }
 }

--- a/apps/web/src/tools/bpmn-viewer/file-input.spec.ts
+++ b/apps/web/src/tools/bpmn-viewer/file-input.spec.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import { validateBpmnFile, MAX_BPMN_BYTES } from "./file-input";
+
+describe("validateBpmnFile", () => {
+  it("accepts .bpmn and .xml within the size limit", () => {
+    expect(validateBpmnFile({ name: "flow.bpmn", size: 100 })).toEqual({ ok: true });
+    expect(validateBpmnFile({ name: "flow.xml", size: 100 })).toEqual({ ok: true });
+    expect(validateBpmnFile({ name: "FLOW.BPMN", size: 100 })).toEqual({ ok: true }); // 大小寫不敏感
+  });
+
+  it("rejects disallowed extensions", () => {
+    expect(validateBpmnFile({ name: "flow.pdf", size: 100 })).toEqual({ ok: false, reason: "extension" });
+    expect(validateBpmnFile({ name: "noext", size: 100 })).toEqual({ ok: false, reason: "extension" });
+  });
+
+  it("rejects empty and oversized files", () => {
+    expect(validateBpmnFile({ name: "flow.bpmn", size: 0 })).toEqual({ ok: false, reason: "empty" });
+    expect(validateBpmnFile({ name: "flow.bpmn", size: MAX_BPMN_BYTES + 1 })).toEqual({ ok: false, reason: "size" });
+  });
+});

--- a/apps/web/src/tools/bpmn-viewer/file-input.spec.ts
+++ b/apps/web/src/tools/bpmn-viewer/file-input.spec.ts
@@ -17,5 +17,6 @@ describe("validateBpmnFile", () => {
   it("rejects empty and oversized files", () => {
     expect(validateBpmnFile({ name: "flow.bpmn", size: 0 })).toEqual({ ok: false, reason: "empty" });
     expect(validateBpmnFile({ name: "flow.bpmn", size: MAX_BPMN_BYTES + 1 })).toEqual({ ok: false, reason: "size" });
+    expect(validateBpmnFile({ name: "flow.bpmn", size: MAX_BPMN_BYTES })).toEqual({ ok: true });
   });
 });

--- a/apps/web/src/tools/bpmn-viewer/file-input.ts
+++ b/apps/web/src/tools/bpmn-viewer/file-input.ts
@@ -1,0 +1,23 @@
+/** 上傳 BPMN 檔案大小上限:1 MiB。 */
+export const MAX_BPMN_BYTES = 1024 * 1024;
+/** 允許的副檔名(小寫)。 */
+export const ALLOWED_BPMN_EXTENSIONS = [".bpmn", ".xml"] as const;
+
+export interface BpmnFileMeta {
+  name: string;
+  size: number;
+}
+
+export type BpmnFileValidation = { ok: true } | { ok: false; reason: "extension" | "size" | "empty" };
+
+function hasAllowedExtension(name: string): boolean {
+  const lower = name.toLowerCase();
+  return ALLOWED_BPMN_EXTENSIONS.some((ext) => lower.endsWith(ext));
+}
+
+export function validateBpmnFile(meta: BpmnFileMeta): BpmnFileValidation {
+  if (!hasAllowedExtension(meta.name)) return { ok: false, reason: "extension" };
+  if (meta.size <= 0) return { ok: false, reason: "empty" };
+  if (meta.size > MAX_BPMN_BYTES) return { ok: false, reason: "size" };
+  return { ok: true };
+}

--- a/apps/web/src/tools/bpmn-viewer/index.ts
+++ b/apps/web/src/tools/bpmn-viewer/index.ts
@@ -1,0 +1,5 @@
+import type { ToolModule } from "@/tools/types";
+
+import { BpmnViewerTool } from "./ui";
+
+export const tool: ToolModule = { id: "bpmn-viewer", Component: BpmnViewerTool };

--- a/apps/web/src/tools/bpmn-viewer/messages.ts
+++ b/apps/web/src/tools/bpmn-viewer/messages.ts
@@ -23,6 +23,7 @@ export const messages: LocaleMessages = {
       bpmnErrSize: "File too large (max 1 MB)",
       bpmnErrEmpty: "File is empty",
       bpmnErrImport: "Could not render this diagram — the XML may be invalid",
+      bpmnErrRead: "Could not read the file",
     },
   },
   "zh-TW": {
@@ -47,6 +48,7 @@ export const messages: LocaleMessages = {
       bpmnErrSize: "檔案過大(上限 1 MB)",
       bpmnErrEmpty: "檔案是空的",
       bpmnErrImport: "無法渲染此圖 —— XML 可能無效",
+      bpmnErrRead: "無法讀取檔案",
     },
   },
 };

--- a/apps/web/src/tools/bpmn-viewer/messages.ts
+++ b/apps/web/src/tools/bpmn-viewer/messages.ts
@@ -1,0 +1,52 @@
+import type { LocaleMessages } from "@/tools/types";
+
+export const messages: LocaleMessages = {
+  en: {
+    Tools: {
+      "bpmn-viewer": {
+        title: "BPMN Viewer",
+        description:
+          "Render read-only BPMN 2.0 process diagrams from XML — pick a sample, paste XML, or upload a .bpmn file, then zoom and fit.",
+      },
+    },
+    ToolUI: {
+      bpmnEyebrow: "BPMN VIEWER",
+      bpmnSample: "Sample",
+      bpmnUpload: "Upload .bpmn",
+      bpmnPasteLabel: "Paste BPMN XML",
+      bpmnApply: "Render",
+      bpmnZoomIn: "Zoom in",
+      bpmnZoomOut: "Zoom out",
+      bpmnReset: "Reset",
+      bpmnFit: "Fit",
+      bpmnErrExtension: "Unsupported file type — use .bpmn or .xml",
+      bpmnErrSize: "File too large (max 1 MB)",
+      bpmnErrEmpty: "File is empty",
+      bpmnErrImport: "Could not render this diagram — the XML may be invalid",
+    },
+  },
+  "zh-TW": {
+    Tools: {
+      "bpmn-viewer": {
+        title: "BPMN 檢視器",
+        description:
+          "從 XML 渲染唯讀的 BPMN 2.0 流程圖 —— 選範例、貼上 XML 或上傳 .bpmn 檔,再縮放與 fit。",
+      },
+    },
+    ToolUI: {
+      bpmnEyebrow: "BPMN 檢視器",
+      bpmnSample: "範例",
+      bpmnUpload: "上傳 .bpmn",
+      bpmnPasteLabel: "貼上 BPMN XML",
+      bpmnApply: "渲染",
+      bpmnZoomIn: "放大",
+      bpmnZoomOut: "縮小",
+      bpmnReset: "重設",
+      bpmnFit: "符合畫面",
+      bpmnErrExtension: "不支援的檔案類型 —— 請用 .bpmn 或 .xml",
+      bpmnErrSize: "檔案過大(上限 1 MB)",
+      bpmnErrEmpty: "檔案是空的",
+      bpmnErrImport: "無法渲染此圖 —— XML 可能無效",
+    },
+  },
+};

--- a/apps/web/src/tools/bpmn-viewer/samples.spec.ts
+++ b/apps/web/src/tools/bpmn-viewer/samples.spec.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+
+import { SAMPLES, DEFAULT_SAMPLE_ID, getSample } from "./samples";
+
+describe("bpmn samples", () => {
+  it("ships at least two samples, each a valid-looking BPMN diagram", () => {
+    expect(SAMPLES.length).toBeGreaterThanOrEqual(2);
+    for (const s of SAMPLES) {
+      expect(s.id).toBeTruthy();
+      expect(s.label).toBeTruthy();
+      expect(s.xml).toContain("<bpmn:definitions");
+      expect(s.xml).toContain("bpmndi:BPMNDiagram"); // 需有 DI 才畫得出版面
+    }
+  });
+
+  it("has unique ids and a resolvable default", () => {
+    const ids = SAMPLES.map((s) => s.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(getSample(DEFAULT_SAMPLE_ID)).toBeDefined();
+    expect(getSample("nope")).toBeUndefined();
+  });
+});

--- a/apps/web/src/tools/bpmn-viewer/samples.ts
+++ b/apps/web/src/tools/bpmn-viewer/samples.ts
@@ -1,0 +1,64 @@
+export interface BpmnSample {
+  id: string;
+  label: string;
+  xml: string;
+}
+
+const LEAVE_REQUEST = `<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Defs_Leave" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="LeaveRequest" isExecutable="false">
+    <bpmn:startEvent id="Start_1" name="Submit request"><bpmn:outgoing>Flow_1</bpmn:outgoing></bpmn:startEvent>
+    <bpmn:task id="Task_1" name="Manager review"><bpmn:incoming>Flow_1</bpmn:incoming><bpmn:outgoing>Flow_2</bpmn:outgoing></bpmn:task>
+    <bpmn:endEvent id="End_1" name="Notified"><bpmn:incoming>Flow_2</bpmn:incoming></bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="Start_1" targetRef="Task_1" />
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="Task_1" targetRef="End_1" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="Diag_Leave">
+    <bpmndi:BPMNPlane id="Plane_Leave" bpmnElement="LeaveRequest">
+      <bpmndi:BPMNShape id="Start_1_di" bpmnElement="Start_1"><dc:Bounds x="152" y="102" width="36" height="36" /></bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_1_di" bpmnElement="Task_1"><dc:Bounds x="240" y="80" width="100" height="80" /></bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="End_1_di" bpmnElement="End_1"><dc:Bounds x="392" y="102" width="36" height="36" /></bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1_di" bpmnElement="Flow_1"><di:waypoint x="188" y="120" /><di:waypoint x="240" y="120" /></bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_2_di" bpmnElement="Flow_2"><di:waypoint x="340" y="120" /><di:waypoint x="392" y="120" /></bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>`;
+
+const ORDER_APPROVAL = `<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Defs_Order" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="OrderApproval" isExecutable="false">
+    <bpmn:startEvent id="O_Start" name="Order placed"><bpmn:outgoing>O_F1</bpmn:outgoing></bpmn:startEvent>
+    <bpmn:exclusiveGateway id="O_Gw" name="Amount > 1000?"><bpmn:incoming>O_F1</bpmn:incoming><bpmn:outgoing>O_F2</bpmn:outgoing><bpmn:outgoing>O_F3</bpmn:outgoing></bpmn:exclusiveGateway>
+    <bpmn:task id="O_Review" name="Manual review"><bpmn:incoming>O_F2</bpmn:incoming><bpmn:outgoing>O_F4</bpmn:outgoing></bpmn:task>
+    <bpmn:endEvent id="O_Auto" name="Auto-approved"><bpmn:incoming>O_F3</bpmn:incoming></bpmn:endEvent>
+    <bpmn:endEvent id="O_Done" name="Approved"><bpmn:incoming>O_F4</bpmn:incoming></bpmn:endEvent>
+    <bpmn:sequenceFlow id="O_F1" sourceRef="O_Start" targetRef="O_Gw" />
+    <bpmn:sequenceFlow id="O_F2" name="yes" sourceRef="O_Gw" targetRef="O_Review" />
+    <bpmn:sequenceFlow id="O_F3" name="no" sourceRef="O_Gw" targetRef="O_Auto" />
+    <bpmn:sequenceFlow id="O_F4" sourceRef="O_Review" targetRef="O_Done" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="Diag_Order">
+    <bpmndi:BPMNPlane id="Plane_Order" bpmnElement="OrderApproval">
+      <bpmndi:BPMNShape id="O_Start_di" bpmnElement="O_Start"><dc:Bounds x="152" y="142" width="36" height="36" /></bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="O_Gw_di" bpmnElement="O_Gw" isMarkerVisible="true"><dc:Bounds x="245" y="135" width="50" height="50" /></bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="O_Review_di" bpmnElement="O_Review"><dc:Bounds x="360" y="120" width="100" height="80" /></bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="O_Auto_di" bpmnElement="O_Auto"><dc:Bounds x="392" y="252" width="36" height="36" /></bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="O_Done_di" bpmnElement="O_Done"><dc:Bounds x="512" y="142" width="36" height="36" /></bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="O_F1_di" bpmnElement="O_F1"><di:waypoint x="188" y="160" /><di:waypoint x="245" y="160" /></bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="O_F2_di" bpmnElement="O_F2"><di:waypoint x="295" y="160" /><di:waypoint x="360" y="160" /></bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="O_F3_di" bpmnElement="O_F3"><di:waypoint x="270" y="185" /><di:waypoint x="270" y="270" /><di:waypoint x="392" y="270" /></bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="O_F4_di" bpmnElement="O_F4"><di:waypoint x="460" y="160" /><di:waypoint x="512" y="160" /></bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>`;
+
+export const SAMPLES: BpmnSample[] = [
+  { id: "leave-request", label: "Leave Request", xml: LEAVE_REQUEST },
+  { id: "order-approval", label: "Order Approval", xml: ORDER_APPROVAL },
+];
+
+export const DEFAULT_SAMPLE_ID = "leave-request";
+
+export function getSample(id: string): BpmnSample | undefined {
+  return SAMPLES.find((s) => s.id === id);
+}

--- a/apps/web/src/tools/bpmn-viewer/ui.spec.tsx
+++ b/apps/web/src/tools/bpmn-viewer/ui.spec.tsx
@@ -11,7 +11,7 @@ import { NextIntlClientProvider } from "next-intl";
 import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@rfjs/bpmn", () => ({
-  BpmnViewer: ({ xml }: { xml: string }) => <div data-testid="bpmn-viewer" data-xml={xml} />,
+  BpmnViewer: ({ xml }: { xml: string }) => <div data-testid="bpmn-viewer">{xml}</div>,
   useBpmnViewer: () => ({
     viewerProps: { ref: { current: null }, onLoadingChange: () => {}, onError: () => {} },
     zoomIn: () => {},
@@ -38,7 +38,7 @@ describe("BpmnViewerTool", () => {
   it("renders the default sample into the viewer", () => {
     renderTool();
     const viewer = screen.getByTestId("bpmn-viewer");
-    expect(viewer.getAttribute("data-xml")).toContain("<bpmn:definitions");
+    expect(viewer.textContent).toContain("<bpmn:definitions");
   });
 
   it("renders pasted XML when Render is clicked", () => {
@@ -46,7 +46,7 @@ describe("BpmnViewerTool", () => {
     const textarea = screen.getByLabelText(/paste bpmn xml/i) as HTMLTextAreaElement;
     fireEvent.change(textarea, { target: { value: "<bpmn:definitions id='X'/>" } });
     fireEvent.click(screen.getByRole("button", { name: /^render$/i }));
-    expect(screen.getByTestId("bpmn-viewer").getAttribute("data-xml")).toContain("id='X'");
+    expect(screen.getByTestId("bpmn-viewer").textContent).toContain("id='X'");
   });
 
   it("shows an error for an unsupported uploaded file type", () => {

--- a/apps/web/src/tools/bpmn-viewer/ui.spec.tsx
+++ b/apps/web/src/tools/bpmn-viewer/ui.spec.tsx
@@ -1,0 +1,59 @@
+// jsdom shim: radix-ui Select 需要 pointer capture / scrollIntoView。
+if (typeof Element !== "undefined") {
+  if (!Element.prototype.hasPointerCapture) Element.prototype.hasPointerCapture = () => false;
+  if (!Element.prototype.setPointerCapture) Element.prototype.setPointerCapture = () => {};
+  if (!Element.prototype.releasePointerCapture) Element.prototype.releasePointerCapture = () => {};
+  if (!Element.prototype.scrollIntoView) Element.prototype.scrollIntoView = () => {};
+}
+
+import { render, screen, fireEvent } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@rfjs/bpmn", () => ({
+  BpmnViewer: ({ xml }: { xml: string }) => <div data-testid="bpmn-viewer" data-xml={xml} />,
+  useBpmnViewer: () => ({
+    viewerProps: { ref: { current: null }, onLoadingChange: () => {}, onError: () => {} },
+    zoomIn: () => {},
+    zoomOut: () => {},
+    resetZoom: () => {},
+    fitViewport: () => {},
+    importing: false,
+    error: null,
+  }),
+}));
+
+import { messages } from "./messages";
+import { BpmnViewerTool } from "./ui";
+
+function renderTool() {
+  return render(
+    <NextIntlClientProvider locale="en" messages={messages.en as Record<string, unknown>}>
+      <BpmnViewerTool />
+    </NextIntlClientProvider>,
+  );
+}
+
+describe("BpmnViewerTool", () => {
+  it("renders the default sample into the viewer", () => {
+    renderTool();
+    const viewer = screen.getByTestId("bpmn-viewer");
+    expect(viewer.getAttribute("data-xml")).toContain("<bpmn:definitions");
+  });
+
+  it("renders pasted XML when Render is clicked", () => {
+    renderTool();
+    const textarea = screen.getByLabelText(/paste bpmn xml/i) as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: "<bpmn:definitions id='X'/>" } });
+    fireEvent.click(screen.getByRole("button", { name: /^render$/i }));
+    expect(screen.getByTestId("bpmn-viewer").getAttribute("data-xml")).toContain("id='X'");
+  });
+
+  it("shows an error for an unsupported uploaded file type", () => {
+    renderTool();
+    const file = new File(["data"], "notes.pdf", { type: "application/pdf" });
+    const input = screen.getByTestId("bpmn-file-input") as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [file] } });
+    expect(screen.getByRole("alert").textContent).toMatch(/unsupported file type/i);
+  });
+});

--- a/apps/web/src/tools/bpmn-viewer/ui.tsx
+++ b/apps/web/src/tools/bpmn-viewer/ui.tsx
@@ -58,7 +58,9 @@ export function BpmnViewerTool() {
       setInputError(null);
       setXml(String(reader.result ?? ""));
     };
+    reader.onerror = () => setInputError(t("bpmnErrImport"));
     reader.readAsText(file);
+    e.target.value = "";
   };
 
   const error = inputError ?? (v.error ? t("bpmnErrImport") : null);

--- a/apps/web/src/tools/bpmn-viewer/ui.tsx
+++ b/apps/web/src/tools/bpmn-viewer/ui.tsx
@@ -59,7 +59,7 @@ export function BpmnViewerTool() {
       setInputError(null);
       setXml(String(reader.result ?? ""));
     };
-    reader.onerror = () => setInputError(t("bpmnErrImport"));
+    reader.onerror = () => setInputError(t("bpmnErrRead"));
     reader.readAsText(file);
   };
 

--- a/apps/web/src/tools/bpmn-viewer/ui.tsx
+++ b/apps/web/src/tools/bpmn-viewer/ui.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import * as React from "react";
+import { ZoomIn, ZoomOut, Maximize, RotateCcw, Upload } from "lucide-react";
+import { useTranslations } from "next-intl";
+
+import { BpmnViewer, useBpmnViewer } from "@rfjs/bpmn";
+import { Button } from "@rfjs/web-ui/components/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@rfjs/web-ui/components/select";
+
+import { SAMPLES, DEFAULT_SAMPLE_ID, getSample } from "./samples";
+import { validateBpmnFile } from "./file-input";
+
+export function BpmnViewerTool() {
+  const t = useTranslations("ToolUI");
+  const v = useBpmnViewer();
+
+  const [xml, setXml] = React.useState(() => getSample(DEFAULT_SAMPLE_ID)?.xml ?? "");
+  const [paste, setPaste] = React.useState("");
+  const [inputError, setInputError] = React.useState<string | null>(null);
+  const fileRef = React.useRef<HTMLInputElement>(null);
+
+  const onSelectSample = (id: string) => {
+    const s = getSample(id);
+    if (!s) return;
+    setInputError(null);
+    setXml(s.xml);
+  };
+
+  const onApplyPaste = () => {
+    if (!paste.trim()) return;
+    setInputError(null);
+    setXml(paste);
+  };
+
+  const onFile = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const result = validateBpmnFile({ name: file.name, size: file.size });
+    if (!result.ok) {
+      setInputError(
+        result.reason === "extension"
+          ? t("bpmnErrExtension")
+          : result.reason === "size"
+            ? t("bpmnErrSize")
+            : t("bpmnErrEmpty"),
+      );
+      return;
+    }
+    const reader = new FileReader();
+    reader.onload = () => {
+      setInputError(null);
+      setXml(String(reader.result ?? ""));
+    };
+    reader.readAsText(file);
+  };
+
+  const error = inputError ?? (v.error ? t("bpmnErrImport") : null);
+
+  return (
+    <div className="flex flex-col gap-3">
+      <p className="text-xs font-semibold tracking-widest text-muted-foreground">{t("bpmnEyebrow")}</p>
+
+      <div className="flex flex-wrap items-center gap-2">
+        <Select defaultValue={DEFAULT_SAMPLE_ID} onValueChange={onSelectSample}>
+          <SelectTrigger className="w-48" aria-label={t("bpmnSample")}>
+            <SelectValue placeholder={t("bpmnSample")} />
+          </SelectTrigger>
+          <SelectContent>
+            {SAMPLES.map((s) => (
+              <SelectItem key={s.id} value={s.id}>
+                {s.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <Button variant="outline" size="sm" onClick={() => fileRef.current?.click()}>
+          <Upload className="mr-1 h-4 w-4" />
+          {t("bpmnUpload")}
+        </Button>
+        <input
+          ref={fileRef}
+          data-testid="bpmn-file-input"
+          type="file"
+          accept=".bpmn,.xml"
+          className="hidden"
+          onChange={onFile}
+        />
+
+        <div className="ml-auto flex items-center gap-1">
+          <Button variant="outline" size="icon" aria-label={t("bpmnZoomIn")} onClick={v.zoomIn}>
+            <ZoomIn className="h-4 w-4" />
+          </Button>
+          <Button variant="outline" size="icon" aria-label={t("bpmnZoomOut")} onClick={v.zoomOut}>
+            <ZoomOut className="h-4 w-4" />
+          </Button>
+          <Button variant="outline" size="icon" aria-label={t("bpmnReset")} onClick={v.resetZoom}>
+            <RotateCcw className="h-4 w-4" />
+          </Button>
+          <Button variant="outline" size="icon" aria-label={t("bpmnFit")} onClick={v.fitViewport}>
+            <Maximize className="h-4 w-4" />
+          </Button>
+        </div>
+      </div>
+
+      {error && (
+        <p role="alert" className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+          {error}
+        </p>
+      )}
+
+      <BpmnViewer
+        {...v.viewerProps}
+        xml={xml}
+        className="h-[600px] w-full rounded-md border bg-card"
+      />
+
+      <div className="flex flex-col gap-2">
+        <label htmlFor="bpmn-paste" className="text-sm font-medium">
+          {t("bpmnPasteLabel")}
+        </label>
+        <textarea
+          id="bpmn-paste"
+          value={paste}
+          onChange={(e) => setPaste(e.target.value)}
+          rows={5}
+          className="w-full rounded-md border bg-background p-2 font-mono text-xs"
+          placeholder="<bpmn:definitions ...>"
+        />
+        <div>
+          <Button size="sm" onClick={onApplyPaste}>
+            {t("bpmnApply")}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/tools/bpmn-viewer/ui.tsx
+++ b/apps/web/src/tools/bpmn-viewer/ui.tsx
@@ -42,6 +42,7 @@ export function BpmnViewerTool() {
   const onFile = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
+    e.target.value = "";
     const result = validateBpmnFile({ name: file.name, size: file.size });
     if (!result.ok) {
       setInputError(
@@ -60,7 +61,6 @@ export function BpmnViewerTool() {
     };
     reader.onerror = () => setInputError(t("bpmnErrImport"));
     reader.readAsText(file);
-    e.target.value = "";
   };
 
   const error = inputError ?? (v.error ? t("bpmnErrImport") : null);

--- a/apps/web/src/tools/index.spec.ts
+++ b/apps/web/src/tools/index.spec.ts
@@ -23,6 +23,7 @@ const EXPECTED_WEB_TOOL_IDS = [
   "pg-filter-builder",
   "form-builder",
   "form-designer",
+  "bpmn-viewer",
 ].sort();
 
 describe("implementation registry", () => {

--- a/apps/web/src/tools/index.ts
+++ b/apps/web/src/tools/index.ts
@@ -6,6 +6,7 @@ import { tool as dataFilterBuilder } from "./data-filter-builder";
 import { tool as dataFilterTester } from "./data-filter-tester";
 import { tool as formBuilder } from "./form-builder";
 import { tool as formDesigner } from "./form-designer";
+import { tool as bpmnViewer } from "./bpmn-viewer";
 import { tool as esClientDemo } from "./es-client-demo";
 import { tool as esQueryBuilder } from "./es-query-builder";
 import { tool as jsonbQueryBuilder } from "./jsonb-query-builder";
@@ -35,6 +36,7 @@ export const toolModules: ToolModule[] = [
   pgFilterBuilder,
   formBuilder,
   formDesigner,
+  bpmnViewer,
 ];
 
 export const TOOL_COMPONENTS: Record<string, ComponentType> = Object.fromEntries(

--- a/apps/web/src/tools/messages.ts
+++ b/apps/web/src/tools/messages.ts
@@ -4,6 +4,7 @@ import { messages as dataFilterBuilder } from "./data-filter-builder/messages";
 import { messages as dataFilterTester } from "./data-filter-tester/messages";
 import { messages as formBuilder } from "./form-builder/messages";
 import { messages as formDesigner } from "./form-designer/messages";
+import { messages as bpmnViewer } from "./bpmn-viewer/messages";
 import { messages as esClientDemo } from "./es-client-demo/messages";
 import { messages as esQueryBuilder } from "./es-query-builder/messages";
 import { messages as jsonbQueryBuilder } from "./jsonb-query-builder/messages";
@@ -33,4 +34,5 @@ export const toolMessages: LocaleMessages[] = [
   pgFilterBuilder,
   formBuilder,
   formDesigner,
+  bpmnViewer,
 ];

--- a/docs/superpowers/plans/2026-06-30-rfjs-bpmn-viewer.md
+++ b/docs/superpowers/plans/2026-06-30-rfjs-bpmn-viewer.md
@@ -1,0 +1,1640 @@
+# @rfjs/bpmn Viewer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 封裝 `bpmn-js` 的唯讀 BPMN 流程圖檢視器,做成 private 套件 `@rfjs/bpmn`(薄 React wrapper),並在 `apps/web` 加一個 `bpmn-viewer` tool 展示。
+
+**Architecture:** 無頭薄封裝 —— 套件只提供 `<BpmnViewer>`(controlled `xml` prop + ref handle)、`useBpmnViewer` hook、型別;工具列/範例/上傳/錯誤面板等外殼留在 `apps/web` 展示頁(用 `@rfjs/web-ui`)。套件無 build step,由 Next.js `transpilePackages` 直接消費 source。bpmn-js 於 mount effect 內動態 import(SSR 安全),只在 client 端建立。
+
+**Tech Stack:** React 19、`bpmn-js@^18.19.0`(NavigatedViewer,內建 TS 型別)、Vitest(jsdom,mock bpmn-js)、`@playwright/test`(net-new e2e)、Next.js(apps/web)。
+
+## Global Constraints
+
+- 全程在 worktree `.claude/worktrees/feat-bpmn-viewer` 內編輯/測試/commit(從 `origin/main` 建立)。
+- 套件 `@rfjs/bpmn`:`"private": true`、`"type": "module"`、`"version": "0.0.0"`、`exports` 僅 `{ ".": "./src/index.ts" }`(無 dist)。
+- React 為 `peerDependencies`(`^19.0.0`);`bpmn-js@^18.19.0` 為 `dependencies`。套件**不依賴** `@rfjs/web-ui`、**不使用 Tailwind**(因此 apps/web 不需加 `@source`,只需 `transpilePackages`)。
+- **授權硬約束**:`NavigatedViewer` 自動加入的 `.bjs-powered-by`(Powered by bpmn.io)標誌**絕不可**用 CSS/DOM 隱藏。e2e 斷言其可見;code review 檢查無隱藏規則。
+- 檔案命名 kebab-case(比照 `filter-builder-ui`);co-locate `*.spec.ts(x)`。
+- commit/PR:英文 conventional commits,每個 commit 訊息結尾加 `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`。
+- **HOLD PR**:全部完成後不開/不合 PR,等人工於 GitHub 合併。
+- 所有觸及 `@rfjs/*` 與 `apps/web` 皆為 private package,**不需 changeset**。
+- git 指令一律加 `-C /home/royfw/_/code/royfw/rfjs/.claude/worktrees/feat-bpmn-viewer`,pnpm 一律加 `-C <worktree>` 或 `--filter`,避免動到主 checkout。
+
+> 下文所有相對路徑均相對於 worktree 根目錄 `.claude/worktrees/feat-bpmn-viewer/`。
+> 每個 commit 前先 `git -C <worktree> add <files>`。為精簡,步驟中的 `git commit` 省略 worktree 前綴,實際執行時請帶上 `-C <worktree>`。
+
+---
+
+## Task 1: Scaffold `@rfjs/bpmn` 套件 + zoom 純函式
+
+**Files:**
+- Create: `packages/bpmn/package.json`
+- Create: `packages/bpmn/tsconfig.json`
+- Create: `packages/bpmn/vitest.config.mts`
+- Create: `packages/bpmn/src/zoom.ts`
+- Test: `packages/bpmn/src/zoom.spec.ts`
+- Create: `packages/bpmn/src/index.ts`(暫時只 export zoom)
+
+**Interfaces:**
+- Produces:
+  - `ZOOM_FACTOR: number`、`MIN_ZOOM: number`、`MAX_ZOOM: number`
+  - `clampZoom(z: number): number`
+  - `zoomBy(current: number, factor: number): number`
+
+- [ ] **Step 1: 建立套件設定檔**
+
+`packages/bpmn/package.json`:
+
+```json
+{
+  "name": "@rfjs/bpmn",
+  "version": "0.0.0",
+  "description": "Headless React wrapper around bpmn-js NavigatedViewer (read-only BPMN viewer); consumed via transpilePackages",
+  "type": "module",
+  "private": true,
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "lint": "eslint . --max-warnings 0",
+    "check-types": "tsc --noEmit",
+    "test": "vitest --passWithNoTests --run",
+    "vitest:run": "vitest --passWithNoTests --run"
+  },
+  "dependencies": {
+    "bpmn-js": "^18.19.0"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.20.0",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.2",
+    "@types/react": "19.2.17",
+    "@types/react-dom": "19.2.3",
+    "eslint": "^9.20.1",
+    "eslint-config-prettier": "^10.0.1",
+    "eslint-plugin-react": "^7.37.4",
+    "eslint-plugin-react-hooks": "^5.1.0",
+    "jsdom": "^29.1.1",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
+    "typescript": "6.0.3",
+    "typescript-eslint": "^8.61.0",
+    "vitest": "^3.2.4"
+  },
+  "peerDependencies": {
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  }
+}
+```
+
+`packages/bpmn/tsconfig.json`:
+
+```json
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["es2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "moduleDetection": "force",
+    "jsx": "react-jsx",
+    "noEmit": true,
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
+}
+```
+
+`packages/bpmn/vitest.config.mts`:
+
+```ts
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+  resolve: { alias: { '@': path.resolve(__dirname, 'src') } },
+  test: {
+    environment: 'jsdom',
+    include: ['src/**/*.spec.(ts|tsx)'],
+    globals: true,
+    reporters: ['verbose'],
+  },
+});
+```
+
+`packages/bpmn/src/index.ts`(先放 zoom,後續 task 補):
+
+```ts
+export * from "./zoom";
+```
+
+- [ ] **Step 2: 安裝相依、連結 workspace、鎖定 CSS 路徑**
+
+Run:
+```bash
+pnpm -C /home/royfw/_/code/royfw/rfjs/.claude/worktrees/feat-bpmn-viewer install
+ls /home/royfw/_/code/royfw/rfjs/.claude/worktrees/feat-bpmn-viewer/node_modules/bpmn-js/dist/assets
+ls /home/royfw/_/code/royfw/rfjs/.claude/worktrees/feat-bpmn-viewer/node_modules/bpmn-js/dist/assets/bpmn-font/css
+```
+Expected: `assets/` 含 `diagram-js.css`、`bpmn-js.css`;`bpmn-font/css/` 含 `bpmn-embedded.css`(若實際檔名不同,於 Task 2 的 CSS import 改用實際檔名)。
+
+- [ ] **Step 3: 寫失敗測試** — `packages/bpmn/src/zoom.spec.ts`
+
+```ts
+import { describe, expect, it } from "vitest";
+
+import { ZOOM_FACTOR, MIN_ZOOM, MAX_ZOOM, clampZoom, zoomBy } from "./zoom";
+
+describe("zoom helpers", () => {
+  it("clamps below min and above max", () => {
+    expect(clampZoom(MIN_ZOOM - 1)).toBe(MIN_ZOOM);
+    expect(clampZoom(MAX_ZOOM + 1)).toBe(MAX_ZOOM);
+    expect(clampZoom(1)).toBe(1);
+  });
+
+  it("zoomBy multiplies then clamps", () => {
+    expect(zoomBy(1, ZOOM_FACTOR)).toBeCloseTo(ZOOM_FACTOR);
+    expect(zoomBy(1, 1 / ZOOM_FACTOR)).toBeCloseTo(1 / ZOOM_FACTOR);
+    expect(zoomBy(MAX_ZOOM, ZOOM_FACTOR)).toBe(MAX_ZOOM); // already at max
+    expect(zoomBy(MIN_ZOOM, 1 / ZOOM_FACTOR)).toBe(MIN_ZOOM); // already at min
+  });
+});
+```
+
+- [ ] **Step 4: 跑測試確認失敗**
+
+Run: `pnpm -C <worktree> --filter @rfjs/bpmn vitest:run`
+Expected: FAIL —— 找不到 `./zoom` 模組。
+
+- [ ] **Step 5: 實作 `packages/bpmn/src/zoom.ts`**
+
+```ts
+/** 縮放係數:每次 zoomIn/zoomOut 乘以或除以此值。 */
+export const ZOOM_FACTOR = 1.2;
+/** 最小縮放倍率。 */
+export const MIN_ZOOM = 0.2;
+/** 最大縮放倍率。 */
+export const MAX_ZOOM = 4;
+
+/** 把縮放倍率限制在 [MIN_ZOOM, MAX_ZOOM]。 */
+export const clampZoom = (z: number): number => Math.max(MIN_ZOOM, Math.min(MAX_ZOOM, z));
+
+/** 以 current × factor 計算新倍率並 clamp。 */
+export const zoomBy = (current: number, factor: number): number => clampZoom(current * factor);
+```
+
+- [ ] **Step 6: 跑測試確認通過**
+
+Run: `pnpm -C <worktree> --filter @rfjs/bpmn vitest:run`
+Expected: PASS(2 passed)。
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/bpmn/package.json packages/bpmn/tsconfig.json packages/bpmn/vitest.config.mts \
+  packages/bpmn/src/zoom.ts packages/bpmn/src/zoom.spec.ts packages/bpmn/src/index.ts \
+  pnpm-lock.yaml
+git commit -m "feat(bpmn): scaffold @rfjs/bpmn package with zoom helpers
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: `<BpmnViewer>` 元件 + 型別(mock bpmn-js)
+
+**Files:**
+- Create: `packages/bpmn/src/types.ts`
+- Create: `packages/bpmn/src/bpmn-viewer.tsx`
+- Test: `packages/bpmn/src/bpmn-viewer.spec.tsx`
+- Modify: `packages/bpmn/src/index.ts`
+
+**Interfaces:**
+- Consumes: `zoomBy`, `ZOOM_FACTOR` from `./zoom`
+- Produces:
+  - `interface BpmnImportResult { warnings: unknown[] }`
+  - `interface BpmnViewerError { message: string; warnings?: unknown[]; cause?: unknown }`
+  - `interface BpmnViewerProps { xml: string; options?: Record<string, unknown>; className?: string; style?: React.CSSProperties; onImport?: (r: BpmnImportResult) => void; onError?: (e: BpmnViewerError) => void; onLoadingChange?: (loading: boolean) => void }`
+  - `interface BpmnViewerHandle { zoomIn(): void; zoomOut(): void; resetZoom(): void; fitViewport(): void; getZoom(): number; getViewer(): unknown }`
+  - `const BpmnViewer: React.ForwardRefExoticComponent<BpmnViewerProps & React.RefAttributes<BpmnViewerHandle>>`
+
+- [ ] **Step 1: 寫型別 `packages/bpmn/src/types.ts`**
+
+```ts
+import type { CSSProperties } from "react";
+
+export interface BpmnImportResult {
+  warnings: unknown[];
+}
+
+export interface BpmnViewerError {
+  message: string;
+  warnings?: unknown[];
+  cause?: unknown;
+}
+
+export interface BpmnViewerProps {
+  /** 受控的 BPMN 2.0 XML 字串。 */
+  xml: string;
+  /** 透傳給 NavigatedViewer 建構子的額外選項。 */
+  options?: Record<string, unknown>;
+  className?: string;
+  style?: CSSProperties;
+  onImport?: (result: BpmnImportResult) => void;
+  onError?: (error: BpmnViewerError) => void;
+  onLoadingChange?: (loading: boolean) => void;
+}
+
+export interface BpmnViewerHandle {
+  zoomIn(): void;
+  zoomOut(): void;
+  resetZoom(): void;
+  fitViewport(): void;
+  getZoom(): number;
+  /** 逃生艙:回傳底層 NavigatedViewer 實例(未建立時為 null)。 */
+  getViewer(): unknown;
+}
+```
+
+- [ ] **Step 2: 寫失敗測試 `packages/bpmn/src/bpmn-viewer.spec.tsx`**
+
+```tsx
+import { render, waitFor } from "@testing-library/react";
+import { createRef } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { BpmnViewer } from "./bpmn-viewer";
+import type { BpmnViewerHandle } from "./types";
+
+// 共享的 mock 函式,讓我們跨實例斷言呼叫。
+const ctor = vi.fn();
+const importXML = vi.fn();
+const destroy = vi.fn();
+const zoom = vi.fn(() => 1);
+const canvas = { zoom };
+const get = vi.fn((name: string) => (name === "canvas" ? canvas : undefined));
+
+vi.mock("bpmn-js/lib/NavigatedViewer", () => ({
+  default: class MockViewer {
+    constructor(opts: unknown) {
+      ctor(opts);
+    }
+    importXML = importXML;
+    get = get;
+    destroy = destroy;
+  },
+}));
+
+const XML_A = "<bpmn:a/>";
+const XML_B = "<bpmn:b/>";
+
+beforeEach(() => {
+  ctor.mockClear();
+  importXML.mockReset().mockResolvedValue({ warnings: [] });
+  destroy.mockClear();
+  zoom.mockReset().mockReturnValue(1);
+  get.mockClear();
+});
+
+describe("<BpmnViewer>", () => {
+  it("creates a NavigatedViewer with a container element on mount", async () => {
+    render(<BpmnViewer xml={XML_A} />);
+    await waitFor(() => expect(ctor).toHaveBeenCalledTimes(1));
+    const opts = ctor.mock.calls[0]![0] as { container: unknown };
+    expect(opts.container).toBeInstanceOf(HTMLElement);
+  });
+
+  it("imports the xml and fits the viewport, then calls onImport", async () => {
+    const onImport = vi.fn();
+    render(<BpmnViewer xml={XML_A} onImport={onImport} />);
+    await waitFor(() => expect(importXML).toHaveBeenCalledWith(XML_A));
+    await waitFor(() => expect(onImport).toHaveBeenCalledWith({ warnings: [] }));
+    expect(zoom).toHaveBeenCalledWith("fit-viewport");
+  });
+
+  it("toggles onLoadingChange true then false", async () => {
+    const onLoadingChange = vi.fn();
+    render(<BpmnViewer xml={XML_A} onLoadingChange={onLoadingChange} />);
+    await waitFor(() => expect(onLoadingChange).toHaveBeenCalledWith(false));
+    expect(onLoadingChange.mock.calls[0]![0]).toBe(true);
+  });
+
+  it("calls onError when importXML rejects", async () => {
+    importXML.mockRejectedValueOnce(new Error("bad xml"));
+    const onError = vi.fn();
+    render(<BpmnViewer xml={XML_A} onError={onError} />);
+    await waitFor(() => expect(onError).toHaveBeenCalledTimes(1));
+    expect(onError.mock.calls[0]![0]).toMatchObject({ message: "bad xml" });
+  });
+
+  it("re-imports when xml prop changes", async () => {
+    const { rerender } = render(<BpmnViewer xml={XML_A} />);
+    await waitFor(() => expect(importXML).toHaveBeenCalledWith(XML_A));
+    rerender(<BpmnViewer xml={XML_B} />);
+    await waitFor(() => expect(importXML).toHaveBeenCalledWith(XML_B));
+  });
+
+  it("destroys the viewer on unmount", async () => {
+    const { unmount } = render(<BpmnViewer xml={XML_A} />);
+    await waitFor(() => expect(ctor).toHaveBeenCalledTimes(1));
+    unmount();
+    await waitFor(() => expect(destroy).toHaveBeenCalledTimes(1));
+  });
+
+  it("exposes imperative zoom handle methods", async () => {
+    const ref = createRef<BpmnViewerHandle>();
+    render(<BpmnViewer xml={XML_A} ref={ref} />);
+    await waitFor(() => expect(ctor).toHaveBeenCalledTimes(1));
+    ref.current!.fitViewport();
+    expect(zoom).toHaveBeenCalledWith("fit-viewport");
+    zoom.mockReturnValue(1);
+    ref.current!.zoomIn();
+    // zoomIn → zoom(current * ZOOM_FACTOR) = zoom(1.2)
+    expect(zoom).toHaveBeenCalledWith(expect.closeTo(1.2, 5));
+    expect(ref.current!.getZoom()).toBe(1);
+  });
+
+  it("ignores a stale import result when a newer import supersedes it", async () => {
+    // 第一次 import 延遲解析,第二次先解析 → 只有第二次的 onImport 生效。
+    let resolveFirst!: (v: { warnings: unknown[] }) => void;
+    importXML
+      .mockImplementationOnce(() => new Promise((res) => (resolveFirst = res)))
+      .mockResolvedValueOnce({ warnings: ["second"] });
+    const onImport = vi.fn();
+    const { rerender } = render(<BpmnViewer xml={XML_A} onImport={onImport} />);
+    await waitFor(() => expect(importXML).toHaveBeenCalledTimes(1));
+    rerender(<BpmnViewer xml={XML_B} onImport={onImport} />);
+    await waitFor(() => expect(onImport).toHaveBeenCalledWith({ warnings: ["second"] }));
+    // 現在才解析第一次(過期)—— 不應再觸發 onImport。
+    resolveFirst({ warnings: ["first"] });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(onImport).toHaveBeenCalledTimes(1);
+    expect(onImport).not.toHaveBeenCalledWith({ warnings: ["first"] });
+  });
+});
+```
+
+- [ ] **Step 3: 跑測試確認失敗**
+
+Run: `pnpm -C <worktree> --filter @rfjs/bpmn vitest:run`
+Expected: FAIL —— 找不到 `./bpmn-viewer`。
+
+- [ ] **Step 4: 實作 `packages/bpmn/src/bpmn-viewer.tsx`**
+
+> CSS import 路徑若 Task 1 Step 2 實測檔名不同,改成實測值。
+
+```tsx
+"use client";
+
+import {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from "react";
+
+import "bpmn-js/dist/assets/diagram-js.css";
+import "bpmn-js/dist/assets/bpmn-js.css";
+import "bpmn-js/dist/assets/bpmn-font/css/bpmn-embedded.css";
+
+import { ZOOM_FACTOR, zoomBy } from "./zoom";
+import type { BpmnViewerError, BpmnViewerHandle, BpmnViewerProps } from "./types";
+
+interface BpmnCanvas {
+  zoom(level?: number | string, center?: unknown): number;
+}
+interface BpmnInstance {
+  importXML(xml: string): Promise<{ warnings?: unknown[] }>;
+  get(name: string): unknown;
+  destroy(): void;
+}
+
+export const BpmnViewer = forwardRef<BpmnViewerHandle, BpmnViewerProps>(
+  function BpmnViewer({ xml, options, className, style, onImport, onError, onLoadingChange }, ref) {
+    const containerRef = useRef<HTMLDivElement>(null);
+    const viewerRef = useRef<BpmnInstance | null>(null);
+    const importSeq = useRef(0);
+    const [ready, setReady] = useState(false);
+
+    // 把最新 callback 收進 ref,避免 inline callback 造成 import effect 反覆重跑。
+    const cbRef = useRef({ onImport, onError, onLoadingChange });
+    cbRef.current = { onImport, onError, onLoadingChange };
+
+    // 建立 / 銷毀 viewer(client-only;動態 import 確保 SSR 不觸碰 bpmn-js)。
+    useEffect(() => {
+      const container = containerRef.current;
+      if (!container) return;
+      let cancelled = false;
+      let created: BpmnInstance | null = null;
+
+      void (async () => {
+        const mod = await import("bpmn-js/lib/NavigatedViewer");
+        if (cancelled) return;
+        const NavigatedViewer = mod.default as new (opts: Record<string, unknown>) => BpmnInstance;
+        created = new NavigatedViewer({ container, ...(options ?? {}) });
+        viewerRef.current = created;
+        setReady(true);
+      })();
+
+      return () => {
+        cancelled = true;
+        if (created) created.destroy();
+        viewerRef.current = null;
+        setReady(false);
+      };
+    }, [options]);
+
+    // viewer 就緒或 xml 變更 → import(含競態保護)。
+    useEffect(() => {
+      const viewer = viewerRef.current;
+      if (!ready || !viewer || !xml) return;
+      const seq = ++importSeq.current;
+      cbRef.current.onLoadingChange?.(true);
+      viewer
+        .importXML(xml)
+        .then((result) => {
+          if (seq !== importSeq.current) return;
+          cbRef.current.onLoadingChange?.(false);
+          (viewer.get("canvas") as BpmnCanvas).zoom("fit-viewport");
+          cbRef.current.onImport?.({ warnings: result?.warnings ?? [] });
+        })
+        .catch((err: unknown) => {
+          if (seq !== importSeq.current) return;
+          cbRef.current.onLoadingChange?.(false);
+          const e: BpmnViewerError = {
+            message: err instanceof Error ? err.message : String(err),
+            warnings: (err as { warnings?: unknown[] })?.warnings,
+            cause: err,
+          };
+          cbRef.current.onError?.(e);
+        });
+    }, [ready, xml]);
+
+    useImperativeHandle(
+      ref,
+      (): BpmnViewerHandle => {
+        const canvas = (): BpmnCanvas | null =>
+          (viewerRef.current?.get("canvas") as BpmnCanvas | undefined) ?? null;
+        return {
+          zoomIn() {
+            const c = canvas();
+            if (c) c.zoom(zoomBy(c.zoom(), ZOOM_FACTOR));
+          },
+          zoomOut() {
+            const c = canvas();
+            if (c) c.zoom(zoomBy(c.zoom(), 1 / ZOOM_FACTOR));
+          },
+          resetZoom() {
+            canvas()?.zoom("fit-viewport");
+          },
+          fitViewport() {
+            canvas()?.zoom("fit-viewport");
+          },
+          getZoom() {
+            return canvas()?.zoom() ?? 1;
+          },
+          getViewer() {
+            return viewerRef.current;
+          },
+        };
+      },
+      [ready],
+    );
+
+    return <div ref={containerRef} className={className} style={style} />;
+  },
+);
+```
+
+- [ ] **Step 5: 更新 barrel `packages/bpmn/src/index.ts`**
+
+```ts
+export * from "./zoom";
+export * from "./types";
+export * from "./bpmn-viewer";
+```
+
+- [ ] **Step 6: 跑測試確認通過**
+
+Run: `pnpm -C <worktree> --filter @rfjs/bpmn vitest:run`
+Expected: PASS(zoom 2 + viewer 8 = 10 passed)。
+
+- [ ] **Step 7: typecheck**
+
+Run: `pnpm -C <worktree> --filter @rfjs/bpmn check-types`
+Expected: 無錯誤。
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/bpmn/src/types.ts packages/bpmn/src/bpmn-viewer.tsx \
+  packages/bpmn/src/bpmn-viewer.spec.tsx packages/bpmn/src/index.ts
+git commit -m "feat(bpmn): add headless BpmnViewer component over NavigatedViewer
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: `useBpmnViewer` hook
+
+**Files:**
+- Create: `packages/bpmn/src/use-bpmn-viewer.ts`
+- Test: `packages/bpmn/src/use-bpmn-viewer.spec.ts`
+- Modify: `packages/bpmn/src/index.ts`
+
+**Interfaces:**
+- Consumes: `BpmnViewerHandle`, `BpmnViewerError` from `./types`
+- Produces:
+  - `interface UseBpmnViewer { viewerProps: { ref: React.RefObject<BpmnViewerHandle | null>; onLoadingChange: (loading: boolean) => void; onError: (error: BpmnViewerError) => void }; zoomIn: () => void; zoomOut: () => void; resetZoom: () => void; fitViewport: () => void; importing: boolean; error: BpmnViewerError | null }`
+  - `function useBpmnViewer(): UseBpmnViewer`
+
+- [ ] **Step 1: 寫失敗測試 `packages/bpmn/src/use-bpmn-viewer.spec.ts`**
+
+```ts
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { useBpmnViewer } from "./use-bpmn-viewer";
+import type { BpmnViewerHandle } from "./types";
+
+describe("useBpmnViewer", () => {
+  it("returns viewerProps with a ref and the two handlers", () => {
+    const { result } = renderHook(() => useBpmnViewer());
+    expect(result.current.viewerProps).toHaveProperty("ref");
+    expect(typeof result.current.viewerProps.onLoadingChange).toBe("function");
+    expect(typeof result.current.viewerProps.onError).toBe("function");
+  });
+
+  it("proxies zoom actions to the attached ref handle", () => {
+    const { result } = renderHook(() => useBpmnViewer());
+    const handle: BpmnViewerHandle = {
+      zoomIn: vi.fn(),
+      zoomOut: vi.fn(),
+      resetZoom: vi.fn(),
+      fitViewport: vi.fn(),
+      getZoom: vi.fn(() => 1),
+      getViewer: vi.fn(() => null),
+    };
+    result.current.viewerProps.ref.current = handle;
+    act(() => result.current.zoomIn());
+    act(() => result.current.fitViewport());
+    expect(handle.zoomIn).toHaveBeenCalledTimes(1);
+    expect(handle.fitViewport).toHaveBeenCalledTimes(1);
+  });
+
+  it("tracks importing state and clears error when a new load starts", () => {
+    const { result } = renderHook(() => useBpmnViewer());
+    act(() => result.current.viewerProps.onError({ message: "x" }));
+    expect(result.current.error).toEqual({ message: "x" });
+    act(() => result.current.viewerProps.onLoadingChange(true));
+    expect(result.current.importing).toBe(true);
+    expect(result.current.error).toBeNull();
+    act(() => result.current.viewerProps.onLoadingChange(false));
+    expect(result.current.importing).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: 跑測試確認失敗**
+
+Run: `pnpm -C <worktree> --filter @rfjs/bpmn vitest:run`
+Expected: FAIL —— 找不到 `./use-bpmn-viewer`。
+
+- [ ] **Step 3: 實作 `packages/bpmn/src/use-bpmn-viewer.ts`**
+
+```ts
+"use client";
+
+import { useCallback, useMemo, useRef, useState } from "react";
+import type { RefObject } from "react";
+
+import type { BpmnViewerError, BpmnViewerHandle } from "./types";
+
+export interface UseBpmnViewer {
+  /** 直接 spread 到 <BpmnViewer> 的 props(ref + 內部 handler)。 */
+  viewerProps: {
+    ref: RefObject<BpmnViewerHandle | null>;
+    onLoadingChange: (loading: boolean) => void;
+    onError: (error: BpmnViewerError) => void;
+  };
+  zoomIn: () => void;
+  zoomOut: () => void;
+  resetZoom: () => void;
+  fitViewport: () => void;
+  importing: boolean;
+  error: BpmnViewerError | null;
+}
+
+export function useBpmnViewer(): UseBpmnViewer {
+  const ref = useRef<BpmnViewerHandle | null>(null);
+  const [importing, setImporting] = useState(false);
+  const [error, setError] = useState<BpmnViewerError | null>(null);
+
+  const onLoadingChange = useCallback((loading: boolean) => {
+    setImporting(loading);
+    if (loading) setError(null);
+  }, []);
+  const onError = useCallback((e: BpmnViewerError) => setError(e), []);
+
+  const zoomIn = useCallback(() => ref.current?.zoomIn(), []);
+  const zoomOut = useCallback(() => ref.current?.zoomOut(), []);
+  const resetZoom = useCallback(() => ref.current?.resetZoom(), []);
+  const fitViewport = useCallback(() => ref.current?.fitViewport(), []);
+
+  const viewerProps = useMemo(
+    () => ({ ref, onLoadingChange, onError }),
+    [onLoadingChange, onError],
+  );
+
+  return { viewerProps, zoomIn, zoomOut, resetZoom, fitViewport, importing, error };
+}
+```
+
+- [ ] **Step 4: 更新 barrel** — 在 `packages/bpmn/src/index.ts` 末尾加:
+
+```ts
+export * from "./use-bpmn-viewer";
+```
+
+- [ ] **Step 5: 跑測試 + typecheck 確認通過**
+
+Run: `pnpm -C <worktree> --filter @rfjs/bpmn vitest:run && pnpm -C <worktree> --filter @rfjs/bpmn check-types`
+Expected: PASS(13 passed)、typecheck 無錯誤。
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/bpmn/src/use-bpmn-viewer.ts packages/bpmn/src/use-bpmn-viewer.spec.ts packages/bpmn/src/index.ts
+git commit -m "feat(bpmn): add useBpmnViewer hook wrapping the ref handle
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: 套件 README + lint 綠燈(套件完成 gate)
+
+**Files:**
+- Create: `packages/bpmn/README.md`
+- Create: `packages/bpmn/README.zh-TW.md`
+
+**Interfaces:** 無新增程式介面。
+
+- [ ] **Step 1: 寫 `packages/bpmn/README.md`**
+
+````markdown
+# @rfjs/bpmn
+
+Headless React wrapper around [`bpmn-js`](https://github.com/bpmn-io/bpmn-js) `NavigatedViewer` — a read-only BPMN 2.0 diagram viewer. Private workspace package, consumed via Next.js `transpilePackages` (no build step).
+
+> **License:** `bpmn-js` is distributed under the [bpmn.io license](https://bpmn.io/license/). The viewer renders a "Powered by bpmn.io" badge; **do not hide it**.
+
+## Usage
+
+```tsx
+import { BpmnViewer, useBpmnViewer } from "@rfjs/bpmn";
+
+function Demo({ xml }: { xml: string }) {
+  const v = useBpmnViewer();
+  return (
+    <div>
+      <button onClick={v.zoomIn}>+</button>
+      <button onClick={v.zoomOut}>-</button>
+      <button onClick={v.fitViewport}>fit</button>
+      <BpmnViewer {...v.viewerProps} xml={xml} className="h-[600px] w-full" />
+      {v.error && <p role="alert">{v.error.message}</p>}
+    </div>
+  );
+}
+```
+
+## API
+
+- `<BpmnViewer xml options className style onImport onError onLoadingChange ref />` — controlled component. The `ref` exposes `BpmnViewerHandle` (`zoomIn`/`zoomOut`/`resetZoom`/`fitViewport`/`getZoom`/`getViewer`).
+- `useBpmnViewer()` — returns `{ viewerProps, zoomIn, zoomOut, resetZoom, fitViewport, importing, error }`. Spread `viewerProps` onto `<BpmnViewer>`.
+
+The container needs an explicit height to render.
+````
+
+- [ ] **Step 2: 寫 `packages/bpmn/README.zh-TW.md`**
+
+````markdown
+# @rfjs/bpmn
+
+封裝 [`bpmn-js`](https://github.com/bpmn-io/bpmn-js) `NavigatedViewer` 的無頭 React 元件 —— 唯讀 BPMN 2.0 流程圖檢視器。Private workspace 套件,透過 Next.js `transpilePackages` 消費(無 build step)。
+
+> **授權:** `bpmn-js` 採用 [bpmn.io 授權](https://bpmn.io/license/)。檢視器會顯示「Powered by bpmn.io」標誌,**請勿隱藏**。
+
+## 用法
+
+```tsx
+import { BpmnViewer, useBpmnViewer } from "@rfjs/bpmn";
+
+function Demo({ xml }: { xml: string }) {
+  const v = useBpmnViewer();
+  return (
+    <div>
+      <button onClick={v.zoomIn}>+</button>
+      <button onClick={v.fitViewport}>fit</button>
+      <BpmnViewer {...v.viewerProps} xml={xml} className="h-[600px] w-full" />
+      {v.error && <p role="alert">{v.error.message}</p>}
+    </div>
+  );
+}
+```
+
+## API
+
+- `<BpmnViewer>` —— 受控元件;`ref` 提供 `BpmnViewerHandle`(`zoomIn`/`zoomOut`/`resetZoom`/`fitViewport`/`getZoom`/`getViewer`)。
+- `useBpmnViewer()` —— 回傳 `{ viewerProps, zoomIn, zoomOut, resetZoom, fitViewport, importing, error }`;把 `viewerProps` spread 到 `<BpmnViewer>`。
+
+容器需有明確高度才能渲染。
+````
+
+- [ ] **Step 3: lint + 全套件測試 + typecheck 綠燈**
+
+Run:
+```bash
+pnpm -C <worktree> --filter @rfjs/bpmn lint
+pnpm -C <worktree> --filter @rfjs/bpmn check-types
+pnpm -C <worktree> --filter @rfjs/bpmn vitest:run
+```
+Expected: lint 0 warning、typecheck 無錯誤、測試 13 passed。
+
+> 若 lint 因 eslint 設定缺檔報錯,比照 `packages/filter-builder-ui` 補上相同的 eslint flat config(`eslint.config.mjs`);沿用其內容。
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/bpmn/README.md packages/bpmn/README.zh-TW.md
+git commit -m "docs(bpmn): add @rfjs/bpmn README (en + zh-TW)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: 展示頁範例資料 `samples.ts`
+
+**Files:**
+- Create: `apps/web/src/tools/bpmn-viewer/samples.ts`
+- Test: `apps/web/src/tools/bpmn-viewer/samples.spec.ts`
+
+**Interfaces:**
+- Produces:
+  - `interface BpmnSample { id: string; label: string; xml: string }`
+  - `const SAMPLES: BpmnSample[]`(至少 2 筆)
+  - `const DEFAULT_SAMPLE_ID: string`
+  - `function getSample(id: string): BpmnSample | undefined`
+
+- [ ] **Step 1: 寫失敗測試 `apps/web/src/tools/bpmn-viewer/samples.spec.ts`**
+
+```ts
+import { describe, expect, it } from "vitest";
+
+import { SAMPLES, DEFAULT_SAMPLE_ID, getSample } from "./samples";
+
+describe("bpmn samples", () => {
+  it("ships at least two samples, each a valid-looking BPMN diagram", () => {
+    expect(SAMPLES.length).toBeGreaterThanOrEqual(2);
+    for (const s of SAMPLES) {
+      expect(s.id).toBeTruthy();
+      expect(s.label).toBeTruthy();
+      expect(s.xml).toContain("<bpmn:definitions");
+      expect(s.xml).toContain("bpmndi:BPMNDiagram"); // 需有 DI 才畫得出版面
+    }
+  });
+
+  it("has unique ids and a resolvable default", () => {
+    const ids = SAMPLES.map((s) => s.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(getSample(DEFAULT_SAMPLE_ID)).toBeDefined();
+    expect(getSample("nope")).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: 跑測試確認失敗**
+
+Run: `pnpm -C <worktree> --filter web vitest:run -- samples`
+Expected: FAIL —— 找不到 `./samples`。
+
+- [ ] **Step 3: 實作 `apps/web/src/tools/bpmn-viewer/samples.ts`**
+
+```ts
+export interface BpmnSample {
+  id: string;
+  label: string;
+  xml: string;
+}
+
+const LEAVE_REQUEST = `<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Defs_Leave" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="LeaveRequest" isExecutable="false">
+    <bpmn:startEvent id="Start_1" name="Submit request"><bpmn:outgoing>Flow_1</bpmn:outgoing></bpmn:startEvent>
+    <bpmn:task id="Task_1" name="Manager review"><bpmn:incoming>Flow_1</bpmn:incoming><bpmn:outgoing>Flow_2</bpmn:outgoing></bpmn:task>
+    <bpmn:endEvent id="End_1" name="Notified"><bpmn:incoming>Flow_2</bpmn:incoming></bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="Start_1" targetRef="Task_1" />
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="Task_1" targetRef="End_1" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="Diag_Leave">
+    <bpmndi:BPMNPlane id="Plane_Leave" bpmnElement="LeaveRequest">
+      <bpmndi:BPMNShape id="Start_1_di" bpmnElement="Start_1"><dc:Bounds x="152" y="102" width="36" height="36" /></bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_1_di" bpmnElement="Task_1"><dc:Bounds x="240" y="80" width="100" height="80" /></bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="End_1_di" bpmnElement="End_1"><dc:Bounds x="392" y="102" width="36" height="36" /></bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1_di" bpmnElement="Flow_1"><di:waypoint x="188" y="120" /><di:waypoint x="240" y="120" /></bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_2_di" bpmnElement="Flow_2"><di:waypoint x="340" y="120" /><di:waypoint x="392" y="120" /></bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>`;
+
+const ORDER_APPROVAL = `<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Defs_Order" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="OrderApproval" isExecutable="false">
+    <bpmn:startEvent id="O_Start" name="Order placed"><bpmn:outgoing>O_F1</bpmn:outgoing></bpmn:startEvent>
+    <bpmn:exclusiveGateway id="O_Gw" name="Amount > 1000?"><bpmn:incoming>O_F1</bpmn:incoming><bpmn:outgoing>O_F2</bpmn:outgoing><bpmn:outgoing>O_F3</bpmn:outgoing></bpmn:exclusiveGateway>
+    <bpmn:task id="O_Review" name="Manual review"><bpmn:incoming>O_F2</bpmn:incoming><bpmn:outgoing>O_F4</bpmn:outgoing></bpmn:task>
+    <bpmn:endEvent id="O_Auto" name="Auto-approved"><bpmn:incoming>O_F3</bpmn:incoming></bpmn:endEvent>
+    <bpmn:endEvent id="O_Done" name="Approved"><bpmn:incoming>O_F4</bpmn:incoming></bpmn:endEvent>
+    <bpmn:sequenceFlow id="O_F1" sourceRef="O_Start" targetRef="O_Gw" />
+    <bpmn:sequenceFlow id="O_F2" name="yes" sourceRef="O_Gw" targetRef="O_Review" />
+    <bpmn:sequenceFlow id="O_F3" name="no" sourceRef="O_Gw" targetRef="O_Auto" />
+    <bpmn:sequenceFlow id="O_F4" sourceRef="O_Review" targetRef="O_Done" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="Diag_Order">
+    <bpmndi:BPMNPlane id="Plane_Order" bpmnElement="OrderApproval">
+      <bpmndi:BPMNShape id="O_Start_di" bpmnElement="O_Start"><dc:Bounds x="152" y="142" width="36" height="36" /></bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="O_Gw_di" bpmnElement="O_Gw" isMarkerVisible="true"><dc:Bounds x="245" y="135" width="50" height="50" /></bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="O_Review_di" bpmnElement="O_Review"><dc:Bounds x="360" y="120" width="100" height="80" /></bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="O_Auto_di" bpmnElement="O_Auto"><dc:Bounds x="392" y="252" width="36" height="36" /></bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="O_Done_di" bpmnElement="O_Done"><dc:Bounds x="512" y="142" width="36" height="36" /></bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="O_F1_di" bpmnElement="O_F1"><di:waypoint x="188" y="160" /><di:waypoint x="245" y="160" /></bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="O_F2_di" bpmnElement="O_F2"><di:waypoint x="295" y="160" /><di:waypoint x="360" y="160" /></bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="O_F3_di" bpmnElement="O_F3"><di:waypoint x="270" y="185" /><di:waypoint x="270" y="270" /><di:waypoint x="392" y="270" /></bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="O_F4_di" bpmnElement="O_F4"><di:waypoint x="460" y="160" /><di:waypoint x="512" y="160" /></bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>`;
+
+export const SAMPLES: BpmnSample[] = [
+  { id: "leave-request", label: "Leave Request", xml: LEAVE_REQUEST },
+  { id: "order-approval", label: "Order Approval", xml: ORDER_APPROVAL },
+];
+
+export const DEFAULT_SAMPLE_ID = "leave-request";
+
+export function getSample(id: string): BpmnSample | undefined {
+  return SAMPLES.find((s) => s.id === id);
+}
+```
+
+- [ ] **Step 4: 跑測試確認通過**
+
+Run: `pnpm -C <worktree> --filter web vitest:run -- samples`
+Expected: PASS。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/tools/bpmn-viewer/samples.ts apps/web/src/tools/bpmn-viewer/samples.spec.ts
+git commit -m "feat(web): add bundled BPMN samples for bpmn-viewer tool
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: 檔案上傳驗證 `file-input.ts`
+
+**Files:**
+- Create: `apps/web/src/tools/bpmn-viewer/file-input.ts`
+- Test: `apps/web/src/tools/bpmn-viewer/file-input.spec.ts`
+
+**Interfaces:**
+- Produces:
+  - `const MAX_BPMN_BYTES = 1048576`(1 MiB)
+  - `const ALLOWED_BPMN_EXTENSIONS: readonly string[]`(`[".bpmn", ".xml"]`)
+  - `interface BpmnFileMeta { name: string; size: number }`
+  - `type BpmnFileValidation = { ok: true } | { ok: false; reason: "extension" | "size" | "empty" }`
+  - `function validateBpmnFile(meta: BpmnFileMeta): BpmnFileValidation`
+
+- [ ] **Step 1: 寫失敗測試 `apps/web/src/tools/bpmn-viewer/file-input.spec.ts`**
+
+```ts
+import { describe, expect, it } from "vitest";
+
+import { validateBpmnFile, MAX_BPMN_BYTES } from "./file-input";
+
+describe("validateBpmnFile", () => {
+  it("accepts .bpmn and .xml within the size limit", () => {
+    expect(validateBpmnFile({ name: "flow.bpmn", size: 100 })).toEqual({ ok: true });
+    expect(validateBpmnFile({ name: "flow.xml", size: 100 })).toEqual({ ok: true });
+    expect(validateBpmnFile({ name: "FLOW.BPMN", size: 100 })).toEqual({ ok: true }); // 大小寫不敏感
+  });
+
+  it("rejects disallowed extensions", () => {
+    expect(validateBpmnFile({ name: "flow.pdf", size: 100 })).toEqual({ ok: false, reason: "extension" });
+    expect(validateBpmnFile({ name: "noext", size: 100 })).toEqual({ ok: false, reason: "extension" });
+  });
+
+  it("rejects empty and oversized files", () => {
+    expect(validateBpmnFile({ name: "flow.bpmn", size: 0 })).toEqual({ ok: false, reason: "empty" });
+    expect(validateBpmnFile({ name: "flow.bpmn", size: MAX_BPMN_BYTES + 1 })).toEqual({ ok: false, reason: "size" });
+  });
+});
+```
+
+- [ ] **Step 2: 跑測試確認失敗**
+
+Run: `pnpm -C <worktree> --filter web vitest:run -- file-input`
+Expected: FAIL。
+
+- [ ] **Step 3: 實作 `apps/web/src/tools/bpmn-viewer/file-input.ts`**
+
+```ts
+/** 上傳 BPMN 檔案大小上限:1 MiB。 */
+export const MAX_BPMN_BYTES = 1024 * 1024;
+/** 允許的副檔名(小寫)。 */
+export const ALLOWED_BPMN_EXTENSIONS = [".bpmn", ".xml"] as const;
+
+export interface BpmnFileMeta {
+  name: string;
+  size: number;
+}
+
+export type BpmnFileValidation = { ok: true } | { ok: false; reason: "extension" | "size" | "empty" };
+
+function hasAllowedExtension(name: string): boolean {
+  const lower = name.toLowerCase();
+  return ALLOWED_BPMN_EXTENSIONS.some((ext) => lower.endsWith(ext));
+}
+
+export function validateBpmnFile(meta: BpmnFileMeta): BpmnFileValidation {
+  if (!hasAllowedExtension(meta.name)) return { ok: false, reason: "extension" };
+  if (meta.size <= 0) return { ok: false, reason: "empty" };
+  if (meta.size > MAX_BPMN_BYTES) return { ok: false, reason: "size" };
+  return { ok: true };
+}
+```
+
+- [ ] **Step 4: 跑測試確認通過**
+
+Run: `pnpm -C <worktree> --filter web vitest:run -- file-input`
+Expected: PASS。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/tools/bpmn-viewer/file-input.ts apps/web/src/tools/bpmn-viewer/file-input.spec.ts
+git commit -m "feat(web): add bpmn file-upload validation helper
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: 展示頁元件 `ui.tsx` + `messages.ts` + `index.ts`
+
+**先決:** 此 task 的測試會 import `@rfjs/bpmn`,故先把它加進 apps/web 相依並 install。
+
+**Files:**
+- Modify: `apps/web/package.json`(加 `"@rfjs/bpmn": "workspace:*"` 到 `dependencies`)
+- Create: `apps/web/src/tools/bpmn-viewer/messages.ts`
+- Create: `apps/web/src/tools/bpmn-viewer/ui.tsx`
+- Create: `apps/web/src/tools/bpmn-viewer/index.ts`
+- Test: `apps/web/src/tools/bpmn-viewer/ui.spec.tsx`
+
+**Interfaces:**
+- Consumes: `BpmnViewer`, `useBpmnViewer` from `@rfjs/bpmn`;`SAMPLES`, `DEFAULT_SAMPLE_ID`, `getSample` from `./samples`;`validateBpmnFile` from `./file-input`
+- Produces:
+  - `const messages: LocaleMessages`(含 `Tools["bpmn-viewer"]` 與 `ToolUI` 的 `bpmn*` 前綴鍵)
+  - `function BpmnViewerTool(): JSX.Element`
+  - `const tool: ToolModule = { id: "bpmn-viewer", Component: BpmnViewerTool }`
+
+- [ ] **Step 1: 加相依並 install**
+
+修改 `apps/web/package.json` 的 `dependencies`,加入(依字母序放在 `@rfjs/*` 區塊頂部即可):
+
+```json
+    "@rfjs/bpmn": "workspace:*",
+```
+
+Run:
+```bash
+pnpm -C /home/royfw/_/code/royfw/rfjs/.claude/worktrees/feat-bpmn-viewer install
+```
+Expected: 成功連結 workspace。
+
+- [ ] **Step 2: 寫 `apps/web/src/tools/bpmn-viewer/messages.ts`**
+
+```ts
+import type { LocaleMessages } from "@/tools/types";
+
+export const messages: LocaleMessages = {
+  en: {
+    Tools: {
+      "bpmn-viewer": {
+        title: "BPMN Viewer",
+        description:
+          "Render read-only BPMN 2.0 process diagrams from XML — pick a sample, paste XML, or upload a .bpmn file, then zoom and fit.",
+      },
+    },
+    ToolUI: {
+      bpmnEyebrow: "BPMN VIEWER",
+      bpmnSample: "Sample",
+      bpmnUpload: "Upload .bpmn",
+      bpmnPasteLabel: "Paste BPMN XML",
+      bpmnApply: "Render",
+      bpmnZoomIn: "Zoom in",
+      bpmnZoomOut: "Zoom out",
+      bpmnReset: "Reset",
+      bpmnFit: "Fit",
+      bpmnErrExtension: "Unsupported file type — use .bpmn or .xml",
+      bpmnErrSize: "File too large (max 1 MB)",
+      bpmnErrEmpty: "File is empty",
+      bpmnErrImport: "Could not render this diagram — the XML may be invalid",
+    },
+  },
+  "zh-TW": {
+    Tools: {
+      "bpmn-viewer": {
+        title: "BPMN 檢視器",
+        description:
+          "從 XML 渲染唯讀的 BPMN 2.0 流程圖 —— 選範例、貼上 XML 或上傳 .bpmn 檔,再縮放與 fit。",
+      },
+    },
+    ToolUI: {
+      bpmnEyebrow: "BPMN 檢視器",
+      bpmnSample: "範例",
+      bpmnUpload: "上傳 .bpmn",
+      bpmnPasteLabel: "貼上 BPMN XML",
+      bpmnApply: "渲染",
+      bpmnZoomIn: "放大",
+      bpmnZoomOut: "縮小",
+      bpmnReset: "重設",
+      bpmnFit: "符合畫面",
+      bpmnErrExtension: "不支援的檔案類型 —— 請用 .bpmn 或 .xml",
+      bpmnErrSize: "檔案過大(上限 1 MB)",
+      bpmnErrEmpty: "檔案是空的",
+      bpmnErrImport: "無法渲染此圖 —— XML 可能無效",
+    },
+  },
+};
+```
+
+- [ ] **Step 3: 寫失敗測試 `apps/web/src/tools/bpmn-viewer/ui.spec.tsx`**
+
+> 頂部的 jsdom shim 與 form-designer 測試一致(radix Select 需要)。`@rfjs/bpmn` 整個被 mock,避免在 jsdom 跑真 bpmn-js。
+
+```tsx
+// jsdom shim: radix-ui Select 需要 pointer capture / scrollIntoView。
+if (typeof Element !== "undefined") {
+  if (!Element.prototype.hasPointerCapture) Element.prototype.hasPointerCapture = () => false;
+  if (!Element.prototype.setPointerCapture) Element.prototype.setPointerCapture = () => {};
+  if (!Element.prototype.releasePointerCapture) Element.prototype.releasePointerCapture = () => {};
+  if (!Element.prototype.scrollIntoView) Element.prototype.scrollIntoView = () => {};
+}
+
+import { render, screen, fireEvent } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@rfjs/bpmn", () => ({
+  BpmnViewer: ({ xml }: { xml: string }) => <div data-testid="bpmn-viewer" data-xml={xml} />,
+  useBpmnViewer: () => ({
+    viewerProps: { ref: { current: null }, onLoadingChange: () => {}, onError: () => {} },
+    zoomIn: () => {},
+    zoomOut: () => {},
+    resetZoom: () => {},
+    fitViewport: () => {},
+    importing: false,
+    error: null,
+  }),
+}));
+
+import { messages } from "./messages";
+import { BpmnViewerTool } from "./ui";
+
+function renderTool() {
+  return render(
+    <NextIntlClientProvider locale="en" messages={messages.en as Record<string, unknown>}>
+      <BpmnViewerTool />
+    </NextIntlClientProvider>,
+  );
+}
+
+describe("BpmnViewerTool", () => {
+  it("renders the default sample into the viewer", () => {
+    renderTool();
+    const viewer = screen.getByTestId("bpmn-viewer");
+    expect(viewer.getAttribute("data-xml")).toContain("<bpmn:definitions");
+  });
+
+  it("renders pasted XML when Render is clicked", () => {
+    renderTool();
+    const textarea = screen.getByLabelText(/paste bpmn xml/i) as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: "<bpmn:definitions id='X'/>" } });
+    fireEvent.click(screen.getByRole("button", { name: /^render$/i }));
+    expect(screen.getByTestId("bpmn-viewer").getAttribute("data-xml")).toContain("id='X'");
+  });
+
+  it("shows an error for an unsupported uploaded file type", () => {
+    renderTool();
+    const file = new File(["data"], "notes.pdf", { type: "application/pdf" });
+    const input = screen.getByTestId("bpmn-file-input") as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [file] } });
+    expect(screen.getByRole("alert").textContent).toMatch(/unsupported file type/i);
+  });
+});
+```
+
+- [ ] **Step 4: 跑測試確認失敗**
+
+Run: `pnpm -C <worktree> --filter web vitest:run -- bpmn-viewer/ui`
+Expected: FAIL —— 找不到 `./ui`。
+
+- [ ] **Step 5: 寫 `apps/web/src/tools/bpmn-viewer/ui.tsx`**
+
+```tsx
+"use client";
+
+import * as React from "react";
+import { ZoomIn, ZoomOut, Maximize, RotateCcw, Upload } from "lucide-react";
+import { useTranslations } from "next-intl";
+
+import { BpmnViewer, useBpmnViewer } from "@rfjs/bpmn";
+import { Button } from "@rfjs/web-ui/components/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@rfjs/web-ui/components/select";
+
+import { SAMPLES, DEFAULT_SAMPLE_ID, getSample } from "./samples";
+import { validateBpmnFile } from "./file-input";
+
+export function BpmnViewerTool() {
+  const t = useTranslations("ToolUI");
+  const v = useBpmnViewer();
+
+  const [xml, setXml] = React.useState(() => getSample(DEFAULT_SAMPLE_ID)?.xml ?? "");
+  const [paste, setPaste] = React.useState("");
+  const [inputError, setInputError] = React.useState<string | null>(null);
+  const fileRef = React.useRef<HTMLInputElement>(null);
+
+  const onSelectSample = (id: string) => {
+    const s = getSample(id);
+    if (!s) return;
+    setInputError(null);
+    setXml(s.xml);
+  };
+
+  const onApplyPaste = () => {
+    if (!paste.trim()) return;
+    setInputError(null);
+    setXml(paste);
+  };
+
+  const onFile = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const result = validateBpmnFile({ name: file.name, size: file.size });
+    if (!result.ok) {
+      setInputError(
+        result.reason === "extension"
+          ? t("bpmnErrExtension")
+          : result.reason === "size"
+            ? t("bpmnErrSize")
+            : t("bpmnErrEmpty"),
+      );
+      return;
+    }
+    const reader = new FileReader();
+    reader.onload = () => {
+      setInputError(null);
+      setXml(String(reader.result ?? ""));
+    };
+    reader.readAsText(file);
+  };
+
+  const error = inputError ?? (v.error ? t("bpmnErrImport") : null);
+
+  return (
+    <div className="flex flex-col gap-3">
+      <p className="text-xs font-semibold tracking-widest text-muted-foreground">{t("bpmnEyebrow")}</p>
+
+      <div className="flex flex-wrap items-center gap-2">
+        <Select defaultValue={DEFAULT_SAMPLE_ID} onValueChange={onSelectSample}>
+          <SelectTrigger className="w-48" aria-label={t("bpmnSample")}>
+            <SelectValue placeholder={t("bpmnSample")} />
+          </SelectTrigger>
+          <SelectContent>
+            {SAMPLES.map((s) => (
+              <SelectItem key={s.id} value={s.id}>
+                {s.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <Button variant="outline" size="sm" onClick={() => fileRef.current?.click()}>
+          <Upload className="mr-1 h-4 w-4" />
+          {t("bpmnUpload")}
+        </Button>
+        <input
+          ref={fileRef}
+          data-testid="bpmn-file-input"
+          type="file"
+          accept=".bpmn,.xml"
+          className="hidden"
+          onChange={onFile}
+        />
+
+        <div className="ml-auto flex items-center gap-1">
+          <Button variant="outline" size="icon" aria-label={t("bpmnZoomIn")} onClick={v.zoomIn}>
+            <ZoomIn className="h-4 w-4" />
+          </Button>
+          <Button variant="outline" size="icon" aria-label={t("bpmnZoomOut")} onClick={v.zoomOut}>
+            <ZoomOut className="h-4 w-4" />
+          </Button>
+          <Button variant="outline" size="icon" aria-label={t("bpmnReset")} onClick={v.resetZoom}>
+            <RotateCcw className="h-4 w-4" />
+          </Button>
+          <Button variant="outline" size="icon" aria-label={t("bpmnFit")} onClick={v.fitViewport}>
+            <Maximize className="h-4 w-4" />
+          </Button>
+        </div>
+      </div>
+
+      {error && (
+        <p role="alert" className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+          {error}
+        </p>
+      )}
+
+      <BpmnViewer
+        {...v.viewerProps}
+        xml={xml}
+        className="h-[600px] w-full rounded-md border bg-card"
+      />
+
+      <div className="flex flex-col gap-2">
+        <label htmlFor="bpmn-paste" className="text-sm font-medium">
+          {t("bpmnPasteLabel")}
+        </label>
+        <textarea
+          id="bpmn-paste"
+          value={paste}
+          onChange={(e) => setPaste(e.target.value)}
+          rows={5}
+          className="w-full rounded-md border bg-background p-2 font-mono text-xs"
+          placeholder="<bpmn:definitions ...>"
+        />
+        <div>
+          <Button size="sm" onClick={onApplyPaste}>
+            {t("bpmnApply")}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 6: 寫 `apps/web/src/tools/bpmn-viewer/index.ts`**
+
+```ts
+import type { ToolModule } from "@/tools/types";
+
+import { BpmnViewerTool } from "./ui";
+
+export const tool: ToolModule = { id: "bpmn-viewer", Component: BpmnViewerTool };
+```
+
+- [ ] **Step 7: 跑測試確認通過**
+
+Run: `pnpm -C <worktree> --filter web vitest:run -- bpmn-viewer/ui`
+Expected: PASS(3 passed)。
+
+> 若 `@rfjs/web-ui/components/select` 或 `button` 的實際匯出名稱/路徑不同,以 `packages/filter-builder-ui/src/filter-tree-editor.tsx` 的實際 import 為準調整。
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/web/package.json apps/web/src/tools/bpmn-viewer/messages.ts \
+  apps/web/src/tools/bpmn-viewer/ui.tsx apps/web/src/tools/bpmn-viewer/index.ts \
+  apps/web/src/tools/bpmn-viewer/ui.spec.tsx pnpm-lock.yaml
+git commit -m "feat(web): add bpmn-viewer tool UI (toolbar, samples, upload, paste)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: 註冊 tool(registry + 聚合器 + transpilePackages)
+
+**Files:**
+- Modify: `packages/web-core/src/registry/tools.ts`(append tool 一筆)
+- Modify: `packages/web-core/src/registry/packages.ts`(append package catalog 一筆 —— `registry.spec.ts` 要求每個 `relatedPackages` 都存在於 `packageRegistry`)
+- Modify: `apps/web/src/tools/index.ts`(import + 加入 `toolModules`)
+- Modify: `apps/web/src/tools/messages.ts`(import + 加入 `toolMessages`)
+- Modify: `apps/web/src/tools/index.spec.ts`(`EXPECTED_WEB_TOOL_IDS` 加 `"bpmn-viewer"`)
+- Modify: `apps/web/next.config.js`(`transpilePackages` 加 `"@rfjs/bpmn"`)
+
+**Interfaces:**
+- Consumes: `tool`、`messages` from `./bpmn-viewer`(Task 7)
+
+- [ ] **Step 1: 先改測試(EXPECTED ids)讓它失敗** — `apps/web/src/tools/index.spec.ts`
+
+在 `EXPECTED_WEB_TOOL_IDS` 陣列(form-designer 之後)加一行:
+
+```ts
+  "form-designer",
+  "bpmn-viewer",
+].sort();
+```
+
+- [ ] **Step 2: 跑測試確認失敗**
+
+Run: `pnpm -C <worktree> --filter web vitest:run -- tools/index`
+Expected: FAIL —— `toolModules` 尚未含 `bpmn-viewer`(且 catalog 也缺)。
+
+- [ ] **Step 3: web-core registry append** — `packages/web-core/src/registry/tools.ts`
+
+在 `form-designer` 條目之後、`object-transformer`(workbench)之前插入:
+
+```ts
+  {
+    id: 'bpmn-viewer',
+    category: 'inspect',
+    surface: 'web',
+    status: 'preview',
+    relatedPackages: ['@rfjs/bpmn'],
+    tags: ['diagram', 'bpmn', 'workflow', 'viewer'],
+  },
+```
+
+- [ ] **Step 3b: web-core package catalog append** — `packages/web-core/src/registry/packages.ts`
+
+在 `packageRegistry` 陣列(例如 `@rfjs/form-builder` 條目之後)插入一筆。**私有套件,不放 `npm`**(比照 `@rfjs/data-label`/`@rfjs/form-builder`):
+
+```ts
+  {
+    name: '@rfjs/bpmn',
+    status: 'preview',
+    href: '/packages/bpmn',
+    github: GITHUB,
+    tags: ['bpmn', 'diagram', 'viewer'],
+    relatedTools: ['bpmn-viewer'],
+  },
+```
+
+> 這同時滿足 `registry.spec.ts` 的兩條斷言:`relatedPackages all exist in packageRegistry`(tool → package)與 `relatedTools all exist in toolRegistry`(package → tool)。`/packages/bpmn` 由 registry slug 自動產生詳情頁,無需額外內容檔。
+
+- [ ] **Step 4: 聚合器 `apps/web/src/tools/index.ts`**
+
+加 import(放在 `formDesigner` 之後):
+```ts
+import { tool as bpmnViewer } from "./bpmn-viewer";
+```
+加入陣列(`formDesigner` 之後):
+```ts
+  formDesigner,
+  bpmnViewer,
+];
+```
+
+- [ ] **Step 5: 聚合器 `apps/web/src/tools/messages.ts`**
+
+加 import(放在 `formDesigner` 之後):
+```ts
+import { messages as bpmnViewer } from "./bpmn-viewer/messages";
+```
+加入陣列(`formDesigner` 之後):
+```ts
+  formDesigner,
+  bpmnViewer,
+];
+```
+
+- [ ] **Step 6: `apps/web/next.config.js` 的 `transpilePackages` 加 `@rfjs/bpmn`**
+
+在 `transpilePackages` 陣列加入 `"@rfjs/bpmn"`(任意位置),例如:
+```js
+  transpilePackages: [
+    "@rfjs/web-ui",
+    "@rfjs/web-core",
+    "@rfjs/filter-builder-ui",
+    "@rfjs/form-builder-ui",
+    "@rfjs/bpmn",
+  ],
+```
+
+> 若 `apps/web/next.config.js` 實際檔名為 `next.config.mjs`/`next.config.ts`,改該檔。**不需** 改 `globals.css` 的 `@source`(套件無 Tailwind)。
+
+- [ ] **Step 7: 跑 tool 註冊測試 + web-core 測試確認通過**
+
+Run:
+```bash
+pnpm -C <worktree> --filter web vitest:run -- tools/index
+pnpm -C <worktree> --filter @rfjs/web-core test
+```
+Expected: PASS —— `registers exactly the expected web tools`、`every registered component id exists in the web-core catalog`、`component and message aggregators cover the same ids`、`tool ToolUI keys never collide` 全綠;web-core registry schema 驗證通過。
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/web-core/src/registry/tools.ts packages/web-core/src/registry/packages.ts \
+  apps/web/src/tools/index.ts apps/web/src/tools/messages.ts \
+  apps/web/src/tools/index.spec.ts apps/web/next.config.js
+git commit -m "feat(web): register bpmn-viewer tool in registry and aggregators
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 9: Playwright e2e 真 SVG 煙霧測試(net-new infra)
+
+> 此 task 引入全新的 `@playwright/test` 基礎設施(repo 既有的 e2e 都是 vitest,非瀏覽器)。需下載 chromium。若執行環境無法下載瀏覽器,記錄為已知限制並改於 Task 10 以手動截圖驗證真渲染;但預設照此 task 完成。
+
+**Files:**
+- Modify: `apps/web/package.json`(加 `@playwright/test` devDep + `test:e2e` script)
+- Create: `apps/web/playwright.config.ts`
+- Create: `apps/web/e2e/bpmn-viewer.e2e.ts`
+- Modify: `apps/web/.gitignore`(若無,建立;忽略 `test-results/`、`playwright-report/`)
+
+**Interfaces:** 無程式介面;純測試。
+
+- [ ] **Step 1: 加 devDep 與 script,並安裝瀏覽器**
+
+修改 `apps/web/package.json`:`devDependencies` 加 `"@playwright/test": "^1.49.0"`;`scripts` 加 `"test:e2e": "playwright test"`。
+
+Run:
+```bash
+pnpm -C /home/royfw/_/code/royfw/rfjs/.claude/worktrees/feat-bpmn-viewer install
+pnpm -C /home/royfw/_/code/royfw/rfjs/.claude/worktrees/feat-bpmn-viewer --filter web exec playwright install chromium
+```
+Expected: 安裝成功(chromium 下載)。
+
+- [ ] **Step 2: 建 `apps/web/playwright.config.ts`**
+
+```ts
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  testMatch: "**/*.e2e.ts",
+  fullyParallel: true,
+  retries: 0,
+  reporter: "list",
+  use: {
+    baseURL: "http://localhost:3000",
+    trace: "on-first-retry",
+  },
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+  webServer: {
+    command: "pnpm dev",
+    url: "http://localhost:3000",
+    reuseExistingServer: true,
+    timeout: 120_000,
+  },
+});
+```
+
+- [ ] **Step 3: 建 `apps/web/e2e/bpmn-viewer.e2e.ts`**
+
+```ts
+import { test, expect } from "@playwright/test";
+
+const URL = "/en/tools/bpmn-viewer";
+
+test("renders the default BPMN diagram as SVG", async ({ page }) => {
+  await page.goto(URL);
+  // bpmn-js 在 .djs-container 內渲染 SVG;預設範例至少含一個形狀。
+  const shapes = page.locator(".djs-container svg .djs-element");
+  await expect(shapes.first()).toBeVisible({ timeout: 15_000 });
+});
+
+test("keeps the bpmn.io attribution badge visible (license)", async ({ page }) => {
+  await page.goto(URL);
+  await expect(page.locator(".bjs-powered-by")).toBeVisible({ timeout: 15_000 });
+});
+
+test("shows an error panel for invalid pasted XML", async ({ page }) => {
+  await page.goto(URL);
+  await page.getByLabel(/paste bpmn xml/i).fill("not really xml <<<");
+  await page.getByRole("button", { name: /^render$/i }).click();
+  await expect(page.getByRole("alert")).toBeVisible({ timeout: 15_000 });
+});
+```
+
+- [ ] **Step 4: 跑 e2e**
+
+Run(背景需要 dev server;`webServer` 會自動啟動或重用):
+```bash
+pnpm -C /home/royfw/_/code/royfw/rfjs/.claude/worktrees/feat-bpmn-viewer --filter web test:e2e
+```
+Expected: 3 passed。
+
+> 排錯:若 `.djs-element` 選不到,以 `page.locator(".djs-container svg")` 確認 SVG 容器存在後,改用 `[data-element-id]` 選器。確認 locale 前綴(`/en/...`)正確(由 `next-intl` routing 決定)。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/package.json apps/web/playwright.config.ts apps/web/e2e/bpmn-viewer.e2e.ts \
+  apps/web/.gitignore pnpm-lock.yaml
+git commit -m "test(web): add Playwright e2e smoke for bpmn-viewer (render, badge, error)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 10: 終審驗證(typecheck / lint / test / build / 手動截圖)
+
+**Files:** 無(僅驗證,必要時小幅修正)。
+
+- [ ] **Step 1: 套件 + app 全綠**
+
+Run:
+```bash
+pnpm -C <worktree> --filter @rfjs/bpmn check-types
+pnpm -C <worktree> --filter @rfjs/bpmn lint
+pnpm -C <worktree> --filter @rfjs/bpmn vitest:run
+pnpm -C <worktree> --filter @rfjs/web-core test
+pnpm -C <worktree> --filter web check-types
+pnpm -C <worktree> --filter web lint
+pnpm -C <worktree> --filter web vitest:run
+```
+Expected: 全部綠燈。
+
+- [ ] **Step 2: Next build(真正的 SSR 安全驗證)**
+
+Run: `pnpm -C <worktree> --filter web build`
+Expected: build 成功 —— 證明 `@rfjs/bpmn`(動態 import bpmn-js)在 SSR/prerender 不崩,`/tools/bpmn-viewer` 進入 `generateStaticParams`。
+
+> 若 build 報 bpmn-js 觸碰 `window`/`document` 的 SSR 錯誤:確認 `bpmn-viewer.tsx` 的 bpmn-js import 仍在 effect 內(動態),CSS import 留在模組頂層;必要時於 `ui.tsx` 以 `next/dynamic(() => import("@rfjs/bpmn").then(m => m.BpmnViewer), { ssr: false })` 載入 `BpmnViewer`,並把 `useBpmnViewer` 仍直接 import(它不碰 DOM)。
+
+- [ ] **Step 3: 手動截圖驗證真渲染(light + dark)**
+
+啟動 dev server,於瀏覽器開 `http://localhost:3000/en/tools/bpmn-viewer`:
+```bash
+pnpm -C <worktree> --filter web dev
+```
+確認:預設範例渲染成流程圖、工具列 zoom/fit 有效、切換範例/貼上 XML/上傳 .bpmn 正常、無效 XML 顯示錯誤面板、**右下角 bpmn.io 標誌可見**、深色模式可讀。截圖留存。
+
+- [ ] **Step 4: 確認無殘留 + 不需 changeset**
+
+Run: `git -C <worktree> status`
+Expected: 乾淨(所有變更已 commit)。所有觸及套件皆 private,**不建立 changeset**。
+
+- [ ] **Step 5(若有修正才需要): Commit**
+
+```bash
+git commit -am "fix(bpmn): address final verification findings
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+- [ ] **Step 6: HOLD —— 不開 PR**
+
+通知使用者全部完成、附手動驗證截圖摘要,等使用者於 GitHub 合併後回報「merged」。
+
+---
+
+## 附錄:Spec ↔ Plan 對應(self-review)
+
+| Spec 需求 | 對應 Task |
+| --- | --- |
+| 套件 scaffold(private/type:module/exports/scripts/deps) | Task 1 |
+| zoom 純函式 | Task 1 |
+| `<BpmnViewer>` controlled + ref handle + 生命週期 + 競態保護 + 動態 import(SSR) | Task 2 |
+| 型別(Props/Handle/ImportResult/Error) | Task 2 |
+| `useBpmnViewer` hook(viewerProps + actions + importing/error) | Task 3 |
+| CSS import(diagram-js/bpmn-js/font) | Task 2(Step 4)+ Task 1(鎖路徑) |
+| README(en + zh-TW) | Task 4 |
+| 範例流程圖(≥2,含 DI) | Task 5 |
+| 檔案上傳驗證(副檔名/大小/空) | Task 6 |
+| tool UI(工具列/範例/上傳/貼上/錯誤面板/i18n) | Task 7 |
+| registry tool 條目 + package catalog 條目 + 聚合器 + EXPECTED ids + transpilePackages | Task 8 |
+| 測試:mock 單元 + 純函式 + hook | Task 2/3/5/6/7 |
+| 測試:Playwright e2e 真 SVG + badge + 錯誤 | Task 9 |
+| 授權:bpmn.io 標誌保留(不隱藏) | Task 2(無隱藏 CSS)+ Task 9(badge 可見斷言)+ Task 10 Step 3 |
+| SSR 安全 | Task 2(動態 import)+ Task 10 Step 2(build 驗證) |
+| 無 changeset(全 private) | Task 10 Step 4 |
+| HOLD PR | Task 10 Step 6 |

--- a/docs/superpowers/specs/2026-06-30-rfjs-bpmn-viewer-design.md
+++ b/docs/superpowers/specs/2026-06-30-rfjs-bpmn-viewer-design.md
@@ -1,0 +1,251 @@
+# @rfjs/bpmn — BPMN 流程圖檢視器(viewer)設計
+
+- 日期:2026-06-30
+- 分支 / worktree:`feat-bpmn-viewer`（`.claude/worktrees/feat-bpmn-viewer`，由 `origin/main` 建立）
+- 狀態:設計已核可，待寫實作計畫（writing-plans）
+
+## 1. 目標與背景
+
+把 `bpmn-js`（BPMN 2.0 檢視/模型，基於 diagram-js + bpmn-moddle，vanilla JS、命令式 API）封裝成 rfjs stack 使用的 **React 元件**，作為未來自建 BPM 流程網站的第一個探路小套件。
+
+本階段**只做 viewer（唯讀）**：讀 BPMN XML → 渲染、縮放、平移、fit-to-view。modeler（編輯）留待下一階段。
+
+### 已鎖定決策
+
+| 決策 | 結論 |
+| --- | --- |
+| 範圍 | 只做 viewer（唯讀）；不做 modeler、不做匯出、不做 minimap |
+| 發佈 | workspace 內部 **private** 套件，不發 npm（避開 bpmn.io 授權的發佈問題） |
+| 授權 | bpmn.io license（非 MIT）——**必須保留** viewer 內建的「Powered by bpmn.io」標誌連結，**絕不**用 CSS 隱藏 |
+| 套件邊界 | **無頭薄封裝**：套件只給 `<BpmnViewer>` + `useBpmnViewer` hook + 型別；工具列/範例/上傳/錯誤面板等外殼留在 `apps/web` 展示頁 |
+| Wrapper API | **Both**：controlled `xml` prop + ref handle（低階）並存，外加 `useBpmnViewer` hook（人體工學包裝） |
+| Demo 範圍 | 內建範例 + 貼上 XML + **檔案上傳** + 工具列（zoom/fit/reset）+ 錯誤面板 + bpmn.io 標誌 + en/zh-TW i18n |
+| 測試 | mock bpmn-js 的單元測試 + 純函式測試 + **Playwright e2e** 真 SVG 煙霧測試 |
+| viewer 變體 | `NavigatedViewer`（滑鼠滾輪縮放 + 拖曳平移 + 鍵盤），仍唯讀 |
+
+### 依賴事實（已查證）
+
+- `bpmn-js@18.19.0`（最新），**內建 TypeScript 型別**（`./lib/index.d.ts`，`NavigatedViewer` 亦有），**無 peerDependencies**（自帶 diagram-js / bpmn-moddle 等為一般 deps）。
+- CSS 隨 `bpmn-js/dist/assets/` 出貨；確切檔名於 `pnpm add bpmn-js` 安裝後鎖定（預期為 `diagram-js.css` + `bpmn-js.css` + bpmn 字型 CSS）。
+
+## 2. 架構總覽
+
+```
+packages/bpmn/  (@rfjs/bpmn, private)              ← 薄封裝 bpmn-js NavigatedViewer
+        │  <BpmnViewer> + useBpmnViewer + types
+        ▼  (Next.js transpilePackages 串接，無 build step)
+apps/web/src/tools/bpmn-viewer/                    ← 展示頁(/tools/bpmn-viewer)
+        工具列 + 範例 + 檔案上傳/貼上 + 錯誤面板（用 @rfjs/web-ui 組外殼）
+```
+
+**分層哲學**：與既有 `@rfjs/filter-builder-ui` 一致——套件只給「核心可重用元件 + hook」，頁面外殼（chrome）由 app 負責。這讓核心套件乾淨、可重用，未來 modeler 或別處嵌 BPMN 圖時不被某一套工具列樣式綁死。
+
+**與並行 form 工作的關係**：`@rfjs/bpmn` 套件與 `apps/web/src/tools/bpmn-viewer/` 皆為全新檔案，零重疊。唯一觸及的共用檔為「註冊用」檔案（見 §4），皆為 **append** 性質，與 `feat-form-preview-enhancements` 分支改動的 form 既有條目不同行，合併理論上不衝突。本分支 **HOLD PR**，由人工於 GitHub 合併；若合併時真衝突再處理。
+
+## 3. `@rfjs/bpmn` 套件設計
+
+### 3.1 檔案布局（flat，小套件；比照 filter-builder-ui kebab-case）
+
+```
+packages/bpmn/
+  package.json          private, type:module, exports "./src/index.ts", react peer, bpmn-js dep
+  tsconfig.json         比照 filter-builder-ui（target ES2022 / Bundler / react-jsx / strict / noEmit）
+  vitest.config.mts     environment: jsdom；include src/**/*.spec.(ts|tsx)
+  src/
+    index.ts            barrel：re-export 公開介面
+    bpmn-viewer.tsx     "use client" — <BpmnViewer> controlled component + forwardRef
+    use-bpmn-viewer.ts  useBpmnViewer hook
+    zoom.ts             純函式：zoom step / clamp
+    types.ts            BpmnViewerProps / BpmnViewerHandle / BpmnImportResult / BpmnViewerError
+    bpmn-viewer.spec.tsx
+    use-bpmn-viewer.spec.ts
+    zoom.spec.ts
+  README.md
+  README.zh-TW.md
+```
+
+### 3.2 公開型別（`types.ts`）
+
+```ts
+export interface BpmnImportResult {
+  warnings: unknown[]; // bpmn-js importXML 回傳的 warnings
+}
+
+export interface BpmnViewerError {
+  message: string;
+  warnings?: unknown[];
+  cause?: unknown;
+}
+
+export interface BpmnViewerProps {
+  /** 受控的 BPMN 2.0 XML 字串 */
+  xml: string;
+  /** 透傳給 NavigatedViewer 建構子的額外選項 */
+  options?: Record<string, unknown>;
+  className?: string;
+  style?: React.CSSProperties;
+  /** importXML 成功（可能含 warnings） */
+  onImport?: (result: BpmnImportResult) => void;
+  /** importXML 失敗 */
+  onError?: (error: BpmnViewerError) => void;
+  /** import 進行中狀態變化 */
+  onLoadingChange?: (loading: boolean) => void;
+}
+
+export interface BpmnViewerHandle {
+  zoomIn(): void;
+  zoomOut(): void;
+  resetZoom(): void;       // = fitViewport
+  fitViewport(): void;
+  getZoom(): number;
+  getViewer(): unknown;    // 逃生艙：回傳底層 NavigatedViewer 實例
+}
+```
+
+### 3.3 元件契約與生命週期（`bpmn-viewer.tsx`）
+
+- `"use client"`；`forwardRef<BpmnViewerHandle, BpmnViewerProps>`。
+- **建立（mount，client effect）**：動態 `import('bpmn-js/lib/NavigatedViewer')` → `new NavigatedViewer({ container })`。動態 import + `"use client"` 雙保險，確保 SSR 期不觸碰 DOM。
+- **匯入（`xml` 變更）**：`await viewer.importXML(xml)`。
+  - **競態保護**：每次 import 標記序號 / AbortController，只有「最後一次」import 的結果生效；元件已卸載則丟棄結果。
+  - 成功 → `onLoadingChange(false)`、`onImport({ warnings })`；fit 一次 viewport。
+  - 失敗 → `onLoadingChange(false)`、`onError({ message, warnings, cause })`，並保留錯誤狀態。
+- **卸載(unmount)**：`viewer.destroy()`。
+- **縮放**（透過 `canvas = viewer.get('canvas')`）：
+  - `fitViewport` / `resetZoom` = `canvas.zoom('fit-viewport')`。
+  - `zoomIn` / `zoomOut` = 取現值 `canvas.zoom()`，乘以 step，`clamp(min, max)`（邏輯在 `zoom.ts` 純函式）。
+  - `getZoom` = `canvas.zoom()`。
+- **授權硬約束**：`NavigatedViewer` 會自動在容器右下角加入 `.bjs-powered-by` 的 bpmn.io 標誌連結。本套件 **不得** 加入任何隱藏該元素的 CSS / DOM 操作。spec 視為硬約束，並以測試守護（見 §5）。
+- **容器尺寸**：容器需有明確高度才能渲染；props 提供 `className` / `style`，由展示頁給定高度（例 `h-[600px]`）。
+
+### 3.4 `useBpmnViewer()` hook（`use-bpmn-viewer.ts`）
+
+人體工學包裝，讓展示頁綁工具列按鈕更省事：
+
+```ts
+const v = useBpmnViewer();
+// v = { viewerProps, zoomIn, zoomOut, resetZoom, fitViewport, importing, error }
+// viewerProps = { ref, onLoadingChange, onError }，直接 spread 到元件
+<BpmnViewer {...v.viewerProps} xml={xml} />
+<Button onClick={v.zoomIn}>＋</Button>
+```
+
+- 內部持有 `ref`（`BpmnViewerHandle`），`zoomIn/...` 代理到 ref。
+- `viewerProps` 是一個可 spread 的物件（`{ ref, onLoadingChange, onError }`）；hook 在內部封裝 `onLoadingChange` / `onError` 來驅動 `importing` / `error` 狀態，呼叫端只要 `{...v.viewerProps}` 即可，不暴露內部 handler。
+- 呼叫端若另傳自己的 `onImport` / `onError`，於元件層合併（plan 決定合併細節）。
+- **Both 的落實**：低階 = `ref` handle；高階 = 此 hook。兩者並存，使用者可擇一。
+
+### 3.5 CSS
+
+- 套件在元件檔 `import` bpmn-js 隨附的 CSS（`diagram-js.css` + `bpmn-js.css` + bpmn 字型 CSS；確切路徑安裝後鎖定）。Next.js `transpilePackages` 會處理這些 CSS import。
+- 套件 **不使用 Tailwind**，因此 `apps/web` **不需** 加 Tailwind `@source`（只需 `transpilePackages`）。
+
+### 3.6 套件 `package.json` 要點（比照 filter-builder-ui）
+
+- `"name": "@rfjs/bpmn"`、`"private": true`、`"type": "module"`、`"version": "0.0.0"`。
+- `"exports": { ".": "./src/index.ts" }`（無 build / dist，source 直接被 transpile）。
+- scripts：`lint`（`eslint . --max-warnings 0`）、`check-types`（`tsc --noEmit`）、`test` / `vitest:run`（`vitest --run`）。
+- `dependencies`：`bpmn-js@^18.19.0`。
+- `peerDependencies`：`react`、`react-dom`（`^19`）。
+- `devDependencies`：比照 filter-builder-ui（react、@types/react(-dom)、@testing-library/react、@testing-library/dom、jsdom、vitest、eslint 套組、typescript）。
+- **不依賴** `@rfjs/web-ui`。
+
+## 4. `apps/web` tool：`bpmn-viewer`
+
+### 4.1 registry 條目（`packages/web-core/src/registry/tools.ts`，append）
+
+```ts
+{
+  id: 'bpmn-viewer',
+  category: 'inspect',
+  surface: 'web',
+  status: 'preview',
+  relatedPackages: ['@rfjs/bpmn'],
+  tags: ['diagram', 'bpmn', 'workflow', 'viewer'],
+}
+```
+
+### 4.2 tool 模組檔案
+
+```
+apps/web/src/tools/bpmn-viewer/
+  index.ts        export const tool: ToolModule = { id:'bpmn-viewer', Component: BpmnViewerTool }
+  ui.tsx          "use client" — 命名匯出 BpmnViewerTool()
+  messages.ts     LocaleMessages：Tools['bpmn-viewer'].{title,description}（en + zh-TW）+ UI 字串
+  samples.ts      純資料：2–3 個內建範例 BPMN XML（如「請假流程」「訂單審核」）
+  file-input.ts   純函式：副檔名（.bpmn/.xml）+ 檔案大小驗證
+  ui.spec.tsx / samples.spec.ts / file-input.spec.ts（co-located）
+```
+
+### 4.3 UI（`ui.tsx`，`"use client"`）
+
+- **工具列**：放大 / 縮小 / 重設 / fit 按鈕（`@rfjs/web-ui` Button + lucide 圖示），綁 `useBpmnViewer`。
+- **來源切換**：
+  - 範例選單(Select)——選 `samples.ts` 內建流程圖。
+  - 檔案上傳——`<input type="file" accept=".bpmn,.xml">`，`FileReader.readAsText` 讀入；經 `file-input.ts` 驗證（副檔名 + 大小），失敗顯示錯誤。
+  - 貼上 XML——textarea，按鈕套用。
+- **中央**：`<BpmnViewer xml={xml} className="h-[600px] w-full rounded-md border" ... />`。
+- **錯誤面板**：XML 無效 / 上傳不合法時顯示訊息（i18n）。
+- **bpmn.io 標誌**：由 viewer 自帶（不額外處理，僅確保不隱藏）。
+- **i18n**：en + zh-TW。`Tools['bpmn-viewer'].{title,description}` + UI 字串（比照 form-designer 的 `ToolUI` / 自有命名空間做法）。
+
+### 4.4 註冊接線（皆為 append）
+
+- `apps/web/src/tools/index.ts`：`import { tool as bpmnViewer } from './bpmn-viewer'` → 加入 `toolModules`。
+- `apps/web/src/tools/messages.ts`：`import { messages as bpmnViewer } from './bpmn-viewer/messages'` → 加入 `toolMessages`（順序與 index.ts 對齊）。
+- `apps/web/src/tools/index.spec.ts`：`EXPECTED_WEB_TOOL_IDS` 加 `'bpmn-viewer'`。
+- `apps/web/next.config.js`：`transpilePackages` 加 `'@rfjs/bpmn'`。
+- 路由由 registry slug 自動驅動（`/tools/bpmn-viewer`，`generateStaticParams` 自動涵蓋），無需手動加路由檔。
+- **不需** 改 `apps/web/src/app/globals.css` 的 `@source`（套件無 Tailwind）。
+
+## 5. 測試策略
+
+### 5.1 套件單元（jsdom + vitest，`vi.mock`）
+
+mock `bpmn-js/lib/NavigatedViewer`（jsdom 無 SVG layout，真渲染靠 e2e），驗證 **wrapper 契約**：
+
+- mount → 以含 `container` 的選項 `new NavigatedViewer(...)`。
+- 設定 / 變更 `xml` → `importXML(xml)` 被呼叫；**競態**：先發後到的舊 import 結果被丟棄，只有最後一次生效。
+- unmount → `destroy()` 被呼叫。
+- `importXML` reject → `error` 狀態 + `onError`；resolve 帶 warnings → `onImport({ warnings })`；`onLoadingChange` true→false 流。
+- ref handle：`zoomIn/zoomOut/resetZoom/fitViewport/getZoom` → 呼叫對應 `canvas.zoom(...)` 參數。
+- SSR 安全:在無瀏覽器 API 假設下 render 不崩（或以「未呼叫 importXML 直到 effect」驗證）。
+- **bpmn.io 標誌守護**：以程式碼/DOM 斷言確認本套件未加入隱藏 `.bjs-powered-by` 的規則。
+
+### 5.2 純函式單元
+
+- `zoom.ts`：step 計算、min/max clamp 邊界。
+- `file-input.ts`：副檔名允許/拒絕、大小上限邊界。
+- `samples.ts`:每個範例為非空、可被解析的 XML 字串（結構性檢查）。
+
+### 5.3 hook 單元
+
+`useBpmnViewer`：actions 代理到 ref；`importing` / `error` 狀態流。
+
+### 5.4 Playwright e2e（真 SVG 煙霧測試）
+
+真瀏覽器開 `/tools/bpmn-viewer`：
+
+- 載入內建範例 → 斷言 `.djs-container svg` 內有節點渲染。
+- 按 fit / zoom → viewport / zoom 值改變。
+- 貼上無效 XML → 錯誤面板出現。
+- 斷言 bpmn.io 標誌（`.bjs-powered-by`）可見。
+- 確切跑法（Playwright 直開 dev server vs vitest browser mode）於 plan 階段決定。
+
+## 6. 不做（YAGNI）
+
+modeler / 編輯、發 npm、minimap、匯出 SVG/PNG、多圖比較、自訂 BPMN 元素 renderer。全部留待未來，保持「薄探路套件」。
+
+## 7. 風險與已知事項
+
+- **jsdom 無 SVG layout**：真渲染只能靠 Playwright e2e；單元測試靠 mock。
+- **bpmn-js CSS 檔名**：確切路徑待 `pnpm add bpmn-js` 後鎖定。
+- **共用檔 append 衝突風險**：`web-core/tools.ts`、`apps/web tools/{index,messages}.ts`、`tools/index.spec.ts` 與並行 form 分支共用；皆 append，理論上不撞，合併時留意。
+- **授權**:bpmn.io 標誌必須保留（硬約束，測試守護）。
+
+## 8. 慣例
+
+- commit / PR:英文 conventional commits，結尾 `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`。
+- spec / plan:繁體中文。
+- 全程於 `feat-bpmn-viewer` worktree 內編輯 / 測試 / commit。
+- **HOLD PR**:由人工於 GitHub 合併後再續。

--- a/packages/bpmn/README.md
+++ b/packages/bpmn/README.md
@@ -1,0 +1,31 @@
+# @rfjs/bpmn
+
+Headless React wrapper around [`bpmn-js`](https://github.com/bpmn-io/bpmn-js) `NavigatedViewer` — a read-only BPMN 2.0 diagram viewer. Private workspace package, consumed via Next.js `transpilePackages` (no build step).
+
+> **License:** `bpmn-js` is distributed under the [bpmn.io license](https://bpmn.io/license/). The viewer renders a "Powered by bpmn.io" badge; **do not hide it**.
+
+## Usage
+
+```tsx
+import { BpmnViewer, useBpmnViewer } from "@rfjs/bpmn";
+
+function Demo({ xml }: { xml: string }) {
+  const v = useBpmnViewer();
+  return (
+    <div>
+      <button onClick={v.zoomIn}>+</button>
+      <button onClick={v.zoomOut}>-</button>
+      <button onClick={v.fitViewport}>fit</button>
+      <BpmnViewer {...v.viewerProps} xml={xml} className="h-[600px] w-full" />
+      {v.error && <p role="alert">{v.error.message}</p>}
+    </div>
+  );
+}
+```
+
+## API
+
+- `<BpmnViewer xml options className style onImport onError onLoadingChange ref />` — controlled component. The `ref` exposes `BpmnViewerHandle` (`zoomIn`/`zoomOut`/`resetZoom`/`fitViewport`/`getZoom`/`getViewer`).
+- `useBpmnViewer()` — returns `{ viewerProps, zoomIn, zoomOut, resetZoom, fitViewport, importing, error }`. Spread `viewerProps` onto `<BpmnViewer>`.
+
+The container needs an explicit height to render.

--- a/packages/bpmn/README.zh-TW.md
+++ b/packages/bpmn/README.zh-TW.md
@@ -1,0 +1,30 @@
+# @rfjs/bpmn
+
+封裝 [`bpmn-js`](https://github.com/bpmn-io/bpmn-js) `NavigatedViewer` 的無頭 React 元件 —— 唯讀 BPMN 2.0 流程圖檢視器。Private workspace 套件,透過 Next.js `transpilePackages` 消費(無 build step)。
+
+> **授權:** `bpmn-js` 採用 [bpmn.io 授權](https://bpmn.io/license/)。檢視器會顯示「Powered by bpmn.io」標誌,**請勿隱藏**。
+
+## 用法
+
+```tsx
+import { BpmnViewer, useBpmnViewer } from "@rfjs/bpmn";
+
+function Demo({ xml }: { xml: string }) {
+  const v = useBpmnViewer();
+  return (
+    <div>
+      <button onClick={v.zoomIn}>+</button>
+      <button onClick={v.fitViewport}>fit</button>
+      <BpmnViewer {...v.viewerProps} xml={xml} className="h-[600px] w-full" />
+      {v.error && <p role="alert">{v.error.message}</p>}
+    </div>
+  );
+}
+```
+
+## API
+
+- `<BpmnViewer>` —— 受控元件;`ref` 提供 `BpmnViewerHandle`(`zoomIn`/`zoomOut`/`resetZoom`/`fitViewport`/`getZoom`/`getViewer`)。
+- `useBpmnViewer()` —— 回傳 `{ viewerProps, zoomIn, zoomOut, resetZoom, fitViewport, importing, error }`;把 `viewerProps` spread 到 `<BpmnViewer>`。
+
+容器需有明確高度才能渲染。

--- a/packages/bpmn/eslint.config.js
+++ b/packages/bpmn/eslint.config.js
@@ -1,0 +1,21 @@
+import js from "@eslint/js";
+import eslintConfigPrettier from "eslint-config-prettier";
+import pluginReact from "eslint-plugin-react";
+import pluginReactHooks from "eslint-plugin-react-hooks";
+import tseslint from "typescript-eslint";
+
+/** @type {import("eslint").Linter.Config[]} */
+export default [
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  pluginReact.configs.flat.recommended,
+  {
+    plugins: { "react-hooks": pluginReactHooks },
+    settings: { react: { version: "detect" } },
+    rules: {
+      ...pluginReactHooks.configs.recommended.rules,
+      "react/react-in-jsx-scope": "off",
+    },
+  },
+  eslintConfigPrettier,
+];

--- a/packages/bpmn/package.json
+++ b/packages/bpmn/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@rfjs/bpmn",
+  "version": "0.0.0",
+  "description": "Headless React wrapper around bpmn-js NavigatedViewer (read-only BPMN viewer); consumed via transpilePackages",
+  "type": "module",
+  "private": true,
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "lint": "eslint . --max-warnings 0",
+    "check-types": "tsc --noEmit",
+    "test": "vitest --passWithNoTests --run",
+    "vitest:run": "vitest --passWithNoTests --run"
+  },
+  "dependencies": {
+    "bpmn-js": "^18.19.0"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.20.0",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.2",
+    "@types/react": "19.2.17",
+    "@types/react-dom": "19.2.3",
+    "eslint": "^9.20.1",
+    "eslint-config-prettier": "^10.0.1",
+    "eslint-plugin-react": "^7.37.4",
+    "eslint-plugin-react-hooks": "^5.1.0",
+    "jsdom": "^29.1.1",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
+    "typescript": "6.0.3",
+    "typescript-eslint": "^8.61.0",
+    "vitest": "^3.2.4"
+  },
+  "peerDependencies": {
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  }
+}

--- a/packages/bpmn/src/bpmn-viewer.spec.tsx
+++ b/packages/bpmn/src/bpmn-viewer.spec.tsx
@@ -1,0 +1,113 @@
+import { render, waitFor } from "@testing-library/react";
+import { createRef } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { BpmnViewer } from "./bpmn-viewer";
+import type { BpmnViewerHandle } from "./types";
+
+// 共享的 mock 函式,讓我們跨實例斷言呼叫。
+const ctor = vi.fn();
+const importXML = vi.fn();
+const destroy = vi.fn();
+const zoom = vi.fn(() => 1);
+const canvas = { zoom };
+const get = vi.fn((name: string) => (name === "canvas" ? canvas : undefined));
+
+vi.mock("bpmn-js/lib/NavigatedViewer", () => ({
+  default: class MockViewer {
+    constructor(opts: unknown) {
+      ctor(opts);
+    }
+    importXML = importXML;
+    get = get;
+    destroy = destroy;
+  },
+}));
+
+const XML_A = "<bpmn:a/>";
+const XML_B = "<bpmn:b/>";
+
+beforeEach(() => {
+  ctor.mockClear();
+  importXML.mockReset().mockResolvedValue({ warnings: [] });
+  destroy.mockClear();
+  zoom.mockReset().mockReturnValue(1);
+  get.mockClear();
+});
+
+describe("<BpmnViewer>", () => {
+  it("creates a NavigatedViewer with a container element on mount", async () => {
+    render(<BpmnViewer xml={XML_A} />);
+    await waitFor(() => expect(ctor).toHaveBeenCalledTimes(1));
+    const opts = ctor.mock.calls[0]![0] as { container: unknown };
+    expect(opts.container).toBeInstanceOf(HTMLElement);
+  });
+
+  it("imports the xml and fits the viewport, then calls onImport", async () => {
+    const onImport = vi.fn();
+    render(<BpmnViewer xml={XML_A} onImport={onImport} />);
+    await waitFor(() => expect(importXML).toHaveBeenCalledWith(XML_A));
+    await waitFor(() => expect(onImport).toHaveBeenCalledWith({ warnings: [] }));
+    expect(zoom).toHaveBeenCalledWith("fit-viewport");
+  });
+
+  it("toggles onLoadingChange true then false", async () => {
+    const onLoadingChange = vi.fn();
+    render(<BpmnViewer xml={XML_A} onLoadingChange={onLoadingChange} />);
+    await waitFor(() => expect(onLoadingChange).toHaveBeenCalledWith(false));
+    expect(onLoadingChange.mock.calls[0]![0]).toBe(true);
+  });
+
+  it("calls onError when importXML rejects", async () => {
+    importXML.mockRejectedValueOnce(new Error("bad xml"));
+    const onError = vi.fn();
+    render(<BpmnViewer xml={XML_A} onError={onError} />);
+    await waitFor(() => expect(onError).toHaveBeenCalledTimes(1));
+    expect(onError.mock.calls[0]![0]).toMatchObject({ message: "bad xml" });
+  });
+
+  it("re-imports when xml prop changes", async () => {
+    const { rerender } = render(<BpmnViewer xml={XML_A} />);
+    await waitFor(() => expect(importXML).toHaveBeenCalledWith(XML_A));
+    rerender(<BpmnViewer xml={XML_B} />);
+    await waitFor(() => expect(importXML).toHaveBeenCalledWith(XML_B));
+  });
+
+  it("destroys the viewer on unmount", async () => {
+    const { unmount } = render(<BpmnViewer xml={XML_A} />);
+    await waitFor(() => expect(ctor).toHaveBeenCalledTimes(1));
+    unmount();
+    await waitFor(() => expect(destroy).toHaveBeenCalledTimes(1));
+  });
+
+  it("exposes imperative zoom handle methods", async () => {
+    const ref = createRef<BpmnViewerHandle>();
+    render(<BpmnViewer xml={XML_A} ref={ref} />);
+    await waitFor(() => expect(ctor).toHaveBeenCalledTimes(1));
+    ref.current!.fitViewport();
+    expect(zoom).toHaveBeenCalledWith("fit-viewport");
+    zoom.mockReturnValue(1);
+    ref.current!.zoomIn();
+    // zoomIn → zoom(current * ZOOM_FACTOR) = zoom(1.2)
+    expect(zoom).toHaveBeenCalledWith(expect.closeTo(1.2, 5));
+    expect(ref.current!.getZoom()).toBe(1);
+  });
+
+  it("ignores a stale import result when a newer import supersedes it", async () => {
+    // 第一次 import 延遲解析,第二次先解析 → 只有第二次的 onImport 生效。
+    let resolveFirst!: (v: { warnings: unknown[] }) => void;
+    importXML
+      .mockImplementationOnce(() => new Promise((res) => (resolveFirst = res)))
+      .mockResolvedValueOnce({ warnings: ["second"] });
+    const onImport = vi.fn();
+    const { rerender } = render(<BpmnViewer xml={XML_A} onImport={onImport} />);
+    await waitFor(() => expect(importXML).toHaveBeenCalledTimes(1));
+    rerender(<BpmnViewer xml={XML_B} onImport={onImport} />);
+    await waitFor(() => expect(onImport).toHaveBeenCalledWith({ warnings: ["second"] }));
+    // 現在才解析第一次(過期)—— 不應再觸發 onImport。
+    resolveFirst({ warnings: ["first"] });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(onImport).toHaveBeenCalledTimes(1);
+    expect(onImport).not.toHaveBeenCalledWith({ warnings: ["first"] });
+  });
+});

--- a/packages/bpmn/src/bpmn-viewer.spec.tsx
+++ b/packages/bpmn/src/bpmn-viewer.spec.tsx
@@ -93,6 +93,20 @@ describe("<BpmnViewer>", () => {
     expect(ref.current!.getZoom()).toBe(1);
   });
 
+  it("does not invoke callbacks after unmount when an in-flight import resolves late", async () => {
+    let resolveImport!: (v: { warnings: unknown[] }) => void;
+    importXML.mockImplementationOnce(() => new Promise((res) => (resolveImport = res)));
+    const onImport = vi.fn();
+    const onError = vi.fn();
+    const { unmount } = render(<BpmnViewer xml={XML_A} onImport={onImport} onError={onError} />);
+    await waitFor(() => expect(importXML).toHaveBeenCalledTimes(1));
+    unmount();
+    resolveImport({ warnings: [] });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(onImport).not.toHaveBeenCalled();
+    expect(onError).not.toHaveBeenCalled();
+  });
+
   it("ignores a stale import result when a newer import supersedes it", async () => {
     // 第一次 import 延遲解析,第二次先解析 → 只有第二次的 onImport 生效。
     let resolveFirst!: (v: { warnings: unknown[] }) => void;

--- a/packages/bpmn/src/bpmn-viewer.tsx
+++ b/packages/bpmn/src/bpmn-viewer.tsx
@@ -59,22 +59,25 @@ export const BpmnViewer = forwardRef<BpmnViewerHandle, BpmnViewerProps>(
       };
     }, [options]);
 
-    // viewer 就緒或 xml 變更 → import(含競態保護)。
+    // viewer 就緒或 xml 變更 → import(含競態保護 + unmount 保護)。
     useEffect(() => {
       const viewer = viewerRef.current;
       if (!ready || !viewer || !xml) return;
       const seq = ++importSeq.current;
+      let active = true;
       cbRef.current.onLoadingChange?.(true);
       viewer
         .importXML(xml)
         .then((result) => {
-          if (seq !== importSeq.current) return;
+          if (!active || seq !== importSeq.current) return;
+          // 注意:被 seq 超越的過期 import 刻意不呼叫 onLoadingChange(false),
+          // 因為勝出的那次 import 會自行結束 loading 狀態。
           cbRef.current.onLoadingChange?.(false);
           (viewer.get("canvas") as BpmnCanvas).zoom("fit-viewport");
           cbRef.current.onImport?.({ warnings: result?.warnings ?? [] });
         })
         .catch((err: unknown) => {
-          if (seq !== importSeq.current) return;
+          if (!active || seq !== importSeq.current) return;
           cbRef.current.onLoadingChange?.(false);
           const e: BpmnViewerError = {
             message: err instanceof Error ? err.message : String(err),
@@ -83,6 +86,9 @@ export const BpmnViewer = forwardRef<BpmnViewerHandle, BpmnViewerProps>(
           };
           cbRef.current.onError?.(e);
         });
+      return () => {
+        active = false;
+      };
     }, [ready, xml]);
 
     useImperativeHandle(

--- a/packages/bpmn/src/bpmn-viewer.tsx
+++ b/packages/bpmn/src/bpmn-viewer.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from "react";
+
+import "bpmn-js/dist/assets/diagram-js.css";
+import "bpmn-js/dist/assets/bpmn-js.css";
+import "bpmn-js/dist/assets/bpmn-font/css/bpmn-embedded.css";
+
+import { ZOOM_FACTOR, zoomBy } from "./zoom";
+import type { BpmnViewerError, BpmnViewerHandle, BpmnViewerProps } from "./types";
+
+interface BpmnCanvas {
+  zoom(level?: number | string, center?: unknown): number;
+}
+interface BpmnInstance {
+  importXML(xml: string): Promise<{ warnings?: unknown[] }>;
+  get(name: string): unknown;
+  destroy(): void;
+}
+
+export const BpmnViewer = forwardRef<BpmnViewerHandle, BpmnViewerProps>(
+  function BpmnViewer({ xml, options, className, style, onImport, onError, onLoadingChange }, ref) {
+    const containerRef = useRef<HTMLDivElement>(null);
+    const viewerRef = useRef<BpmnInstance | null>(null);
+    const importSeq = useRef(0);
+    const [ready, setReady] = useState(false);
+
+    // 把最新 callback 收進 ref,避免 inline callback 造成 import effect 反覆重跑。
+    const cbRef = useRef({ onImport, onError, onLoadingChange });
+    cbRef.current = { onImport, onError, onLoadingChange };
+
+    // 建立 / 銷毀 viewer(client-only;動態 import 確保 SSR 不觸碰 bpmn-js)。
+    useEffect(() => {
+      const container = containerRef.current;
+      if (!container) return;
+      let cancelled = false;
+      let created: BpmnInstance | null = null;
+
+      void (async () => {
+        const mod = await import("bpmn-js/lib/NavigatedViewer");
+        if (cancelled) return;
+        const NavigatedViewer = mod.default as new (opts: Record<string, unknown>) => BpmnInstance;
+        created = new NavigatedViewer({ container, ...(options ?? {}) });
+        viewerRef.current = created;
+        setReady(true);
+      })();
+
+      return () => {
+        cancelled = true;
+        if (created) created.destroy();
+        viewerRef.current = null;
+        setReady(false);
+      };
+    }, [options]);
+
+    // viewer 就緒或 xml 變更 → import(含競態保護)。
+    useEffect(() => {
+      const viewer = viewerRef.current;
+      if (!ready || !viewer || !xml) return;
+      const seq = ++importSeq.current;
+      cbRef.current.onLoadingChange?.(true);
+      viewer
+        .importXML(xml)
+        .then((result) => {
+          if (seq !== importSeq.current) return;
+          cbRef.current.onLoadingChange?.(false);
+          (viewer.get("canvas") as BpmnCanvas).zoom("fit-viewport");
+          cbRef.current.onImport?.({ warnings: result?.warnings ?? [] });
+        })
+        .catch((err: unknown) => {
+          if (seq !== importSeq.current) return;
+          cbRef.current.onLoadingChange?.(false);
+          const e: BpmnViewerError = {
+            message: err instanceof Error ? err.message : String(err),
+            warnings: (err as { warnings?: unknown[] })?.warnings,
+            cause: err,
+          };
+          cbRef.current.onError?.(e);
+        });
+    }, [ready, xml]);
+
+    useImperativeHandle(
+      ref,
+      (): BpmnViewerHandle => {
+        const canvas = (): BpmnCanvas | null =>
+          (viewerRef.current?.get("canvas") as BpmnCanvas | undefined) ?? null;
+        return {
+          zoomIn() {
+            const c = canvas();
+            if (c) c.zoom(zoomBy(c.zoom(), ZOOM_FACTOR));
+          },
+          zoomOut() {
+            const c = canvas();
+            if (c) c.zoom(zoomBy(c.zoom(), 1 / ZOOM_FACTOR));
+          },
+          resetZoom() {
+            canvas()?.zoom("fit-viewport");
+          },
+          fitViewport() {
+            canvas()?.zoom("fit-viewport");
+          },
+          getZoom() {
+            return canvas()?.zoom() ?? 1;
+          },
+          getViewer() {
+            return viewerRef.current;
+          },
+        };
+      },
+      [ready],
+    );
+
+    return <div ref={containerRef} className={className} style={style} />;
+  },
+);

--- a/packages/bpmn/src/bpmn-viewer.tsx
+++ b/packages/bpmn/src/bpmn-viewer.tsx
@@ -119,7 +119,7 @@ export const BpmnViewer = forwardRef<BpmnViewerHandle, BpmnViewerProps>(
           },
         };
       },
-      [ready],
+      [],
     );
 
     return <div ref={containerRef} className={className} style={style} />;

--- a/packages/bpmn/src/declarations.d.ts
+++ b/packages/bpmn/src/declarations.d.ts
@@ -1,0 +1,5 @@
+// Allow side-effect CSS imports (consumed at build time by the host Next.js app).
+declare module "*.css" {
+  const _: string;
+  export default _;
+}

--- a/packages/bpmn/src/index.ts
+++ b/packages/bpmn/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./zoom";

--- a/packages/bpmn/src/index.ts
+++ b/packages/bpmn/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./zoom";
 export * from "./types";
 export * from "./bpmn-viewer";
+export * from "./use-bpmn-viewer";

--- a/packages/bpmn/src/index.ts
+++ b/packages/bpmn/src/index.ts
@@ -1,1 +1,3 @@
 export * from "./zoom";
+export * from "./types";
+export * from "./bpmn-viewer";

--- a/packages/bpmn/src/types.ts
+++ b/packages/bpmn/src/types.ts
@@ -13,7 +13,11 @@ export interface BpmnViewerError {
 export interface BpmnViewerProps {
   /** 受控的 BPMN 2.0 XML 字串。 */
   xml: string;
-  /** 透傳給 NavigatedViewer 建構子的額外選項。 */
+  /**
+   * 透傳給 NavigatedViewer 建構子的額外選項。
+   * @warning 請務必將此物件 memoize(例如 `useMemo`)。若每次 render 都傳入新的 inline 物件,
+   * viewer 將在每次 render 時被銷毀並重新建立。
+   */
   options?: Record<string, unknown>;
   className?: string;
   style?: CSSProperties;

--- a/packages/bpmn/src/types.ts
+++ b/packages/bpmn/src/types.ts
@@ -1,0 +1,33 @@
+import type { CSSProperties } from "react";
+
+export interface BpmnImportResult {
+  warnings: unknown[];
+}
+
+export interface BpmnViewerError {
+  message: string;
+  warnings?: unknown[];
+  cause?: unknown;
+}
+
+export interface BpmnViewerProps {
+  /** 受控的 BPMN 2.0 XML 字串。 */
+  xml: string;
+  /** 透傳給 NavigatedViewer 建構子的額外選項。 */
+  options?: Record<string, unknown>;
+  className?: string;
+  style?: CSSProperties;
+  onImport?: (result: BpmnImportResult) => void;
+  onError?: (error: BpmnViewerError) => void;
+  onLoadingChange?: (loading: boolean) => void;
+}
+
+export interface BpmnViewerHandle {
+  zoomIn(): void;
+  zoomOut(): void;
+  resetZoom(): void;
+  fitViewport(): void;
+  getZoom(): number;
+  /** 逃生艙:回傳底層 NavigatedViewer 實例(未建立時為 null)。 */
+  getViewer(): unknown;
+}

--- a/packages/bpmn/src/use-bpmn-viewer.spec.ts
+++ b/packages/bpmn/src/use-bpmn-viewer.spec.ts
@@ -1,0 +1,42 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { useBpmnViewer } from "./use-bpmn-viewer";
+import type { BpmnViewerHandle } from "./types";
+
+describe("useBpmnViewer", () => {
+  it("returns viewerProps with a ref and the two handlers", () => {
+    const { result } = renderHook(() => useBpmnViewer());
+    expect(result.current.viewerProps).toHaveProperty("ref");
+    expect(typeof result.current.viewerProps.onLoadingChange).toBe("function");
+    expect(typeof result.current.viewerProps.onError).toBe("function");
+  });
+
+  it("proxies zoom actions to the attached ref handle", () => {
+    const { result } = renderHook(() => useBpmnViewer());
+    const handle: BpmnViewerHandle = {
+      zoomIn: vi.fn(),
+      zoomOut: vi.fn(),
+      resetZoom: vi.fn(),
+      fitViewport: vi.fn(),
+      getZoom: vi.fn(() => 1),
+      getViewer: vi.fn(() => null),
+    };
+    result.current.viewerProps.ref.current = handle;
+    act(() => result.current.zoomIn());
+    act(() => result.current.fitViewport());
+    expect(handle.zoomIn).toHaveBeenCalledTimes(1);
+    expect(handle.fitViewport).toHaveBeenCalledTimes(1);
+  });
+
+  it("tracks importing state and clears error when a new load starts", () => {
+    const { result } = renderHook(() => useBpmnViewer());
+    act(() => result.current.viewerProps.onError({ message: "x" }));
+    expect(result.current.error).toEqual({ message: "x" });
+    act(() => result.current.viewerProps.onLoadingChange(true));
+    expect(result.current.importing).toBe(true);
+    expect(result.current.error).toBeNull();
+    act(() => result.current.viewerProps.onLoadingChange(false));
+    expect(result.current.importing).toBe(false);
+  });
+});

--- a/packages/bpmn/src/use-bpmn-viewer.ts
+++ b/packages/bpmn/src/use-bpmn-viewer.ts
@@ -1,0 +1,45 @@
+"use client";
+
+import { useCallback, useMemo, useRef, useState } from "react";
+import type { RefObject } from "react";
+
+import type { BpmnViewerError, BpmnViewerHandle } from "./types";
+
+export interface UseBpmnViewer {
+  /** 直接 spread 到 <BpmnViewer> 的 props(ref + 內部 handler)。 */
+  viewerProps: {
+    ref: RefObject<BpmnViewerHandle | null>;
+    onLoadingChange: (loading: boolean) => void;
+    onError: (error: BpmnViewerError) => void;
+  };
+  zoomIn: () => void;
+  zoomOut: () => void;
+  resetZoom: () => void;
+  fitViewport: () => void;
+  importing: boolean;
+  error: BpmnViewerError | null;
+}
+
+export function useBpmnViewer(): UseBpmnViewer {
+  const ref = useRef<BpmnViewerHandle | null>(null);
+  const [importing, setImporting] = useState(false);
+  const [error, setError] = useState<BpmnViewerError | null>(null);
+
+  const onLoadingChange = useCallback((loading: boolean) => {
+    setImporting(loading);
+    if (loading) setError(null);
+  }, []);
+  const onError = useCallback((e: BpmnViewerError) => setError(e), []);
+
+  const zoomIn = useCallback(() => ref.current?.zoomIn(), []);
+  const zoomOut = useCallback(() => ref.current?.zoomOut(), []);
+  const resetZoom = useCallback(() => ref.current?.resetZoom(), []);
+  const fitViewport = useCallback(() => ref.current?.fitViewport(), []);
+
+  const viewerProps = useMemo(
+    () => ({ ref, onLoadingChange, onError }),
+    [onLoadingChange, onError],
+  );
+
+  return { viewerProps, zoomIn, zoomOut, resetZoom, fitViewport, importing, error };
+}

--- a/packages/bpmn/src/zoom.spec.ts
+++ b/packages/bpmn/src/zoom.spec.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+
+import { ZOOM_FACTOR, MIN_ZOOM, MAX_ZOOM, clampZoom, zoomBy } from "./zoom";
+
+describe("zoom helpers", () => {
+  it("clamps below min and above max", () => {
+    expect(clampZoom(MIN_ZOOM - 1)).toBe(MIN_ZOOM);
+    expect(clampZoom(MAX_ZOOM + 1)).toBe(MAX_ZOOM);
+    expect(clampZoom(1)).toBe(1);
+  });
+
+  it("zoomBy multiplies then clamps", () => {
+    expect(zoomBy(1, ZOOM_FACTOR)).toBeCloseTo(ZOOM_FACTOR);
+    expect(zoomBy(1, 1 / ZOOM_FACTOR)).toBeCloseTo(1 / ZOOM_FACTOR);
+    expect(zoomBy(MAX_ZOOM, ZOOM_FACTOR)).toBe(MAX_ZOOM); // already at max
+    expect(zoomBy(MIN_ZOOM, 1 / ZOOM_FACTOR)).toBe(MIN_ZOOM); // already at min
+  });
+});

--- a/packages/bpmn/src/zoom.spec.ts
+++ b/packages/bpmn/src/zoom.spec.ts
@@ -15,4 +15,9 @@ describe("zoom helpers", () => {
     expect(zoomBy(MAX_ZOOM, ZOOM_FACTOR)).toBe(MAX_ZOOM); // already at max
     expect(zoomBy(MIN_ZOOM, 1 / ZOOM_FACTOR)).toBe(MIN_ZOOM); // already at min
   });
+
+  it("zoomOut never increases zoom below the floor; zoomIn still moves up", () => {
+    expect(zoomBy(0.12, 1 / ZOOM_FACTOR)).toBeLessThanOrEqual(0.12);
+    expect(zoomBy(0.12, ZOOM_FACTOR)).toBeGreaterThan(0.12);
+  });
 });

--- a/packages/bpmn/src/zoom.ts
+++ b/packages/bpmn/src/zoom.ts
@@ -8,5 +8,9 @@ export const MAX_ZOOM = 4;
 /** 把縮放倍率限制在 [MIN_ZOOM, MAX_ZOOM]。 */
 export const clampZoom = (z: number): number => Math.max(MIN_ZOOM, Math.min(MAX_ZOOM, z));
 
-/** 以 current × factor 計算新倍率並 clamp。 */
-export const zoomBy = (current: number, factor: number): number => clampZoom(current * factor);
+/** 以 current × factor 計算新倍率並 clamp。縮小時不會因為 floor 而反向拉高。 */
+export const zoomBy = (current: number, factor: number): number => {
+  const next = current * factor;
+  const lo = Math.min(MIN_ZOOM, current); // don't raise an already-below-floor zoom
+  return Math.min(MAX_ZOOM, Math.max(lo, next));
+};

--- a/packages/bpmn/src/zoom.ts
+++ b/packages/bpmn/src/zoom.ts
@@ -1,0 +1,12 @@
+/** 縮放係數:每次 zoomIn/zoomOut 乘以或除以此值。 */
+export const ZOOM_FACTOR = 1.2;
+/** 最小縮放倍率。 */
+export const MIN_ZOOM = 0.2;
+/** 最大縮放倍率。 */
+export const MAX_ZOOM = 4;
+
+/** 把縮放倍率限制在 [MIN_ZOOM, MAX_ZOOM]。 */
+export const clampZoom = (z: number): number => Math.max(MIN_ZOOM, Math.min(MAX_ZOOM, z));
+
+/** 以 current × factor 計算新倍率並 clamp。 */
+export const zoomBy = (current: number, factor: number): number => clampZoom(current * factor);

--- a/packages/bpmn/tsconfig.json
+++ b/packages/bpmn/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["es2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "moduleDetection": "force",
+    "jsx": "react-jsx",
+    "noEmit": true,
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
+}

--- a/packages/bpmn/vitest.config.mts
+++ b/packages/bpmn/vitest.config.mts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+  resolve: { alias: { '@': path.resolve(__dirname, 'src') } },
+  test: {
+    environment: 'jsdom',
+    include: ['src/**/*.spec.(ts|tsx)'],
+    globals: true,
+    reporters: ['verbose'],
+  },
+});

--- a/packages/web-core/src/registry/packages.ts
+++ b/packages/web-core/src/registry/packages.ts
@@ -119,6 +119,14 @@ export const packageRegistry: PackageDefinition[] = [
     relatedTools: ['form-builder', 'form-designer'],
   },
   {
+    name: '@rfjs/bpmn',
+    status: 'preview',
+    href: '/packages/bpmn',
+    github: GITHUB,
+    tags: ['bpmn', 'diagram', 'viewer'],
+    relatedTools: ['bpmn-viewer'],
+  },
+  {
     name: '@rfjs/pg-toolkit',
     status: 'ready',
     href: '/packages/pg-toolkit',

--- a/packages/web-core/src/registry/tools.ts
+++ b/packages/web-core/src/registry/tools.ts
@@ -122,6 +122,14 @@ export const toolRegistry: ToolDefinition[] = [
     tags: ['form', 'builder', 'canvas', '2d'],
   },
   {
+    id: 'bpmn-viewer',
+    category: 'inspect',
+    surface: 'web',
+    status: 'preview',
+    relatedPackages: ['@rfjs/bpmn'],
+    tags: ['diagram', 'bpmn', 'workflow', 'viewer'],
+  },
+  {
     id: 'object-transformer',
     category: 'transform',
     surface: 'workbench',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -190,6 +190,9 @@ importers:
 
   apps/web:
     dependencies:
+      '@rfjs/bpmn':
+        specifier: workspace:*
+        version: link:../../packages/bpmn
       '@rfjs/data-filter':
         specifier: workspace:*
         version: link:../../packages/data-filter

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -501,6 +501,58 @@ importers:
         specifier: ^4.1.8
         version: 4.1.8(@types/node@25.9.3)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@7.2.4(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))
 
+  packages/bpmn:
+    dependencies:
+      bpmn-js:
+        specifier: ^18.19.0
+        version: 18.19.0
+    devDependencies:
+      '@eslint/js':
+        specifier: ^9.20.0
+        version: 9.39.1
+      '@testing-library/dom':
+        specifier: ^10.4.1
+        version: 10.4.1
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@types/react':
+        specifier: 19.2.17
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: 19.2.3
+        version: 19.2.3(@types/react@19.2.17)
+      eslint:
+        specifier: ^9.20.1
+        version: 9.39.1(jiti@2.7.0)
+      eslint-config-prettier:
+        specifier: ^10.0.1
+        version: 10.0.1(eslint@9.39.1(jiti@2.7.0))
+      eslint-plugin-react:
+        specifier: ^7.37.4
+        version: 7.37.4(eslint@9.39.1(jiti@2.7.0))
+      eslint-plugin-react-hooks:
+        specifier: ^5.1.0
+        version: 5.1.0(eslint@9.39.1(jiti@2.7.0))
+      jsdom:
+        specifier: ^29.1.1
+        version: 29.1.1(@noble/hashes@1.8.0)
+      react:
+        specifier: ^19.2.7
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.2.7
+        version: 19.2.7(react@19.2.7)
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
+      typescript-eslint:
+        specifier: ^8.61.0
+        version: 8.61.0(eslint@9.39.1(jiti@2.7.0))(typescript@6.0.3)
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@25.9.3)(@vitest/ui@3.2.4)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0))(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
+
   packages/data-expr:
     dependencies:
       jsonata:
@@ -1743,6 +1795,9 @@ packages:
   '@babel/types@7.28.5':
     resolution: {integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==}
     engines: {node: '>=6.9.0'}
+
+  '@bpmn-io/diagram-js-ui@0.2.4':
+    resolution: {integrity: sha512-I678ZGtoH7z7FgzFhzzppM9ThsJ3Lh83kW3GjhjG3xyYciIPYHMaHK1MABP8F69H9pFZpViM6t4qUo8dwrVz0w==}
 
   '@bramus/specificity@2.4.2':
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
@@ -5023,6 +5078,13 @@ packages:
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
+  bpmn-js@18.19.0:
+    resolution: {integrity: sha512-MxEUdk1zLuf4ie8Bf0Pbr/zYMhzOhi+5LAm3669lormD1vP3XQaOoBNKkdeyJVz3aZmXzT+YbfNAYNUj9goLFQ==}
+
+  bpmn-moddle@10.0.0:
+    resolution: {integrity: sha512-vXePD5jkatcILmM3zwJG/m6IIHIghTGB7WvgcdEraEw8E8VdJHrTgrvBUhbzqaXJpnsGQz15QS936xeBY6l9aA==}
+    engines: {node: '>= 20.12'}
+
   brace-expansion@1.1.11:
     resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
 
@@ -5426,6 +5488,18 @@ packages:
   dezalgo@1.0.4:
     resolution: {integrity: sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==}
 
+  diagram-js-direct-editing@3.4.0:
+    resolution: {integrity: sha512-eXfd+nxJr5xt3YlCrs+E53mPi+gqBWRBkAXkR99ZPL7Pl0B3H5nkv/uiwx4Q4vJU/Sp8Jy3zVdhP/Y2c6loTjw==}
+    peerDependencies:
+      diagram-js: '*'
+
+  diagram-js@15.18.0:
+    resolution: {integrity: sha512-aOVeXrjQc1ki0jlrSuwXDoye5nKO6uAtXCtmgQopUvF/aC9aJwoaBOsNvQ2Na9GmMc6X2b3xAefhRChvGgcbgQ==}
+
+  didi@11.0.0:
+    resolution: {integrity: sha512-PzCfRzQttvFpVcYMbSF7h8EsWjeJpVjWH4qDhB5LkMi1ILvHq4Ob0vhM2wLFziPkbUBi+PAo7ODbe2sacR7nJQ==}
+    engines: {node: '>= 20.12'}
+
   diff@4.0.2:
     resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
     engines: {node: '>=0.3.1'}
@@ -5440,6 +5514,10 @@ packages:
 
   dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  domify@3.0.0:
+    resolution: {integrity: sha512-bs2yO68JDFOm6rKv8f0EnrM2cENduhRkpqOtt/s5l5JBA/eqGBZCzLPmdYoHtJ6utgLGgcBajFsEQbl12pT0lQ==}
+    engines: {node: '>=20'}
 
   dot-prop@5.3.0:
     resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==}
@@ -6146,6 +6224,9 @@ packages:
   hosted-git-info@2.8.9:
     resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
 
+  htm@3.1.1:
+    resolution: {integrity: sha512-983Vyg8NwUE7JkZ6NmOqpCZ+sh1bKv2iYTlUkzlWmA5JD2acKoxd4KVxbMmxX/85mtfdnDmTFoNKcg5DGAvxNQ==}
+
   html-encoding-sniffer@6.0.0:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
@@ -6187,6 +6268,10 @@ packages:
   icu-minify@4.13.0:
     resolution: {integrity: sha512-SIFMeUHZJjzS5RvIGvybKvWoHjDm9cGVEs2EpJ8PmywOdJLWyblPm7TdPLLoUtkJtwQD7iGhl2WMptZ+N0on+w==}
 
+  ids@3.0.2:
+    resolution: {integrity: sha512-t6YJP4mdC+GHF96Nbis/4FEANhP/8VWmYMvUuYpXvSdrhg5hpIVbq2XZlOA3UWTbtdwPCi0q7jEXOdHkAnqOnw==}
+    engines: {node: '>= 20.12'}
+
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
@@ -6219,6 +6304,9 @@ packages:
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
     deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
+
+  inherits-browser@0.1.0:
+    resolution: {integrity: sha512-CJHHvW3jQ6q7lzsXPpapLdMx5hDpSF3FSh45pwsj6bKxJJ8Nl8v43i5yXnr3BdfOimGHKyniewQtnAIp3vyJJw==}
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -6861,6 +6949,12 @@ packages:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
     engines: {node: '>=18'}
 
+  min-dash@5.0.0:
+    resolution: {integrity: sha512-EGuoBnVL7/Fnv2sqakpX5WGmZehZ3YMmLayT7sM8E9DRU74kkeyMg4Rik1lsOkR2GbFNeBca4/L+UfU6gF0Edw==}
+
+  min-dom@5.3.0:
+    resolution: {integrity: sha512-0w5FEBgPAyHhmFojW3zxd7we3D+m5XYS3E/06OyvxmbHJoiQVa4Nagj6RWvoAKYRw5xth6cP5TMePc5cR1M9hA==}
+
   minimatch@10.2.4:
     resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
     engines: {node: 18 || 20 || >=22}
@@ -6891,6 +6985,15 @@ packages:
 
   mitt@3.0.1:
     resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
+
+  moddle-xml@12.0.0:
+    resolution: {integrity: sha512-NJc2+sCe4tvuGlaUBcoZcYf6j9f+z+qxHOyGm/LB3ZrlJXVPPHoBTg/KXgDRCufdBJhJ3AheFs3QU/abABNzRg==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      moddle: '>= 6.2.0'
+
+  moddle@8.1.0:
+    resolution: {integrity: sha512-dBddc1CNuZHgro8nQWwfPZ2BkyLWdnxoNpPu9d+XKPN96DAiiBOeBw527ft++ebDuFez5PMdaR3pgUgoOaUGrA==}
 
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
@@ -7022,6 +7125,9 @@ packages:
   object-keys@1.1.1:
     resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
     engines: {node: '>= 0.4'}
+
+  object-refs@0.4.0:
+    resolution: {integrity: sha512-6kJqKWryKZmtte6QYvouas0/EIJKPI1/MMIuRsiBlNuhIMfqYTggzX2F1AJ2+cDs288xyi9GL7FyasHINR98BQ==}
 
   object.assign@4.1.7:
     resolution: {integrity: sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==}
@@ -7157,6 +7263,10 @@ packages:
   path-exists@5.0.0:
     resolution: {integrity: sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  path-intersection@4.1.0:
+    resolution: {integrity: sha512-urUP6WvhnxbHPdHYl6L7Yrc6+1ny6uOFKPCzPxTSUSYGHG0o94RmI7SvMMaScNAM5RtTf08bg4skc6/kjfne3A==}
+    engines: {node: '>= 14.20'}
 
   path-is-absolute@1.0.1:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
@@ -7323,6 +7433,9 @@ packages:
 
   preact@10.27.2:
     resolution: {integrity: sha512-5SYSgFKSyhCbk6SrXyMpqjb5+MQBgfvEKE/OC+PujcY34sOpqtr+0AZQtPYx5IA6VxynQ7rUPCtKzyovpj9Bpg==}
+
+  preact@10.29.3:
+    resolution: {integrity: sha512-D9NL1GAnJZhc3RndVs4gDdxEeU9TcHgywMrhhOsnpdlvFjdbx0gAsLUnH6JEhlJH5giL7Tx5biWPUSEXE/HPzw==}
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -7655,6 +7768,10 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  saxen@11.0.2:
+    resolution: {integrity: sha512-WDb4gqac8uiJzOdOdVpr9NWh9NrJMm7Brn5GX2Poj+mjE/QTXqYQENr8T/mom54dDDgbd3QjwTg23TRHYiWXRA==}
+    engines: {node: '>= 20.12'}
 
   saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
@@ -8003,6 +8120,10 @@ packages:
 
   through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
+
+  tiny-svg@4.1.4:
+    resolution: {integrity: sha512-cBaEACCbouYrQc9RG+eTXnPYosX1Ijqty/I6DdXovwDd89Pwu4jcmpOR7BuFEF9YCcd7/AWwasE0207WMK7hdw==}
+    engines: {node: '>= 20'}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -8907,6 +9028,11 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@bpmn-io/diagram-js-ui@0.2.4':
+    dependencies:
+      htm: 3.1.1
+      preact: 10.29.3
 
   '@bramus/specificity@2.4.2':
     dependencies:
@@ -12448,6 +12574,23 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
+  bpmn-js@18.19.0:
+    dependencies:
+      bpmn-moddle: 10.0.0
+      diagram-js: 15.18.0
+      diagram-js-direct-editing: 3.4.0(diagram-js@15.18.0)
+      ids: 3.0.2
+      inherits-browser: 0.1.0
+      min-dash: 5.0.0
+      min-dom: 5.3.0
+      tiny-svg: 4.1.4
+
+  bpmn-moddle@10.0.0:
+    dependencies:
+      min-dash: 5.0.0
+      moddle: 8.1.0
+      moddle-xml: 12.0.0(moddle@8.1.0)
+
   brace-expansion@1.1.11:
     dependencies:
       balanced-match: 1.0.2
@@ -12924,6 +13067,26 @@ snapshots:
       asap: 2.0.6
       wrappy: 1.0.2
 
+  diagram-js-direct-editing@3.4.0(diagram-js@15.18.0):
+    dependencies:
+      diagram-js: 15.18.0
+      min-dash: 5.0.0
+      min-dom: 5.3.0
+
+  diagram-js@15.18.0:
+    dependencies:
+      '@bpmn-io/diagram-js-ui': 0.2.4
+      clsx: 2.1.1
+      didi: 11.0.0
+      inherits-browser: 0.1.0
+      min-dash: 5.0.0
+      min-dom: 5.3.0
+      object-refs: 0.4.0
+      path-intersection: 4.1.0
+      tiny-svg: 4.1.4
+
+  didi@11.0.0: {}
+
   diff@4.0.2: {}
 
   dir-glob@3.0.1:
@@ -12935,6 +13098,8 @@ snapshots:
       esutils: 2.0.3
 
   dom-accessibility-api@0.5.16: {}
+
+  domify@3.0.0: {}
 
   dot-prop@5.3.0:
     dependencies:
@@ -13809,6 +13974,8 @@ snapshots:
 
   hosted-git-info@2.8.9: {}
 
+  htm@3.1.1: {}
+
   html-encoding-sniffer@6.0.0(@noble/hashes@1.8.0):
     dependencies:
       '@exodus/bytes': 1.15.1(@noble/hashes@1.8.0)
@@ -13848,6 +14015,8 @@ snapshots:
     dependencies:
       '@formatjs/icu-messageformat-parser': 3.5.11
 
+  ids@3.0.2: {}
+
   ieee754@1.2.1: {}
 
   ignore-by-default@1.0.1: {}
@@ -13871,6 +14040,8 @@ snapshots:
     dependencies:
       once: 1.4.0
       wrappy: 1.0.2
+
+  inherits-browser@0.1.0: {}
 
   inherits@2.0.4: {}
 
@@ -14527,6 +14698,13 @@ snapshots:
 
   mimic-function@5.0.1: {}
 
+  min-dash@5.0.0: {}
+
+  min-dom@5.3.0:
+    dependencies:
+      domify: 3.0.0
+      min-dash: 5.0.0
+
   minimatch@10.2.4:
     dependencies:
       brace-expansion: 5.0.4
@@ -14550,6 +14728,16 @@ snapshots:
   minisearch@7.2.0: {}
 
   mitt@3.0.1: {}
+
+  moddle-xml@12.0.0(moddle@8.1.0):
+    dependencies:
+      min-dash: 5.0.0
+      moddle: 8.1.0
+      saxen: 11.0.2
+
+  moddle@8.1.0:
+    dependencies:
+      min-dash: 5.0.0
 
   mri@1.2.0: {}
 
@@ -14696,6 +14884,8 @@ snapshots:
   object-inspect@1.13.3: {}
 
   object-keys@1.1.1: {}
+
+  object-refs@0.4.0: {}
 
   object.assign@4.1.7:
     dependencies:
@@ -14851,6 +15041,8 @@ snapshots:
   path-exists@4.0.0: {}
 
   path-exists@5.0.0: {}
+
+  path-intersection@4.1.0: {}
 
   path-is-absolute@1.0.1: {}
 
@@ -15010,6 +15202,8 @@ snapshots:
     optional: true
 
   preact@10.27.2: {}
+
+  preact@10.29.3: {}
 
   prelude-ls@1.2.1: {}
 
@@ -15430,6 +15624,8 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
+  saxen@11.0.2: {}
+
   saxes@6.0.0:
     dependencies:
       xmlchars: 2.2.0
@@ -15823,6 +16019,8 @@ snapshots:
       real-require: 0.2.0
 
   through@2.3.8: {}
+
+  tiny-svg@4.1.4: {}
 
   tinybench@2.9.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -243,10 +243,10 @@ importers:
         version: 1.17.0(react@19.2.7)
       next:
         specifier: ^16.2.9
-        version: 16.2.9(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 16.2.9(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       next-intl:
         specifier: ^4.13.0
-        version: 4.13.0(next@16.2.9(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
+        version: 4.13.0(next@16.2.9(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -266,6 +266,9 @@ importers:
       '@next/eslint-plugin-next':
         specifier: ^16.2.9
         version: 16.2.9
+      '@playwright/test':
+        specifier: ^1.49.0
+        version: 1.61.1
       '@tailwindcss/postcss':
         specifier: ^4.3.0
         version: 4.3.0
@@ -352,10 +355,10 @@ importers:
         version: 1.17.0(react@19.2.7)
       next:
         specifier: ^16.2.9
-        version: 16.2.9(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 16.2.9(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       next-intl:
         specifier: ^4.13.0
-        version: 4.13.0(next@16.2.9(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
+        version: 4.13.0(next@16.2.9(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -3308,6 +3311,11 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
 
+  '@playwright/test@1.61.1':
+    resolution: {integrity: sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
@@ -6045,6 +6053,11 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -7398,6 +7411,16 @@ packages:
 
   pkg-types@2.3.0:
     resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
+
+  playwright-core@1.61.1:
+    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.61.1:
+    resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   po-parser@2.1.1:
     resolution: {integrity: sha512-ECF4zHLbUItpUgE3OTtLKlPjeBN+fKEczj2zYjDfCGOzicNs0GK3Vg2IoAYwx7LH/XYw43fZQP6xnZ4TkNxSLQ==}
@@ -10517,6 +10540,10 @@ snapshots:
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
+
+  '@playwright/test@1.61.1':
+    dependencies:
+      playwright: 1.61.1
 
   '@polka/url@1.0.0-next.29': {}
 
@@ -13767,6 +13794,9 @@ snapshots:
 
   fs.realpath@1.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -14778,14 +14808,14 @@ snapshots:
 
   next-intl-swc-plugin-extractor@4.13.0: {}
 
-  next-intl@4.13.0(next@16.2.9(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(typescript@6.0.3):
+  next-intl@4.13.0(next@16.2.9(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(typescript@6.0.3):
     dependencies:
       '@formatjs/intl-localematcher': 0.8.10
       '@parcel/watcher': 2.5.6
       '@swc/core': 1.15.41
       icu-minify: 4.13.0
       negotiator: 1.0.0
-      next: 16.2.9(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      next: 16.2.9(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       next-intl-swc-plugin-extractor: 4.13.0
       po-parser: 2.1.1
       react: 19.2.7
@@ -14800,7 +14830,7 @@ snapshots:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
-  next@16.2.9(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  next@16.2.9(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       '@next/env': 16.2.9
       '@swc/helpers': 0.5.15
@@ -14819,6 +14849,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.2.9
       '@next/swc-win32-arm64-msvc': 16.2.9
       '@next/swc-win32-x64-msvc': 16.2.9
+      '@playwright/test': 1.61.1
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -15174,6 +15205,14 @@ snapshots:
       exsolve: 1.0.8
       pathe: 2.0.3
     optional: true
+
+  playwright-core@1.61.1: {}
+
+  playwright@1.61.1:
+    dependencies:
+      playwright-core: 1.61.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   po-parser@2.1.1: {}
 


### PR DESCRIPTION
## What

- **New private package `@rfjs/bpmn`** — a headless React wrapper around `bpmn-js` `NavigatedViewer` (read-only BPMN 2.0 viewer): `<BpmnViewer>` (controlled `xml` prop + imperative ref handle), `useBpmnViewer` hook, zoom helpers, types. SSR-safe (bpmn-js loaded via dynamic `import()` inside a client effect), import-race + unmount guards, and it retains the "Powered by bpmn.io" badge (license requirement). No dependency on `@rfjs/web-ui`/Tailwind; consumed via `transpilePackages`.
- **New `apps/web` tool `bpmn-viewer`** (`/tools/bpmn-viewer`) — toolbar (zoom in/out, reset, fit), bundled sample diagrams, file upload (`.bpmn`/`.xml`), paste-XML, error panel, en/zh-TW i18n. Registered in the web-core tool registry + package catalog and the apps/web aggregators.

## Scope

Viewer (read-only) only — the **modeler (editing) is a deliberate next phase**. The headless package boundary keeps the viewer reusable and lets the modeler be added later as an extension, not a rewrite.

## Verification

- `@rfjs/bpmn`: check-types ✓, lint ✓, vitest **15/15**
- `@rfjs/web-core`: **12/12**
- `web`: check-types ✓, vitest **160/160**, `next build` ✓ (**83/83** static pages; `/[locale]/tools/[slug]` prerendered via `generateStaticParams` → SSR-safe)
- Playwright **e2e: 3/3** in Chromium — real SVG render, bpmn.io badge visible, error panel on invalid XML

## Notes

- All touched packages are private → **no changeset**.
- **Pre-existing on `main` (not introduced here):** `web lint` reports 5 problems under `apps/web/src/tools/form-designer/` (`model.spec.ts` 4× `no-explicit-any`, `layout-grid.ts` 1× unused eslint-disable). This branch's own code is lint-clean.
- Deferred follow-ups: align `@rfjs/bpmn` vitest to the repo's `^4`; optional `aria-label`/`role` on the viewer container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
