### PR TITLE
fix(form-designer): lift mobile inspector sheet above the app header

### DIFF
--- a/apps/web/src/tools/form-designer/ui.tsx
+++ b/apps/web/src/tools/form-designer/ui.tsx
@@ -426,7 +426,7 @@ export function FormDesignerTool() {
               <div
                 className={
                   selectedCard
-                    ? "fixed inset-0 z-30 overflow-y-auto bg-background p-4 lg:static lg:z-auto lg:bg-transparent lg:p-0"
+                    ? "fixed inset-0 z-50 overflow-y-auto bg-background p-4 lg:static lg:z-auto lg:bg-transparent lg:p-0"
                     : "hidden lg:block"
                 }
               >


### PR DESCRIPTION
## What

On mobile, the form-designer inspector opens as a full-screen sheet when a card is selected. It used `fixed inset-0 z-30`, which sat **below** the sticky, translucent app header (`sticky top-0 z-40` + `bg-bedrock/90 backdrop-blur`).

Result: the header painted over the sheet's top edge — hiding the "← Back to canvas" button and bleeding the `rfjs` header bar through the inspector content (see the reported screenshots).

## Fix

Bump the mobile sheet to `z-50` (the top overlay layer, same as the mobile-nav drawer) so the opaque full-screen sheet fully covers the header. The sheet already carries its own "← Back to canvas" affordance, so covering the global header is the intended behavior. The desktop `lg:static` path is unchanged.

```diff
- "fixed inset-0 z-30 overflow-y-auto bg-background p-4 lg:static …"
+ "fixed inset-0 z-50 overflow-y-auto bg-background p-4 lg:static …"
```

## Verification

- Ran the app at a 390×844 mobile viewport and confirmed via screenshots: "← Back to canvas" is fully visible and the header no longer overlaps the inspector.
- Computed stacking confirmed: sheet `z-index:50` > header `z-index:40`, both anchored at `top:0`.
- `form-designer` test suite passes (56 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)