### PR TITLE
chore(bpmn): post-merge polish + clear web lint

### DIFF
--- a/apps/web/src/tools/bpmn-viewer/messages.ts
+++ b/apps/web/src/tools/bpmn-viewer/messages.ts
@@ -24,6 +24,7 @@ export const messages: LocaleMessages = {
       bpmnErrEmpty: "File is empty",
       bpmnErrImport: "Could not render this diagram — the XML may be invalid",
       bpmnErrRead: "Could not read the file",
+      bpmnDiagramLabel: "BPMN process diagram",
     },
   },
   "zh-TW": {
@@ -49,6 +50,7 @@ export const messages: LocaleMessages = {
       bpmnErrEmpty: "檔案是空的",
       bpmnErrImport: "無法渲染此圖 —— XML 可能無效",
       bpmnErrRead: "無法讀取檔案",
+      bpmnDiagramLabel: "BPMN 流程圖",
     },
   },
 };

--- a/apps/web/src/tools/bpmn-viewer/ui.tsx
+++ b/apps/web/src/tools/bpmn-viewer/ui.tsx
@@ -121,6 +121,7 @@ export function BpmnViewerTool() {
       <BpmnViewer
         {...v.viewerProps}
         xml={xml}
+        ariaLabel={t("bpmnDiagramLabel")}
         className="h-[600px] w-full rounded-md border bg-card"
       />
 

--- a/apps/web/src/tools/form-designer/layout-grid.ts
+++ b/apps/web/src/tools/form-designer/layout-grid.ts
@@ -25,7 +25,6 @@ export function collides(a: GridItem, b: GridItem): boolean {
 // Lowest row >= 1 at which `item` does not collide with any of `placed`.
 function lowestFreeRow(item: GridItem, placed: GridItem[]): number {
   let row = 1;
-  // eslint-disable-next-line no-constant-condition
   while (true) {
     const probe = { ...item, row };
     if (!placed.some((p) => collides(probe, p))) return row;

--- a/apps/web/src/tools/form-designer/model.spec.ts
+++ b/apps/web/src/tools/form-designer/model.spec.ts
@@ -146,11 +146,11 @@ describe("FileUpload / Signature round-trip", () => {
       { id: "fu", key: "f", kind: "field", label: "F", component: "FileUpload", dataType: "object", fileUpload: { accept: "image/*", multiple: true, maxSize: 1000 } },
       { id: "sig", key: "s", kind: "field", label: "S", component: "Signature", dataType: "string" },
     ] }] }] };
-    const { groups: g, cards: cs } = formConfigToCards(cfg as any);
+    const { groups: g, cards: cs } = formConfigToCards(cfg as unknown as FormConfig);
     const back = cardsToFormConfig(g, cs);
     const items = back.sections![0]!.rows[0]!.items;
-    expect((items[0] as any).component).toBe("FileUpload");
-    expect((items[0] as any).fileUpload).toEqual({ accept: "image/*", multiple: true, maxSize: 1000 });
-    expect((items[1] as any).component).toBe("Signature");
+    expect((items[0] as { component?: string }).component).toBe("FileUpload");
+    expect((items[0] as { fileUpload?: unknown }).fileUpload).toEqual({ accept: "image/*", multiple: true, maxSize: 1000 });
+    expect((items[1] as { component?: string }).component).toBe("Signature");
   });
 });

--- a/packages/bpmn/package.json
+++ b/packages/bpmn/package.json
@@ -31,7 +31,7 @@
     "react-dom": "^19.2.7",
     "typescript": "6.0.3",
     "typescript-eslint": "^8.61.0",
-    "vitest": "^3.2.4"
+    "vitest": "^4.1.8"
   },
   "peerDependencies": {
     "react": "^19.0.0",

--- a/packages/bpmn/src/bpmn-viewer.tsx
+++ b/packages/bpmn/src/bpmn-viewer.tsx
@@ -25,7 +25,7 @@ interface BpmnInstance {
 }
 
 export const BpmnViewer = forwardRef<BpmnViewerHandle, BpmnViewerProps>(
-  function BpmnViewer({ xml, options, className, style, onImport, onError, onLoadingChange }, ref) {
+  function BpmnViewer({ xml, options, className, style, onImport, onError, onLoadingChange, ariaLabel }, ref) {
     const containerRef = useRef<HTMLDivElement>(null);
     const viewerRef = useRef<BpmnInstance | null>(null);
     const importSeq = useRef(0);
@@ -122,6 +122,14 @@ export const BpmnViewer = forwardRef<BpmnViewerHandle, BpmnViewerProps>(
       [],
     );
 
-    return <div ref={containerRef} className={className} style={style} />;
+    return (
+      <div
+        ref={containerRef}
+        className={className}
+        style={style}
+        role={ariaLabel ? "group" : undefined}
+        aria-label={ariaLabel}
+      />
+    );
   },
 );

--- a/packages/bpmn/src/types.ts
+++ b/packages/bpmn/src/types.ts
@@ -24,6 +24,8 @@ export interface BpmnViewerProps {
   onImport?: (result: BpmnImportResult) => void;
   onError?: (error: BpmnViewerError) => void;
   onLoadingChange?: (loading: boolean) => void;
+  /** 無障礙標籤;有值時容器會帶上 `role="group"` + `aria-label`。 */
+  ariaLabel?: string;
 }
 
 export interface BpmnViewerHandle {

--- a/packages/bpmn/src/use-bpmn-viewer.spec.ts
+++ b/packages/bpmn/src/use-bpmn-viewer.spec.ts
@@ -24,9 +24,24 @@ describe("useBpmnViewer", () => {
     };
     result.current.viewerProps.ref.current = handle;
     act(() => result.current.zoomIn());
+    act(() => result.current.zoomOut());
+    act(() => result.current.resetZoom());
     act(() => result.current.fitViewport());
     expect(handle.zoomIn).toHaveBeenCalledTimes(1);
+    expect(handle.zoomOut).toHaveBeenCalledTimes(1);
+    expect(handle.resetZoom).toHaveBeenCalledTimes(1);
     expect(handle.fitViewport).toHaveBeenCalledTimes(1);
+  });
+
+  it("zoom actions are safe no-ops before a viewer is attached (ref still null)", () => {
+    const { result } = renderHook(() => useBpmnViewer());
+    expect(result.current.viewerProps.ref.current).toBeNull();
+    expect(() => {
+      act(() => result.current.zoomIn());
+      act(() => result.current.zoomOut());
+      act(() => result.current.resetZoom());
+      act(() => result.current.fitViewport());
+    }).not.toThrow();
   });
 
   it("tracks importing state and clears error when a new load starts", () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -556,8 +556,8 @@ importers:
         specifier: ^8.61.0
         version: 8.61.0(eslint@9.39.1(jiti@2.7.0))(typescript@6.0.3)
       vitest:
-        specifier: ^3.2.4
-        version: 3.2.4(@types/node@25.9.3)(@vitest/ui@3.2.4)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0))(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
+        specifier: ^4.1.8
+        version: 4.1.8(@types/node@25.9.3)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@7.2.4(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))
 
   packages/data-expr:
     dependencies:


### PR DESCRIPTION
Post-merge cleanup after #218. Two unrelated, low-risk concerns kept as separate commits.

## `chore(bpmn)` — deferred polish from the #218 review
- Align `@rfjs/bpmn` `vitest` `^3.2.4` → `^4.1.8` (repo standard; tests still green under v4).
- Add an optional `ariaLabel` prop to `<BpmnViewer>` (sets `role="group"` + `aria-label` on the container); the tool passes a localized label.
- `useBpmnViewer` tests: cover `zoomOut`/`resetZoom` proxying and add a pre-mount null-ref no-op smoke test.

## `fix(form-designer)` — turn `web lint` green
`pnpm -F web lint` was **already red on `main`** (unrelated to bpmn): 4× `no-explicit-any` in `model.spec.ts` and 1 unused `eslint-disable` in `layout-grid.ts`. Fixed with typed/structural casts + removing the dead directive. No behavior change.

## Verification
- `@rfjs/bpmn`: check-types ✓, lint ✓, vitest **16/16** (under v4)
- `web`: check-types ✓, **lint ✓ (now green)**, vitest **160/160**, `next build` ✓
- All touched packages are private → **no changeset**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
