### PR TITLE
fix(web): scroll the nav sidebar independently of page content

### DIFF
--- a/apps/web/src/components/layout/app-shell.tsx
+++ b/apps/web/src/components/layout/app-shell.tsx
@@ -7,7 +7,10 @@ export function AppShell({ children }: { children: React.ReactNode }) {
       <AppHeader />
       <div className="mx-auto flex w-full max-w-[1440px]">
         <aside className="hidden w-60 shrink-0 border-r border-border lg:block">
-          <div className="sticky top-14">
+          {/* Bound the sticky sidebar to the viewport and give it its own
+              scroll, so a long nav scrolls independently of the page content
+              instead of scrolling along with it once it exceeds the viewport. */}
+          <div className="sticky top-14 h-[calc(100vh-3.5rem)] overflow-y-auto overscroll-contain">
             <AppSidebar />
           </div>
         </aside>


### PR DESCRIPTION
The app-shell nav sidebar was `sticky top-14` with no bounded height, so once the nav list grew taller than the viewport it scrolled along with the page content (the left side moving in lockstep with the right side's length).

**Fix:** bound the sticky sidebar to the viewport (`h-[calc(100vh-3.5rem)]`, 3.5rem = the `h-14` header) and give it its own `overflow-y-auto overscroll-contain`. The nav now scrolls on its own, decoupled from the main content.

- `apps/web/src/components/layout/app-shell.tsx` — one className change.
- check-types clean; screenshot-verified the layout is intact (no double scrollbar). The scroll decoupling is interactive — please confirm the feel.
- No changeset (only `apps/web`, private).

🤖 Generated with [Claude Code](https://claude.com/claude-code)