### PR TITLE
fix(web): form-builder canvas is undraggable on mobile (config overlay opens on press)

### DIFF
--- a/apps/web/src/tools/form-builder/ui.spec.tsx
+++ b/apps/web/src/tools/form-builder/ui.spec.tsx
@@ -130,3 +130,28 @@ describe("FormBuilderTool preview tab integration", () => {
     expect(screen.queryByText(/^metadata$/i)).toBeNull();
   });
 });
+
+describe("FormBuilderTool mobile config overlay (does not block canvas drag)", () => {
+  // The inspector container uses the full-screen overlay classes on mobile only
+  // when the mobile config is open. A press-to-drag must NOT open it.
+  const isOverlayOpen = () => screen.getByTestId("card-inspector").className.includes("fixed");
+
+  it("a tap (press-release without moving) opens the mobile config overlay", () => {
+    render(<FormBuilderTool />);
+    const card = screen.getByText("Name").closest(".cursor-grab") as HTMLElement;
+    expect(isOverlayOpen()).toBe(false);
+    fireEvent.pointerDown(card, { clientX: 100, clientY: 100 });
+    expect(isOverlayOpen()).toBe(false); // still closed mid-press → canvas not covered
+    fireEvent.pointerUp(window, { clientX: 100, clientY: 100 }); // no movement → a tap
+    expect(isOverlayOpen()).toBe(true);
+  });
+
+  it("a press-drag (past the threshold) does NOT open the overlay, so the canvas stays draggable", () => {
+    render(<FormBuilderTool />);
+    const card = screen.getByText("Name").closest(".cursor-grab") as HTMLElement;
+    fireEvent.pointerDown(card, { clientX: 100, clientY: 100 });
+    fireEvent.pointerMove(window, { clientX: 140, clientY: 140 }); // ~57px, past the 4px threshold → a drag
+    fireEvent.pointerUp(window, { clientX: 140, clientY: 140 });
+    expect(isOverlayOpen()).toBe(false);
+  });
+});

--- a/apps/web/src/tools/form-builder/ui.tsx
+++ b/apps/web/src/tools/form-builder/ui.tsx
@@ -116,6 +116,12 @@ export function FormBuilderTool() {
   const [groups, setGroups] = React.useState<Group[]>(SEED_GROUPS);
   const [cards, setCards] = React.useState<Card[]>(SEED_CARDS);
   const [selected, setSelected] = React.useState<string | null>(null);
+  // Mobile only: the config panel is a full-screen overlay. Selection (set on
+  // pointer-down for drag/highlight) must NOT open it, or a press-to-drag would
+  // immediately raise the overlay and block the canvas. It opens only on a
+  // confirmed tap (pointer-up without crossing the drag threshold). Desktop is
+  // unaffected — the panel is always inline there (lg: classes).
+  const [mobileConfigOpen, setMobileConfigOpen] = React.useState(false);
   const [tab, setTab] = React.useState<"canvas" | "preview" | "json">("canvas");
   const [jsonError, setJsonError] = React.useState<string | null>(null);
   const [payload, setPayload] = React.useState<{ data: Record<string, unknown>; meta: SubmissionMeta } | null>(null);
@@ -257,6 +263,9 @@ export function FormBuilderTool() {
       }
     };
     const onUp = () => {
+      // A confirmed tap (press that never became a drag) on a card opens the
+      // mobile config overlay; a drag never does, so the canvas stays draggable.
+      if (!active && mode === "move") setMobileConfigOpen(true);
       drag.current = null;
       setDropGroup(null);
       window.removeEventListener("pointermove", onMove);
@@ -397,7 +406,13 @@ export function FormBuilderTool() {
           <Section title="Editor" defaultOpen={true}>
             {/* Canvas + inspector (RWD: stacks below lg) */}
             <div className="flex flex-col gap-4 lg:flex-row lg:items-start">
-              <div className="min-w-0 flex-1" onPointerDown={() => setSelected(null)}>
+              <div
+                className="min-w-0 flex-1"
+                onPointerDown={() => {
+                  setSelected(null);
+                  setMobileConfigOpen(false);
+                }}
+              >
                 <div className="flex flex-col gap-4">
                   {groups.map((group, index) => (
                     <React.Fragment key={group.id}>
@@ -432,10 +447,12 @@ export function FormBuilderTool() {
               </div>
 
               <aside className="shrink-0 lg:w-[420px]">
-                {/* Mobile: full-screen sheet when a card is selected; Desktop: inline column. */}
+                {/* Mobile: full-screen overlay only after a confirmed tap (mobileConfigOpen);
+                    Desktop: always inline when a card is selected (lg: classes). */}
                 <div
+                  data-testid="card-inspector"
                   className={
-                    selectedCard
+                    selectedCard && mobileConfigOpen
                       ? "fixed inset-0 z-50 overflow-y-auto bg-background p-4 lg:static lg:z-auto lg:bg-transparent lg:p-0"
                       : "hidden lg:block"
                   }
@@ -443,7 +460,7 @@ export function FormBuilderTool() {
                   {selectedCard ? (
                     <button
                       type="button"
-                      onClick={() => setSelected(null)}
+                      onClick={() => setMobileConfigOpen(false)}
                       className="mb-3 text-xs text-muted-foreground hover:text-foreground lg:hidden"
                     >
                       ← Back to canvas
@@ -458,6 +475,7 @@ export function FormBuilderTool() {
                       if (!selectedCard) return;
                       setCards((cs) => resolveCards(cs.filter((c) => c.id !== selectedCard.id) as Card[], "", COLS) as Card[]);
                       setSelected(null);
+                      setMobileConfigOpen(false);
                     }}
                   />
                 </div>


### PR DESCRIPTION
**Bug:** On mobile, tapping a form-builder canvas card immediately popped up the full-screen config overlay, so the canvas could never be dragged.

**Cause:** Selection was set on **pointer-down** (`beginDrag` → `setSelected`), and the inspector renders as a `fixed inset-0 z-50` overlay on mobile the moment a card is selected. So a press (the start of a drag gesture) raised the overlay over the canvas before any drag could happen.

**Fix:** Decouple "selected" (needed for drag + the desktop inline inspector) from "mobile config open". A new `mobileConfigOpen` state opens the overlay **only on a confirmed tap** — pointer-up that never crossed the 4px drag threshold (`if (!active && mode === "move")`). A press-drag keeps the overlay closed, so the canvas stays draggable on touch. Deselecting / Back / delete close it.

**Desktop unchanged:** the inspector is always inline there (the `lg:` classes override the overlay classes regardless of `mobileConfigOpen`).

**Tests:** added two — a tap opens the overlay; a press-drag past the threshold does **not** (canvas stays draggable). form-builder suite 81/81, web check-types clean. No changeset (only `apps/web`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)