### PR TITLE
docs(flow): @rfjs/flow design direction + canvas mockup

### DIFF
--- a/docs/mockups/2026-06-30-flow-canvas-directions.html
+++ b/docs/mockups/2026-06-30-flow-canvas-directions.html
@@ -1,0 +1,250 @@
+<!doctype html>
+<html lang="zh-TW">
+<head>
+<meta charset="utf-8" />
+<title>@rfjs/flow — canvas mockup (3 directions)</title>
+<style>
+  :root{
+    --bg:#f6f7f9; --panel:#ffffff; --line:#e5e7eb; --line2:#eef0f3;
+    --ink:#0f172a; --muted:#64748b; --faint:#94a3b8;
+    --form:#3b82f6; --cond:#f59e0b; --act:#8b5cf6; --term:#10b981;
+    --formbg:#eff6ff; --condbg:#fffbeb; --actbg:#f5f3ff; --termbg:#ecfdf5;
+    --shadow:0 1px 2px rgba(15,23,42,.06),0 4px 12px rgba(15,23,42,.06);
+  }
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--ink);
+    font:14px/1.45 ui-sans-serif,system-ui,-apple-system,"Segoe UI",Roboto,"Noto Sans TC",sans-serif;}
+  .wrap{max-width:1240px;margin:0 auto;padding:28px 24px 60px}
+  h1{font-size:22px;margin:0 0 4px} .sub{color:var(--muted);margin:0 0 8px}
+  .legend{display:flex;gap:16px;flex-wrap:wrap;margin:14px 0 26px;color:var(--muted);font-size:12.5px}
+  .legend b{display:inline-block;width:10px;height:10px;border-radius:3px;margin-right:6px;vertical-align:middle}
+  .dir{background:var(--panel);border:1px solid var(--line);border-radius:14px;box-shadow:var(--shadow);margin:0 0 30px;overflow:hidden}
+  .dir-head{padding:14px 18px;border-bottom:1px solid var(--line2);background:linear-gradient(#fff,#fcfcfd)}
+  .dir-head .tag{display:inline-block;font-size:11px;font-weight:700;letter-spacing:.08em;color:#fff;background:#0f172a;border-radius:999px;padding:3px 9px;margin-right:10px}
+  .dir-head h2{display:inline;font-size:16px} .dir-head p{margin:6px 0 0;color:var(--muted);font-size:13px}
+  .editor{display:grid;grid-template-columns:158px 1fr 246px;min-height:430px}
+  .palette{border-right:1px solid var(--line2);padding:12px;background:#fcfcfd}
+  .palette .h{font-size:11px;font-weight:700;color:var(--faint);letter-spacing:.07em;margin:2px 0 10px}
+  .pitem{display:flex;align-items:center;gap:8px;padding:8px 9px;border:1px solid var(--line);border-radius:9px;background:#fff;margin-bottom:8px;font-size:12.5px;cursor:grab}
+  .dot{width:9px;height:9px;border-radius:3px;flex:none}
+  .canvas{position:relative;overflow:hidden;background:
+    radial-gradient(circle at 1px 1px,#e3e7ec 1px,transparent 0);background-size:18px 18px}
+  .inspect{border-left:1px solid var(--line2);padding:14px;background:#fcfcfd}
+  .inspect .h{font-size:11px;font-weight:700;color:var(--faint);letter-spacing:.07em;margin:0 0 10px}
+  .field{margin-bottom:11px}
+  .field label{display:block;font-size:11.5px;color:var(--muted);margin-bottom:4px}
+  .ctrl{border:1px solid var(--line);border-radius:8px;background:#fff;padding:7px 9px;font-size:12.5px;color:var(--ink)}
+  .ctrl.sel{display:flex;justify-content:space-between;align-items:center;color:var(--cond)}
+  .pill{display:inline-flex;align-items:center;gap:6px;background:var(--condbg);color:#b45309;border:1px solid #fcd9a3;border-radius:999px;padding:4px 10px;font-size:12px}
+  /* node card */
+  .node{position:absolute;width:174px;background:#fff;border:1px solid var(--line);border-radius:11px;box-shadow:var(--shadow);overflow:hidden}
+  .node .top{display:flex;align-items:center;gap:7px;padding:7px 10px;font-weight:600;font-size:12.5px;border-bottom:1px solid var(--line2)}
+  .node .ico{width:18px;height:18px;border-radius:5px;flex:none;display:grid;place-items:center;color:#fff;font-size:11px}
+  .node .body{padding:9px 10px;font-size:11.5px;color:var(--muted)}
+  .node.form{border-color:#bfdbfe} .node.form .top{background:var(--formbg);color:#1d4ed8}
+  .node.cond{border-color:#fcd9a3;width:150px} .node.cond .top{background:var(--condbg);color:#b45309}
+  .node.act{border-color:#ddd6fe} .node.act .top{background:var(--actbg);color:#6d28d9}
+  .mini{height:7px;border-radius:3px;background:#eef2f7;margin:5px 0}
+  .mini.s{width:60%} .mini.m{width:85%}
+  .tinput{border:1px solid #e2e8f0;border-radius:5px;padding:3px 6px;font-size:10.5px;color:#475569;background:#fff;display:inline-block}
+  .term{position:absolute;width:74px;text-align:center;background:var(--termbg);border:1px solid #a7f3d0;color:#047857;border-radius:999px;padding:8px 0;font-size:12px;font-weight:600;box-shadow:var(--shadow)}
+  .term.start{background:#f1f5f9;border-color:#cbd5e1;color:#475569}
+  .elabel{position:absolute;font-size:10.5px;font-weight:700;padding:1px 7px;border-radius:999px;background:#fff;border:1px solid var(--line)}
+  .elabel.yes{color:#047857;border-color:#a7f3d0}.elabel.no{color:#b91c1c;border-color:#fecaca}
+  svg.edges{position:absolute;inset:0;width:100%;height:100%;pointer-events:none}
+  .edges path{fill:none;stroke:#cbd5e1;stroke-width:2}
+  .edges path.y{stroke:#34d399}.edges path.n{stroke:#f87171}
+  /* swimlane */
+  .lanes{position:absolute;inset:0;display:grid;grid-template-columns:repeat(4,1fr)}
+  .lane{border-right:1px dashed #e2e8f0;position:relative}
+  .lane:last-child{border-right:0}
+  .lane .lh{position:absolute;top:8px;left:0;right:0;text-align:center;font-size:11px;font-weight:700;color:var(--faint);letter-spacing:.05em}
+  /* spine note */
+  .hint{position:absolute;bottom:10px;left:12px;font-size:11px;color:var(--faint)}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <h1>@rfjs/flow — 流程畫布 mockup</h1>
+  <p class="sub">同一個編輯器框(palette｜canvas｜inspector),三種畫布佈局方向。範例流程:請假申請 → 判斷天數 → 通知主管 / 自動核准。<b style="color:#b91c1c">※ 視覺草稿,非真功能</b></p>
+  <div class="legend">
+    <span><b style="background:var(--form)"></b>Form 節點(form-builder)</span>
+    <span><b style="background:var(--cond)"></b>Condition 節點(filter-builder)</span>
+    <span><b style="background:var(--act)"></b>Action 節點(可插拔 kind)</span>
+    <span><b style="background:var(--term)"></b>Start / End</span>
+  </div>
+
+  <!-- ============ DIRECTION A ============ -->
+  <div class="dir">
+    <div class="dir-head">
+      <span class="tag">方向 A</span><h2>經典節點圖(n8n / React Flow 風)</h2>
+      <p>自由擺放 + 貝茲連線。最大彈性、最像主流自動化工具;複雜流程容易變「義大利麵」。</p>
+    </div>
+    <div class="editor">
+      <div class="palette">
+        <div class="h">節點</div>
+        <div class="pitem"><span class="dot" style="background:var(--form)"></span>表單 Form</div>
+        <div class="pitem"><span class="dot" style="background:var(--cond)"></span>條件 Condition</div>
+        <div class="pitem"><span class="dot" style="background:var(--act)"></span>動作 Action</div>
+        <div class="pitem"><span class="dot" style="background:var(--act)"></span>轉換 Transform</div>
+        <div class="pitem"><span class="dot" style="background:var(--term)"></span>結束 End</div>
+      </div>
+      <div class="canvas" style="height:430px">
+        <svg class="edges" viewBox="0 0 760 430" preserveAspectRatio="none">
+          <path d="M96,212 C120,212 120,212 132,212"/>
+          <path d="M306,212 C326,214 330,222 342,222"/>
+          <path class="y" d="M462,200 C500,196 500,150 524,150"/>
+          <path class="n" d="M462,236 C500,250 500,292 524,292"/>
+          <path d="M698,150 C720,150 716,205 706,212"/>
+          <path d="M698,292 C720,292 716,222 706,214"/>
+        </svg>
+        <div class="term start" style="left:18px;top:196px">開始</div>
+        <div class="node form" style="left:132px;top:158px">
+          <div class="top"><span class="ico" style="background:var(--form)">▤</span>請假申請</div>
+          <div class="body"><div class="tinput">起訖日期</div> <div class="tinput">事由</div><div class="mini m"></div><div class="mini s"></div></div>
+        </div>
+        <div class="node cond" style="left:342px;top:176px">
+          <div class="top"><span class="ico" style="background:var(--cond)">◆</span>天數 &gt; 3?</div>
+          <div class="body"><span class="pill">days &gt; 3</span></div>
+        </div>
+        <div class="node act" style="left:524px;top:110px">
+          <div class="top"><span class="ico" style="background:var(--act)">⚡</span>通知主管</div>
+          <div class="body">kind: <b>notify</b><br>to: manager</div>
+        </div>
+        <div class="node act" style="left:524px;top:255px">
+          <div class="top"><span class="ico" style="background:var(--act)">⚡</span>自動核准</div>
+          <div class="body">kind: <b>db.update</b><br>status: approved</div>
+        </div>
+        <div class="term" style="left:704px;top:196px">結束</div>
+        <div class="elabel yes" style="left:486px;top:158px">是</div>
+        <div class="elabel no" style="left:486px;top:258px">否</div>
+      </div>
+      <div class="inspect">
+        <div class="h">INSPECTOR · 條件節點</div>
+        <div class="field"><label>節點名稱</label><div class="ctrl">天數 &gt; 3?</div></div>
+        <div class="field"><label>條件(filter-builder)</label><div class="ctrl sel">days &gt; 3 <span>▾</span></div></div>
+        <div class="field"><label>出邊</label>
+          <div class="ctrl" style="display:flex;gap:6px"><span class="elabel yes" style="position:static">是 → 通知主管</span></div>
+          <div class="ctrl" style="display:flex;gap:6px;margin-top:6px"><span class="elabel no" style="position:static">否 → 自動核准</span></div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- ============ DIRECTION B ============ -->
+  <div class="dir">
+    <div class="dir-head">
+      <span class="tag">方向 B</span><h2>泳道 / 階段欄</h2>
+      <p>由左到右的固定階段欄,節點落進欄裡。對「審批流程」最直覺、最整齊;自由度低,迴圈/跳關較難表達。</p>
+    </div>
+    <div class="editor">
+      <div class="palette">
+        <div class="h">節點</div>
+        <div class="pitem"><span class="dot" style="background:var(--form)"></span>表單 Form</div>
+        <div class="pitem"><span class="dot" style="background:var(--cond)"></span>條件 Condition</div>
+        <div class="pitem"><span class="dot" style="background:var(--act)"></span>動作 Action</div>
+        <div class="pitem"><span class="dot" style="background:var(--term)"></span>結束 End</div>
+      </div>
+      <div class="canvas" style="height:430px">
+        <div class="lanes">
+          <div class="lane"><div class="lh">① 申請</div></div>
+          <div class="lane"><div class="lh">② 判斷</div></div>
+          <div class="lane"><div class="lh">③ 處理</div></div>
+          <div class="lane"><div class="lh">④ 完成</div></div>
+        </div>
+        <svg class="edges" viewBox="0 0 760 430" preserveAspectRatio="none">
+          <path d="M174,212 C196,212 196,212 206,212"/>
+          <path class="y" d="M356,205 C390,200 390,150 396,150"/>
+          <path class="n" d="M356,236 C390,250 390,300 396,300"/>
+          <path d="M570,150 C592,150 590,206 596,210"/>
+          <path d="M570,300 C592,300 590,220 596,214"/>
+        </svg>
+        <div class="term start" style="left:24px;top:196px">開始</div>
+        <div class="node form" style="left:36px;top:250px;width:140px">
+          <div class="top"><span class="ico" style="background:var(--form)">▤</span>請假申請</div>
+          <div class="body"><div class="tinput">起訖日期</div><div class="mini m"></div></div>
+        </div>
+        <div class="node cond" style="left:212px;top:176px">
+          <div class="top"><span class="ico" style="background:var(--cond)">◆</span>天數 &gt; 3?</div>
+          <div class="body"><span class="pill">days &gt; 3</span></div>
+        </div>
+        <div class="node act" style="left:396px;top:112px;width:150px">
+          <div class="top"><span class="ico" style="background:var(--act)">⚡</span>通知主管</div>
+          <div class="body">kind: <b>notify</b></div>
+        </div>
+        <div class="node act" style="left:396px;top:264px;width:150px">
+          <div class="top"><span class="ico" style="background:var(--act)">⚡</span>自動核准</div>
+          <div class="body">kind: <b>db.update</b></div>
+        </div>
+        <div class="term" style="left:600px;top:196px">結束</div>
+        <div class="elabel yes" style="left:372px;top:150px">是</div>
+        <div class="elabel no" style="left:372px;top:300px">否</div>
+      </div>
+      <div class="inspect">
+        <div class="h">INSPECTOR · 表單節點</div>
+        <div class="field"><label>節點名稱</label><div class="ctrl">請假申請</div></div>
+        <div class="field"><label>表單(form-builder)</label><div class="ctrl sel" style="color:var(--form)">FormConfig: 2 欄位 ▾</div></div>
+        <div class="field"><label>階段</label><div class="ctrl">① 申請</div></div>
+        <div class="field"><label>輸出 → context</label><div class="ctrl">leave.request</div></div>
+      </div>
+    </div>
+  </div>
+
+  <!-- ============ DIRECTION C ============ -->
+  <div class="dir">
+    <div class="dir-head">
+      <span class="tag">方向 C</span><h2>混合:主軸線性 + 分支展開</h2>
+      <p>主流程是一條由上而下的脊椎,只有遇到條件時才向左右展開。一開始最簡單好讀,分支多時仍可成圖。</p>
+    </div>
+    <div class="editor">
+      <div class="palette">
+        <div class="h">節點</div>
+        <div class="pitem"><span class="dot" style="background:var(--form)"></span>表單 Form</div>
+        <div class="pitem"><span class="dot" style="background:var(--cond)"></span>條件 Condition</div>
+        <div class="pitem"><span class="dot" style="background:var(--act)"></span>動作 Action</div>
+        <div class="pitem"><span class="dot" style="background:var(--term)"></span>結束 End</div>
+      </div>
+      <div class="canvas" style="height:430px">
+        <svg class="edges" viewBox="0 0 760 430" preserveAspectRatio="none">
+          <path d="M380,52 L380,74"/>
+          <path d="M380,150 L380,172"/>
+          <path class="y" d="M340,210 C250,212 210,250 210,270"/>
+          <path class="n" d="M420,210 C540,212 560,250 560,270"/>
+          <path d="M210,330 C210,360 360,360 380,360"/>
+          <path d="M560,330 C560,360 400,360 384,360"/>
+        </svg>
+        <div class="term start" style="left:343px;top:30px">開始</div>
+        <div class="node form" style="left:293px;top:74px;width:174px">
+          <div class="top"><span class="ico" style="background:var(--form)">▤</span>請假申請</div>
+          <div class="body"><div class="tinput">起訖日期</div> <div class="tinput">事由</div><div class="mini m"></div></div>
+        </div>
+        <div class="node cond" style="left:305px;top:172px">
+          <div class="top"><span class="ico" style="background:var(--cond)">◆</span>天數 &gt; 3?</div>
+          <div class="body"><span class="pill">days &gt; 3</span></div>
+        </div>
+        <div class="node act" style="left:123px;top:270px">
+          <div class="top"><span class="ico" style="background:var(--act)">⚡</span>通知主管</div>
+          <div class="body">kind: <b>notify</b></div>
+        </div>
+        <div class="node act" style="left:473px;top:270px">
+          <div class="top"><span class="ico" style="background:var(--act)">⚡</span>自動核准</div>
+          <div class="body">kind: <b>db.update</b></div>
+        </div>
+        <div class="term" style="left:343px;top:344px">結束</div>
+        <div class="elabel yes" style="left:250px;top:232px">是</div>
+        <div class="elabel no" style="left:486px;top:232px">否</div>
+        <div class="hint">分支只在條件節點展開,其餘步驟維持單一直線</div>
+      </div>
+      <div class="inspect">
+        <div class="h">INSPECTOR · 動作節點</div>
+        <div class="field"><label>節點名稱</label><div class="ctrl">通知主管</div></div>
+        <div class="field"><label>Action kind</label><div class="ctrl sel" style="color:var(--act)">notify ▾</div></div>
+        <div class="field"><label>params</label><div class="ctrl">to: {{leave.managerId}}</div></div>
+        <div class="field"><label>輸入來自 context</label><div class="ctrl">leave.request</div></div>
+      </div>
+    </div>
+  </div>
+
+</div>
+</body>
+</html>

--- a/docs/superpowers/specs/2026-06-30-rfjs-flow-design.md
+++ b/docs/superpowers/specs/2026-06-30-rfjs-flow-design.md
@@ -1,0 +1,127 @@
+# @rfjs/flow — 視覺流程建構器 設計方向(design doc)
+
+- 日期:2026-06-30
+- 狀態:**設計方向已定,尚未進入實作 spec。** 這是 north star / 架構決策紀錄;真正要做 v1 時,再由此走 brainstorming → spec → plan → 實作(像 `@rfjs/bpmn` 那樣)。
+- 相關:`@rfjs/bpmn`(已上線,唯讀 BPMN 檢視器,與本案**正交**)、`@rfjs/form-builder`、`@rfjs/filter-builder`、`@rfjs/data-filter`、`@rfjs/data-transform`。
+- 對應 memory:`rfjs-flow-canvas-direction`。
+
+> ⚠️ 本文不含任何要立即實作的程式。所有 schema / 介面皆為**草案**,供討論定稿。
+
+## 1. 目標
+
+讓**產品的終端使用者**在我們的 App 裡,用 no-code 視覺畫布**建立流程**,流程以**我們自有的 JSON** 表示,節點直接內嵌我們既有的工具(form-builder 的表單、filter-builder 的條件)。
+
+### 1.1 為什麼自己做(build-vs-buy)
+
+評估過直接用 **n8n / Windmill / Temporal**。結論:
+
+- **內部自動化(ops/開發者在用)→ 直接用 n8n,不要自己做**(它的畫布、Merge=join、item 模型、IF/Switch、AI 節點、Wait/webhook 近似簽核、可自架 —— 都成熟)。
+- **本案是「產品內、給終端使用者、深度綁我們的 form/filter/資料/品牌/多租戶」→ 自己做才對**:n8n 嵌入產品困難、fair-code 授權限制「把它當成你販售產品的一部分」、其 Form 陽春、UX 是給開發者非終端使用者。
+
+決策(2026-06-30,使用者確認「**產品的終端使用者**」):**自己做 native slice。** 但**重的 server 執行不自己蓋**,可借引擎(見 §6 runtime registry,甚至「export 到 n8n/Temporal」當一個 target)。
+
+## 2. 核心架構:一張 canonical graph → 可插拔 runtime registry
+
+借用 repo 既有的 **filter-builder 哲學**(一棵 canonical tree → 多個 compile/execute 目標),往上提一層:
+
+```
+一張 canonical flow graph(鎖 schema)
+        │  編輯:React Flow 畫布 + 節點 kind(內嵌 form/filter)
+        ▼  執行:可插拔 runtime registry(像 getEngine)
+   ┌───────────────┬───────────────┬────────────────┐
+   navigation       workflow         durable          (export)
+   client 狀態機     server 跑 DAG     可暫停/待辦       → n8n/Temporal
+   = 頁面流程/wizard  = data/AI flow    = 人員簽核
+```
+
+**關鍵領悟:畫布是「通用圖編輯器」,各種用途是「同一張圖的不同 runtime」**,不是各做一套引擎。
+
+## 3. 一個模型,長出四種用途
+
+| 用途 | 加哪種 node kind | runtime |
+| --- | --- | --- |
+| 純 data flow(含 join/select/merge) | `data-op`(委派給 data-ops 引擎) | workflow(server) |
+| AI 情景 | `ai.generate` / `agent` / `tool` | workflow(server) |
+| 人員簽核 + 申請 | `human-task`(form)+ `condition` + 上述混用 | durable(server,可暫停) |
+| **no-code 頁面流程 / wizard** | `page`/`screen`(內嵌 form-builder 頁) | **navigation(client)** |
+
+全部重用 form-builder / filter-builder / context,差別只在 node kind 與 runtime。
+
+## 4. 套件邊界
+
+**不按用途拆 flow 套件**(page/approval/data 是 runtime + node kind,屬同一個 `@rfjs/flow`)。**重的資料運算拆成獨立 engine 套件給 flow 消費** —— 沿用既有 edit↔execute 分層:
+
+```
+@rfjs/flow            畫布 + canonical graph schema + node kinds + runtime registry(編排)
+  └─ data-op 節點  ──委派──▶  @rfjs/<data-ops>   join/select/merge/aggregate 引擎(執行)
+                              (與 data-filter / data-transform 同一家族)
+(可選)@rfjs/flow-ui    若畫布要被多 app 共用,再抽 React Flow wrapper;否則先內含
+```
+
+- `@rfjs/flow` 只負責編排;join/select 這種關聯運算另立 engine,`data-op` 節點委派(就像 filter-builder→data-filter/pg-filter)。
+- **不要因為「資料運算很重」就讓 flow 套件膨脹。**
+
+## 5. flow JSON schema(草案)
+
+完全自有、用 zod 定。重點是**現在就保留兩個維度**,免得 data-flow 之後逼著改格式:
+
+```jsonc
+{
+  "version": 1,
+  "nodes": [
+    { "id": "n1", "type": "page",      "position": {"x":0,"y":0}, "config": { /* FormConfig 原樣內嵌 */ } },
+    { "id": "n2", "type": "condition", "position": {"x":0,"y":0}, "config": { /* filter tree 原樣內嵌 */ } },
+    { "id": "n3", "type": "data-op",   "position": {"x":0,"y":0}, "config": { "op": "join", /* 委派 data-ops */ } },
+    { "id": "n4", "type": "action",    "position": {"x":0,"y":0}, "config": { "kind": "notify", "params": {} } }
+  ],
+  "edges": [
+    { "id": "e1", "source": "n1", "target": "n2", "trigger": "onSubmit" },
+    { "id": "e2", "source": "n2", "target": "n3", "sourceHandle": "yes", "condition": { /* optional */ } }
+  ]
+}
+```
+
+**兩個刻意保留(便宜、避免日後重寫):**
+1. **節點可多輸入**(join ≥2 input handle)。
+2. **節點輸出可為集合/多筆**(非只 scalar)。
+
+**約定:** `node.config` 直接內嵌既有工具的 JSON(FormConfig / filter tree),**不發明新子格式**。`edge.trigger` 服務 navigation(`onSubmit`/`onClick(btnId)`),`edge.condition` 服務分支;不同 runtime 各取所需。
+
+## 6. context 模型 + runtime registry
+
+- **context = 各節點輸出的 map(`{ nodeId → output }`)**,而非單一合併 blob。如此 `data-op`/`join` 可讀多個前置輸出(n8n 式引用),不需一開始就上「型別埠」。型別埠(每條線帶 schema)留作未來強化,**v1 不做**。
+- **runtime registry(像 `getEngine`)**:每個 runtime 拿同一張 graph 去執行。
+  - `navigation`(client 狀態機):渲染目前 page、等使用者事件 → 依 trigger/condition 跳下一個 node;context = wizard 累積資料。**v1。**
+  - `workflow`(server):把 DAG 跑完,action/ai/data-op 節點各自執行。
+  - `durable`(server):同 workflow 但可在 `human-task` 暫停、持久化 run 狀態、待辦收件匣、resume、逾時/升級。
+  - `export`(可選):把 graph 編譯/匯出給 n8n / Temporal 執行。
+
+## 7. 視覺方向
+
+採 **方向 A:經典節點圖(React Flow `@xyflow/react`,MIT)**,**預設由左到右 auto-layout(dagre/elk)+「整理」按鈕**(借泳道的可讀性,但底層仍是自由圖)。否決方向 B(泳道,當主編輯器太硬)、方向 C(混合脊椎,為 UX 甜頭多寫兩套佈局)。
+mockup:`docs/mockups/2026-06-30-flow-canvas-directions.html`(三方向對照,含 palette/canvas/inspector 與節點內嵌縮影)。
+
+## 8. 路線圖(按 runtime 分階,各由真實場景驅動)
+
+1. **v1 — navigation / wizard(client)**:畫布 + `page`/`condition` 節點 + client 狀態機 + context 累積。**不碰 server 引擎、不碰持久化**,最大重用 form/filter,風險最低,可先當「給使用者的 no-code 多步驟表單/流程」功能出貨。
+2. **v2 — workflow(server,data + AI)**:`action`/`ai`/`data-op` 節點;`@rfjs/<data-ops>` 引擎做 join/select。可考慮借引擎執行。
+3. **v3 — durable(人員簽核)**:可暫停/待辦/resume 的 durable workflow(這是最重的 80%,等簽核場景明確再做,或評估 Temporal)。
+
+## 9. 非目標(YAGNI / 明確不做)
+
+- v1 **不做** server durable 引擎、不做持久化、不做人工待辦。
+- **不**採 n8n 作為「產品內、給終端使用者」的編輯器(評估後不合);但內部 ops 自動化仍可另用 n8n,與本案無關。
+- **不**發明新的 form/filter 子格式(一律內嵌既有 JSON)。
+- v1 **不做**型別化每條邊的資料埠(先用 context map);不做迴圈/平行(分支足矣)。
+- **不**自己重造一套通用工作流引擎去跟 n8n/Temporal 競爭 server 執行 —— 需要時借。
+
+## 10. 未決 / 待真實場景定
+
+- **第一個要給使用者做的具體 flow 是什麼?**(intake 表單?onboarding?申請單?)—— v1 可先做通用 wizard,但有具體場景能更準。
+- collections/items 模型細節(節點處理單筆 vs 多筆;n8n 的 items 模型值得參考)。
+- `data-ops` 引擎的運算詞彙(join 類型、select/project、aggregate……)—— 等 data-flow 場景出現再定。
+- 多租戶 / 權限 / flow 版本(產品化才需要)。
+
+## 11. 慣例
+
+spec/plan 繁中;commit/PR 英文 conventional(結尾 `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`);worktree 內開發;HOLD PR 由人工合併。


### PR DESCRIPTION
Consolidates the @rfjs/flow design discussion into a north-star design doc (zh-TW) + a 3-direction canvas mockup. **Design only — no code, nothing to build yet.**

## Key decisions captured
- **Build-vs-buy:** build a native slice (end users build flows *in our product*, tied to our form-builder/filter-builder/branding) — n8n stays for internal ops only (embeds poorly + fair-code license restricts product embedding).
- **Architecture:** one canonical JSON flow graph → **pluggable runtime registry** (filter-builder's "one tree → many engines", one level up): `navigation` (client wizard) / `workflow` (server data+AI) / `durable` (human approval) / `export` (→ n8n/Temporal).
- **One model, 4 uses:** data flow / AI / human sign-off / no-code page-flow — differ only by node kind + runtime.
- **Package boundaries:** `@rfjs/flow` orchestrates; heavy data ops (join/select/merge) live in a separate engine package it consumes (edit↔execute, like filter-builder→data-filter).
- **Schema draft** reserves multi-input nodes + collection outputs up front; `node.config` embeds FormConfig / filter tree verbatim.
- **Roadmap:** v1 client wizard (no durable engine, max reuse) → v2 server data/AI → v3 durable approval.

## Files
- `docs/superpowers/specs/2026-06-30-rfjs-flow-design.md`
- `docs/mockups/2026-06-30-flow-canvas-directions.html`

HOLD — review at your leisure; actual v1 build would be a later brainstorm → spec → plan → subagent run (like @rfjs/bpmn).

🤖 Generated with [Claude Code](https://claude.com/claude-code)