### PR TITLE
fix(ui-packages): add use client directive to hook modules

### DIFF
--- a/.changeset/ui-hooks-use-client.md
+++ b/.changeset/ui-hooks-use-client.md
@@ -1,0 +1,6 @@
+---
+'@rfjs/filter-builder-ui': patch
+'@rfjs/form-builder-ui': patch
+---
+
+Add the missing `"use client"` directive to the React hook modules (`useFilterTree`, `useConfigBuilder`, `useContainerBreakpoint`, `useDataSource`, `useSignatureCapture`). Importing these through a package barrel from a React Server Component (e.g. workbench's dataset explorer page) failed the Turbopack production build.

--- a/packages/filter-builder-ui/src/use-filter-tree.ts
+++ b/packages/filter-builder-ui/src/use-filter-tree.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { useState } from "react";
 
 import { addInferredField, emptyGroup } from "@rfjs/filter-builder";

--- a/packages/form-builder-ui/src/use-config-builder.ts
+++ b/packages/form-builder-ui/src/use-config-builder.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import {
   addField,

--- a/packages/form-builder-ui/src/use-container-breakpoint.ts
+++ b/packages/form-builder-ui/src/use-container-breakpoint.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import * as React from "react";
 
 export function useContainerBreakpoint(

--- a/packages/form-builder-ui/src/use-data-source.ts
+++ b/packages/form-builder-ui/src/use-data-source.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import {
   loadDataSource,

--- a/packages/form-builder-ui/src/use-signature-capture.ts
+++ b/packages/form-builder-ui/src/use-signature-capture.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import type { SignatureTransport, SignatureCaptureHandle } from '@rfjs/form-builder';
 


### PR DESCRIPTION
Unblocks the release train — the versioning workflow on `release/stable` (triggered by #230) failed on `workbench#build`:

> `./packages/filter-builder-ui/src/use-filter-tree.ts` — importing `useState` into a React Server Component module (workbench's `datasets/explore/page.tsx` pulls it through the package barrel).

## Root cause + fix
`useFilterTree` (and, on audit, all four `form-builder-ui` hooks: `useConfigBuilder`, `useContainerBreakpoint`, `useDataSource`, `useSignatureCapture`) call React state APIs without the `"use client"` directive — every *component* in these packages has it, only the hooks were missed. This never surfaced before because **no CI job built workbench until the release workflow did**. One-line directive added to each of the 5 files.

## Verification
- `pnpm -F workbench build` ✓ Compiled successfully (the exact CI failure, now green)
- `pnpm -F web build` ✓
- `@rfjs/filter-builder-ui` 3 files / `@rfjs/form-builder-ui` 10 files — all tests pass

## Changeset
Included (patch for both packages — private, per repo policy every `packages/*` change carries one).

## After merging
Re-run the train: open a fresh `main → release/stable` PR so the versioning workflow retries with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)