### PR TITLE
feat(form-builder): configurable button items with action model

### DIFF
--- a/.changeset/form-action-model-engine.md
+++ b/.changeset/form-action-model-engine.md
@@ -1,0 +1,5 @@
+---
+"@rfjs/form-builder": minor
+---
+
+Add configurable button items: `ButtonItem` (`kind: 'button'`) with a `ButtonAction` union (`submit` / `reset` / `clear` / `custom` / `api`), plus optional top-level `FormConfig.id` and `FormConfig.meta` for the action payload envelope. `DataSourceRequest.method` now also accepts `PATCH`.

--- a/.changeset/form-action-model-ui.md
+++ b/.changeset/form-action-model-ui.md
@@ -1,0 +1,5 @@
+---
+"@rfjs/form-builder-ui": minor
+---
+
+ConfigForm renders configurable button items and emits a unified `{ data, meta: ActionMeta }` envelope for submit/custom/api actions (breaking: `onSubmit` now receives the envelope instead of bare values). New props: `onAction`, `metaProvider`.

--- a/apps/web/e2e/form-builder.e2e.ts
+++ b/apps/web/e2e/form-builder.e2e.ts
@@ -1,0 +1,10 @@
+import { test, expect } from "@playwright/test";
+
+const URL = "/en/tools/form-builder";
+
+test("preview: custom action button surfaces its payload in the submission panel", async ({ page }) => {
+  await page.goto(URL);
+  await page.getByRole("button", { name: "Preview", exact: true }).click();
+  await page.getByRole("button", { name: /save draft/i }).click();
+  await expect(page.getByText(/save-draft/).first()).toBeVisible({ timeout: 15_000 });
+});

--- a/apps/web/src/tools/form-builder/inspector/action.spec.tsx
+++ b/apps/web/src/tools/form-builder/inspector/action.spec.tsx
@@ -1,0 +1,51 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { Card } from "../model";
+import { ActionSection } from "./action";
+
+const btnCard = (over?: Partial<Card>): Card => ({
+  id: "b1", groupId: "g1", kind: "button", label: "Go",
+  action: { type: "custom", name: "save-draft" },
+  col: 1, span: 3, row: 1, ...over,
+});
+
+const fields = [{ key: "name", dataType: "string" }, { key: "amount", dataType: "numeric" }];
+
+describe("ActionSection", () => {
+  it("switching type to clear shows the field multi-select and writes a valid clear action", () => {
+    const onChange = vi.fn();
+    render(<ActionSection card={btnCard()} onChange={onChange} siblingFields={fields} />);
+    fireEvent.change(screen.getByLabelText(/action type/i), { target: { value: "clear" } });
+    expect(onChange).toHaveBeenCalledWith({ action: { type: "clear", fields: [] } });
+  });
+
+  it("clear: toggling a field key adds it to action.fields", () => {
+    const onChange = vi.fn();
+    render(<ActionSection card={btnCard({ action: { type: "clear", fields: [] } })} onChange={onChange} siblingFields={fields} />);
+    fireEvent.click(screen.getByLabelText("name"));
+    expect(onChange).toHaveBeenCalledWith({ action: { type: "clear", fields: ["name"] } });
+  });
+
+  it("custom: renders the name input", () => {
+    const onChange = vi.fn();
+    render(<ActionSection card={btnCard()} onChange={onChange} siblingFields={fields} />);
+    fireEvent.change(screen.getByLabelText(/event name/i), { target: { value: "notify" } });
+    expect(onChange).toHaveBeenCalledWith({ action: { type: "custom", name: "notify" } });
+  });
+
+  it("api: renders url/method and responseMap editor", () => {
+    const onChange = vi.fn();
+    render(<ActionSection card={btnCard({ action: { type: "api", url: "/x" } })} onChange={onChange} siblingFields={fields} />);
+    fireEvent.change(screen.getByLabelText(/url/i), { target: { value: "/api/y" } });
+    expect(onChange).toHaveBeenCalledWith({ action: { type: "api", url: "/api/y" } });
+    expect(screen.getByText(/response map/i)).toBeTruthy();
+  });
+
+  it("validate switch writes through", () => {
+    const onChange = vi.fn();
+    render(<ActionSection card={btnCard()} onChange={onChange} siblingFields={fields} />);
+    fireEvent.click(screen.getByLabelText(/validate before run/i));
+    expect(onChange).toHaveBeenCalledWith({ validate: true });
+  });
+});

--- a/apps/web/src/tools/form-builder/inspector/action.spec.tsx
+++ b/apps/web/src/tools/form-builder/inspector/action.spec.tsx
@@ -48,4 +48,12 @@ describe("ActionSection", () => {
     fireEvent.click(screen.getByLabelText(/validate before run/i));
     expect(onChange).toHaveBeenCalledWith({ validate: true });
   });
+
+  it("responseMap: clicking + mapping twice keeps both rows editable (no silent collapse on duplicate empty paths)", () => {
+    const onChange = vi.fn();
+    render(<ActionSection card={btnCard({ action: { type: "api", url: "/x" } })} onChange={onChange} siblingFields={fields} />);
+    fireEvent.click(screen.getByText("+ mapping"));
+    fireEvent.click(screen.getByText("+ mapping"));
+    expect(screen.getAllByLabelText(/response path/i)).toHaveLength(2);
+  });
 });

--- a/apps/web/src/tools/form-builder/inspector/action.tsx
+++ b/apps/web/src/tools/form-builder/inspector/action.tsx
@@ -92,7 +92,7 @@ export function ActionSection({
               );
             })}
           </fieldset>
-          <ResponseMapEditor action={action} patch={patch} siblingFields={siblingFields} />
+          <ResponseMapEditor key={card.id} action={action} patch={patch} siblingFields={siblingFields} />
           <label className="flex flex-col gap-1 text-xs text-muted-foreground">
             Success message
             <input className={INPUT_CLS} value={typeof action.messages?.success === "string" ? action.messages.success : ""} onChange={(e) => patch({ ...action, messages: { ...action.messages, success: e.target.value || undefined } })} />
@@ -126,30 +126,65 @@ export function ActionSection({
   );
 }
 
-/** responseMap 的 key-value 列表編輯(path → field key)。 */
+type ResponseMapRow = { id: number; path: string; target: string };
+
+/**
+ * responseMap 的 key-value 列表編輯(path → field key)。
+ *
+ * Rows are kept in local state with a stable synthetic `id` so duplicate/empty
+ * `path` values don't collapse into each other while typing (Object.fromEntries
+ * would silently drop earlier rows sharing a path). Only entries with a
+ * non-empty, de-duplicated path are serialized outward via `patch`; rows with
+ * empty or duplicate paths simply stay local (unsaved) until resolved.
+ */
 function ResponseMapEditor({
   action, patch, siblingFields,
 }: { action: Extract<ButtonAction, { type: "api" }>; patch: (a: ButtonAction) => void; siblingFields: { key: string; dataType: string }[] }) {
-  const entries = Object.entries(action.responseMap ?? {});
-  const write = (next: [string, string][]) =>
-    patch({ ...action, responseMap: next.length ? Object.fromEntries(next) : undefined });
+  const nextId = React.useRef(0);
+  const makeId = () => nextId.current++;
+  const [rows, setRows] = React.useState<ResponseMapRow[]>(() =>
+    Object.entries(action.responseMap ?? {}).map(([path, target]) => ({ id: makeId(), path, target })),
+  );
+
+  const commit = (next: ResponseMapRow[]) => {
+    setRows(next);
+    const seen = new Set<string>();
+    const entries: [string, string][] = [];
+    for (const { path, target } of next) {
+      if (!path || seen.has(path)) continue;
+      seen.add(path);
+      entries.push([path, target]);
+    }
+    patch({ ...action, responseMap: entries.length ? Object.fromEntries(entries) : undefined });
+  };
+
   return (
     <fieldset className="flex flex-col gap-1 text-xs text-muted-foreground">
       <legend>Response map (path → field)</legend>
-      {entries.map(([path, target], i) => (
-        <div key={i} className="flex items-center gap-1">
-          <input className={`${INPUT_CLS} min-w-0 flex-1 font-mono`} aria-label={`response path ${i}`} value={path} onChange={(e) => write(entries.map((en, j) => (j === i ? [e.target.value, en[1]] : en)) as [string, string][])} />
+      {rows.map((row, i) => (
+        <div key={row.id} className="flex items-center gap-1">
+          <input
+            className={`${INPUT_CLS} min-w-0 flex-1 font-mono`}
+            aria-label={`response path ${i}`}
+            value={row.path}
+            onChange={(e) => commit(rows.map((r) => (r.id === row.id ? { ...r, path: e.target.value } : r)))}
+          />
           <span>→</span>
-          <select className={`${INPUT_CLS} min-w-0 flex-1`} aria-label={`target field ${i}`} value={target} onChange={(e) => write(entries.map((en, j) => (j === i ? [en[0], e.target.value] : en)) as [string, string][])}>
+          <select
+            className={`${INPUT_CLS} min-w-0 flex-1`}
+            aria-label={`target field ${i}`}
+            value={row.target}
+            onChange={(e) => commit(rows.map((r) => (r.id === row.id ? { ...r, target: e.target.value } : r)))}
+          >
             {siblingFields.map((f) => <option key={f.key} value={f.key}>{f.key}</option>)}
           </select>
-          <button type="button" aria-label={`remove mapping ${i}`} className="text-muted-foreground hover:text-foreground" onClick={() => write(entries.filter((_, j) => j !== i) as [string, string][])}>×</button>
+          <button type="button" aria-label={`remove mapping ${i}`} className="text-muted-foreground hover:text-foreground" onClick={() => commit(rows.filter((r) => r.id !== row.id))}>×</button>
         </div>
       ))}
       <button
         type="button"
         className="self-start rounded-md border border-input px-2 py-1 hover:bg-accent"
-        onClick={() => write([...entries, ["", siblingFields[0]?.key ?? ""]] as [string, string][])}
+        onClick={() => commit([...rows, { id: makeId(), path: "", target: siblingFields[0]?.key ?? "" }])}
         disabled={siblingFields.length === 0}
       >
         + mapping

--- a/apps/web/src/tools/form-builder/inspector/action.tsx
+++ b/apps/web/src/tools/form-builder/inspector/action.tsx
@@ -1,0 +1,159 @@
+"use client";
+import * as React from "react";
+
+import type { ButtonAction } from "@rfjs/form-builder";
+import type { Card } from "../model";
+import { INPUT_CLS } from "./constants";
+
+const TYPES: ButtonAction["type"][] = ["submit", "reset", "clear", "custom", "api"];
+const METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE"] as const;
+
+/** 依 type 切換的預設 action 值(切換時舊參數不保留 —— 各型別參數互不相容)。 */
+function defaultAction(type: ButtonAction["type"]): ButtonAction {
+  switch (type) {
+    case "submit": return { type: "submit" };
+    case "reset": return { type: "reset" };
+    case "clear": return { type: "clear", fields: [] };
+    case "custom": return { type: "custom", name: "action-1" };
+    case "api": return { type: "api", url: "" };
+  }
+}
+
+export function ActionSection({
+  card, onChange, siblingFields = [],
+}: { card: Card; onChange: (p: Partial<Card>) => void; siblingFields?: { key: string; dataType: string }[] }) {
+  const action = card.action ?? { type: "custom" as const, name: "action-1" };
+  const patch = (a: ButtonAction) => onChange({ action: a });
+
+  return (
+    <div className="flex flex-col gap-2">
+      <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+        Action type
+        <select className={INPUT_CLS} value={action.type} onChange={(e) => patch(defaultAction(e.target.value as ButtonAction["type"]))}>
+          {TYPES.map((t) => <option key={t} value={t}>{t}</option>)}
+        </select>
+      </label>
+
+      {action.type === "clear" && (
+        <fieldset className="flex flex-col gap-1 text-xs text-muted-foreground">
+          <legend>Fields to clear</legend>
+          {siblingFields.map((f) => (
+            <label key={f.key} className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                aria-label={f.key}
+                checked={action.fields.includes(f.key)}
+                onChange={(e) =>
+                  patch({ type: "clear", fields: e.target.checked ? [...action.fields, f.key] : action.fields.filter((k) => k !== f.key) })
+                }
+              />
+              <span className="font-mono">{f.key}</span>
+            </label>
+          ))}
+        </fieldset>
+      )}
+
+      {action.type === "custom" && (
+        <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+          Event name
+          <input className={`${INPUT_CLS} font-mono`} value={action.name} onChange={(e) => patch({ type: "custom", name: e.target.value })} />
+        </label>
+      )}
+
+      {action.type === "api" && (
+        <>
+          <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+            URL
+            <input className={`${INPUT_CLS} font-mono`} value={action.url} onChange={(e) => patch({ ...action, url: e.target.value })} />
+          </label>
+          <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+            Method
+            <select className={INPUT_CLS} value={action.method ?? "POST"} onChange={(e) => patch({ ...action, method: e.target.value as (typeof METHODS)[number] })}>
+              {METHODS.map((m) => <option key={m} value={m}>{m}</option>)}
+            </select>
+          </label>
+          <fieldset className="flex flex-col gap-1 text-xs text-muted-foreground">
+            <legend>Send fields (empty = all visible)</legend>
+            {siblingFields.map((f) => {
+              const sel = action.fields ?? [];
+              return (
+                <label key={f.key} className="flex items-center gap-2">
+                  <input
+                    type="checkbox"
+                    aria-label={`send ${f.key}`}
+                    checked={sel.includes(f.key)}
+                    onChange={(e) => {
+                      const next = e.target.checked ? [...sel, f.key] : sel.filter((k) => k !== f.key);
+                      patch({ ...action, fields: next.length ? next : undefined });
+                    }}
+                  />
+                  <span className="font-mono">{f.key}</span>
+                </label>
+              );
+            })}
+          </fieldset>
+          <ResponseMapEditor action={action} patch={patch} siblingFields={siblingFields} />
+          <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+            Success message
+            <input className={INPUT_CLS} value={typeof action.messages?.success === "string" ? action.messages.success : ""} onChange={(e) => patch({ ...action, messages: { ...action.messages, success: e.target.value || undefined } })} />
+          </label>
+          <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+            Error message
+            <input className={INPUT_CLS} value={typeof action.messages?.error === "string" ? action.messages.error : ""} onChange={(e) => patch({ ...action, messages: { ...action.messages, error: e.target.value || undefined } })} />
+          </label>
+        </>
+      )}
+
+      {(action.type === "submit" || action.type === "custom" || action.type === "api") && (
+        <label className="flex items-center gap-2 text-xs text-muted-foreground">
+          <input
+            type="checkbox"
+            aria-label="Validate before run"
+            checked={card.validate ?? action.type === "submit"}
+            onChange={(e) => onChange({ validate: e.target.checked })}
+          />
+          Validate before run
+        </label>
+      )}
+
+      <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+        Variant
+        <select className={INPUT_CLS} value={card.buttonVariant ?? (action.type === "submit" ? "primary" : "outline")} onChange={(e) => onChange({ buttonVariant: e.target.value as Card["buttonVariant"] })}>
+          {(["primary", "outline", "ghost", "destructive"] as const).map((v) => <option key={v} value={v}>{v}</option>)}
+        </select>
+      </label>
+    </div>
+  );
+}
+
+/** responseMap 的 key-value 列表編輯(path → field key)。 */
+function ResponseMapEditor({
+  action, patch, siblingFields,
+}: { action: Extract<ButtonAction, { type: "api" }>; patch: (a: ButtonAction) => void; siblingFields: { key: string; dataType: string }[] }) {
+  const entries = Object.entries(action.responseMap ?? {});
+  const write = (next: [string, string][]) =>
+    patch({ ...action, responseMap: next.length ? Object.fromEntries(next) : undefined });
+  return (
+    <fieldset className="flex flex-col gap-1 text-xs text-muted-foreground">
+      <legend>Response map (path → field)</legend>
+      {entries.map(([path, target], i) => (
+        <div key={i} className="flex items-center gap-1">
+          <input className={`${INPUT_CLS} min-w-0 flex-1 font-mono`} aria-label={`response path ${i}`} value={path} onChange={(e) => write(entries.map((en, j) => (j === i ? [e.target.value, en[1]] : en)) as [string, string][])} />
+          <span>→</span>
+          <select className={`${INPUT_CLS} min-w-0 flex-1`} aria-label={`target field ${i}`} value={target} onChange={(e) => write(entries.map((en, j) => (j === i ? [en[0], e.target.value] : en)) as [string, string][])}>
+            {siblingFields.map((f) => <option key={f.key} value={f.key}>{f.key}</option>)}
+          </select>
+          <button type="button" aria-label={`remove mapping ${i}`} className="text-muted-foreground hover:text-foreground" onClick={() => write(entries.filter((_, j) => j !== i) as [string, string][])}>×</button>
+        </div>
+      ))}
+      <button
+        type="button"
+        className="self-start rounded-md border border-input px-2 py-1 hover:bg-accent"
+        onClick={() => write([...entries, ["", siblingFields[0]?.key ?? ""]] as [string, string][])}
+        disabled={siblingFields.length === 0}
+      >
+        + mapping
+      </button>
+    </fieldset>
+  );
+}

--- a/apps/web/src/tools/form-builder/inspector/settings-panel.tsx
+++ b/apps/web/src/tools/form-builder/inspector/settings-panel.tsx
@@ -2,6 +2,7 @@
 import * as React from "react";
 import { Trash2 } from "lucide-react";
 import { Section } from "./section";
+import { ActionSection } from "./action";
 import { OptionsSection } from "./options";
 import { ValidationSection } from "./validation";
 import { AiNoteSection, ContentSection, SpacerSection } from "./misc-sections";
@@ -40,6 +41,7 @@ export function SettingsPanel({
     );
   }
   const isField = card.kind === "field";
+  const isButton = card.kind === "button";
   const comp = card.component;
   return (
     <div className="flex flex-col gap-3">
@@ -95,6 +97,12 @@ export function SettingsPanel({
       </Section>
 
       {/* Common config: expanded by default. Advanced: collapsed with a "has content" badge. */}
+      {isButton ? (
+        <Section title="Action">
+          <ActionSection card={card} onChange={onChange} siblingFields={siblingFields} />
+        </Section>
+      ) : null}
+
       {isField ? (
         <Section title="Validation" badge={card.validation && Object.keys(card.validation).length ? <Count n={Object.keys(card.validation).length} /> : undefined}>
           <ValidationSection card={card} onChange={onChange} />

--- a/apps/web/src/tools/form-builder/model.spec.ts
+++ b/apps/web/src/tools/form-builder/model.spec.ts
@@ -154,3 +154,26 @@ describe("FileUpload / Signature round-trip", () => {
     expect((items[1] as { component?: string }).component).toBe("Signature");
   });
 });
+
+describe("button cards", () => {
+  it("round-trips a button card through FormConfig", () => {
+    const groups = [{ id: "g1", title: "G", collapsed: false }];
+    const cards = [{
+      id: "b1", groupId: "g1", kind: "button" as const, label: "Save draft",
+      action: { type: "custom" as const, name: "save-draft" }, buttonVariant: "outline" as const, validate: true,
+      col: 1, span: 3, row: 1,
+    }];
+    const config = cardsToFormConfig(groups, cards);
+    const item = config.sections![0]!.rows[0]!.items[0]!;
+    expect(item).toMatchObject({ kind: "button", label: "Save draft", action: { type: "custom", name: "save-draft" }, variant: "outline", validate: true });
+    const back = formConfigToCards(config);
+    expect(back.cards[0]).toMatchObject({ kind: "button", action: { type: "custom", name: "save-draft" }, buttonVariant: "outline", validate: true });
+  });
+
+  it("button card without explicit action defaults to custom", () => {
+    const groups = [{ id: "g1", title: "G", collapsed: false }];
+    const cards = [{ id: "b1", groupId: "g1", kind: "button" as const, label: "Button", col: 1, span: 3, row: 1 }];
+    const item = cardsToFormConfig(groups, cards).sections![0]!.rows[0]!.items[0]!;
+    expect(item).toMatchObject({ kind: "button", action: { type: "custom", name: "action-1" } });
+  });
+});

--- a/apps/web/src/tools/form-builder/model.ts
+++ b/apps/web/src/tools/form-builder/model.ts
@@ -3,9 +3,10 @@ import {
   type FieldComponent, type FieldType,
   type FormConfig, type FormItem, type FormSection,
   type LocalizedLabel, type FieldOption, type FieldValidation, type ConditionalRule, type DataSource,
+  type ButtonAction,
 } from "@rfjs/form-builder";
 
-export type Kind = "field" | "content" | "divider" | "spacer" | "ai-note";
+export type Kind = "field" | "content" | "divider" | "spacer" | "ai-note" | "button";
 // Canvas Component = full engine FieldComponent union.
 export type Component = FieldComponent;
 
@@ -31,6 +32,9 @@ export interface Card {
   fileUpload?: { accept?: string; multiple?: boolean; maxSize?: number };
   locked?: boolean; // content
   size?: "sm" | "md" | "lg"; // spacer
+  action?: ButtonAction; // button
+  buttonVariant?: "primary" | "outline" | "ghost" | "destructive"; // button
+  validate?: boolean; // button
   col: number;
   span: number;
   row: number;
@@ -99,6 +103,13 @@ function cardToItem(c: Card): FormItem {
       return { id: c.id, kind: "divider" };
     case "spacer":
       return { id: c.id, kind: "spacer", ...(c.size ? { size: c.size } : {}) };
+    case "button":
+      return {
+        id: c.id, kind: "button", label: c.label,
+        action: c.action ?? { type: "custom", name: "action-1" },
+        ...(c.buttonVariant ? { variant: c.buttonVariant } : {}),
+        ...(c.validate !== undefined ? { validate: c.validate } : {}),
+      };
   }
 }
 
@@ -147,6 +158,8 @@ export function formConfigToCards(config: FormConfig): { groups: Group[]; cards:
         });
       } else if (item.kind === "content") {
         cards.push({ ...base, kind: "content", label: item.text, locked: item.locked });
+      } else if (item.kind === "button") {
+        cards.push({ ...base, kind: "button", label: item.label, action: item.action, buttonVariant: item.variant, validate: item.validate });
       } else if (item.kind === "ai-note") {
         cards.push({ ...base, kind: "ai-note", label: item.text });
       } else {

--- a/apps/web/src/tools/form-builder/sample.ts
+++ b/apps/web/src/tools/form-builder/sample.ts
@@ -165,6 +165,14 @@ export const SAMPLE_CONFIG: FormConfig = {
           ],
         },
         { id: "r_div", items: [{ id: "i_div", kind: "divider" }] },
+        {
+          id: "r_actions",
+          items: [
+            { id: "btn_submit", kind: "button", label: { en: "Submit request", "zh-TW": "送出申請" }, action: { type: "submit" }, variant: "primary" },
+            { id: "btn_draft", kind: "button", label: { en: "Save draft", "zh-TW": "存草稿" }, action: { type: "custom", name: "save-draft" } },
+            { id: "btn_clear", kind: "button", label: { en: "Clear", "zh-TW": "清除" }, action: { type: "clear", fields: ["name", "email"] }, variant: "ghost" },
+          ],
+        },
       ],
     },
   ],

--- a/apps/web/src/tools/form-builder/submission-panel.spec.tsx
+++ b/apps/web/src/tools/form-builder/submission-panel.spec.tsx
@@ -83,4 +83,18 @@ describe("SubmissionPanel", () => {
     // Friendly error message shown
     expect(screen.getByText(/Invalid email format/)).toBeDefined();
   });
+
+  it('shows the firing action and apiError when present', () => {
+    render(
+      <SubmissionPanel
+        payload={{
+          data: { a: 1 },
+          meta: { valid: true, errors: {}, visibleKeys: ['a'], schemaVersion: 1, timestamp: 't', action: { type: 'custom', name: 'save-draft' }, apiError: 'boom' },
+        }}
+      />,
+    );
+    expect(screen.getByText(/custom/)).toBeTruthy();
+    expect(screen.getByText(/save-draft/)).toBeTruthy();
+    expect(screen.getByText(/boom/)).toBeTruthy();
+  });
 });

--- a/apps/web/src/tools/form-builder/submission-panel.tsx
+++ b/apps/web/src/tools/form-builder/submission-panel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import type { SubmissionMeta } from "@rfjs/form-builder-ui";
+import type { ActionMeta, SubmissionMeta } from "@rfjs/form-builder-ui";
 import { cn } from "@rfjs/web-ui/lib/utils";
 
 // ---------------------------------------------------------------------------
@@ -10,7 +10,7 @@ import { cn } from "@rfjs/web-ui/lib/utils";
 // ---------------------------------------------------------------------------
 
 export interface SubmissionPanelProps {
-  payload: { data: Record<string, unknown>; meta: SubmissionMeta } | null;
+  payload: { data: Record<string, unknown>; meta: SubmissionMeta | ActionMeta } | null;
   compact?: boolean;
 }
 
@@ -86,6 +86,20 @@ export function SubmissionPanel({ payload, compact = false }: SubmissionPanelPro
             </span>
           )}
         </div>
+
+        {/* Action / apiError — present only on ActionMeta (onSubmit/onAction payloads) */}
+        {'action' in meta && meta.action != null && (
+          <div className="mb-3 space-y-1">
+            <p className="text-xs font-medium text-muted-foreground">Action:</p>
+            <p className="font-mono text-xs text-foreground">
+              {(meta as ActionMeta).action.type}
+              {(meta as ActionMeta).action.name ? ` — ${(meta as ActionMeta).action.name}` : ''}
+            </p>
+          </div>
+        )}
+        {'apiError' in meta && (meta as ActionMeta).apiError && (
+          <p className="mb-3 text-xs text-red-600 dark:text-red-400">API error: {(meta as ActionMeta).apiError}</p>
+        )}
 
         {/* Errors List — only shown when NOT in the calm Incomplete state */}
         {!showIncomplete && errorCount > 0 && (

--- a/apps/web/src/tools/form-builder/ui.spec.tsx
+++ b/apps/web/src/tools/form-builder/ui.spec.tsx
@@ -23,8 +23,30 @@ if (typeof window !== 'undefined' && !window.ResizeObserver) {
 
 import { describe, it, expect } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
-import { FormBuilderTool } from "./ui";
+import { FormBuilderTool, createPreviewFetcher } from "./ui";
 import { resolveCards, collides, type PlacedCard } from "./layout-grid";
+
+describe("createPreviewFetcher", () => {
+  it("echoes an api-action request (body shaped { data, meta }) instead of delegating to sampleFetcher", async () => {
+    const body = { data: { name: "Ada" }, meta: { name: "save-draft" } };
+    const result = await createPreviewFetcher({ url: "/api/actions/save-draft", body });
+    expect(typeof (result as { echoedAt: string }).echoedAt).toBe("string");
+    expect((result as { received: unknown }).received).toEqual(body);
+    // Not sampleFetcher's canned dataSource shape (an array under `data`).
+    expect(Array.isArray((result as { data?: unknown }).data)).toBe(false);
+  });
+
+  it("delegates a dataSource request (no data/meta body) to sampleFetcher's canned response", async () => {
+    const result = await createPreviewFetcher({ url: "/api/countries" });
+    expect(result).toEqual({
+      data: [
+        { code: "tw", name: "Taiwan" },
+        { code: "jp", name: "Japan" },
+        { code: "us", name: "United States" },
+      ],
+    });
+  });
+});
 
 describe("FormBuilderTool preview", () => {
   it("Preview tab renders the real ConfigForm with a labelled control", () => {

--- a/apps/web/src/tools/form-builder/ui.spec.tsx
+++ b/apps/web/src/tools/form-builder/ui.spec.tsx
@@ -22,7 +22,7 @@ if (typeof window !== 'undefined' && !window.ResizeObserver) {
 }
 
 import { describe, it, expect } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { FormBuilderTool } from "./ui";
 import { resolveCards, collides, type PlacedCard } from "./layout-grid";
 
@@ -128,6 +128,15 @@ describe("FormBuilderTool preview tab integration", () => {
     expect(screen.getByRole("button", { name: /submission/i })).toBeTruthy();
     // Section is collapsed by default: the inner panel content (Metadata heading) is NOT in the DOM
     expect(screen.queryByText(/^metadata$/i)).toBeNull();
+  });
+
+  it("preview: clicking a custom button surfaces the action in the submission panel", async () => {
+    render(<FormBuilderTool />);
+    // Anchored (as the rest of this file does) — an unanchored /preview/i also matches
+    // the Canvas tab's "Live Preview" section toggle button.
+    fireEvent.click(screen.getByRole("button", { name: /^preview$/i }));
+    fireEvent.click(await screen.findByRole("button", { name: /save draft/i }));
+    await waitFor(() => expect(screen.getAllByText(/save-draft/).length).toBeGreaterThan(0));
   });
 });
 

--- a/apps/web/src/tools/form-builder/ui.tsx
+++ b/apps/web/src/tools/form-builder/ui.tsx
@@ -20,6 +20,7 @@ import {
   Mail,
   Upload,
   PenLine,
+  MousePointerClick,
 } from "lucide-react";
 
 import { ConfigForm } from "@rfjs/form-builder-ui";
@@ -55,6 +56,7 @@ const KIND_META: Record<
   "ai-note": { color: "#d9a441", icon: Sparkles, label: "AI Note" },
   divider: { color: "#6b7280", icon: Minus, label: "Divider" },
   spacer: { color: "#6b7280", icon: MoveVertical, label: "Spacer" },
+  button: { color: "#10b981", icon: MousePointerClick, label: "Button" },
 };
 
 const fieldSub = (c: Card) => (c.kind === "field" ? `${c.key ?? "field"} · ${c.component ?? "Input"}` : undefined);
@@ -336,7 +338,7 @@ export function FormBuilderTool() {
     return () => window.removeEventListener("keydown", onKey);
   }, [selected]);
 
-  const PALETTE: Kind[] = ["field", "content", "divider", "spacer", "ai-note"];
+  const PALETTE: Kind[] = ["field", "content", "divider", "spacer", "ai-note", "button"];
   const TABS = [
     { id: "canvas", label: "Canvas" },
     { id: "preview", label: "Preview" },

--- a/apps/web/src/tools/form-builder/ui.tsx
+++ b/apps/web/src/tools/form-builder/ui.tsx
@@ -24,10 +24,10 @@ import {
 } from "lucide-react";
 
 import { ConfigForm } from "@rfjs/form-builder-ui";
-import type { SubmissionMeta } from "@rfjs/form-builder-ui";
+import type { ActionMeta, SubmissionMeta } from "@rfjs/form-builder-ui";
 import type { Card, Group, Kind, Component } from "./model";
 import { cardsToFormConfig, jsonToCards, cardLabel, componentDataType, formConfigToCards } from "./model";
-import { SAMPLE_CONFIG, sampleFetcher, sampleUploader } from "./sample";
+import { SAMPLE_CONFIG, sampleUploader } from "./sample";
 import { resolveCards, moveItem } from "./layout-grid";
 import { SettingsPanel } from "./inspector/settings-panel";
 import { Section } from "./inspector/section";
@@ -63,11 +63,14 @@ const fieldSub = (c: Card) => (c.kind === "field" ? `${c.key ?? "field"} · ${c.
 
 // Seed the canvas from SAMPLE_CONFIG and lay it out in COLUMNS:
 // short fields pack two-per-row; long/structural items
-// (textarea, content, ai-note, divider, spacer) take the full row.
+// (textarea, content, ai-note, divider, spacer) take the full row; buttons
+// pack narrow (three comfortably fit a row) so a row of action buttons
+// doesn't force one-per-row.
 const SEED = formConfigToCards(SAMPLE_CONFIG);
 const SEED_GROUPS: Group[] = SEED.groups;
 
 const seedSpan = (c: Card): number => {
+  if (c.kind === "button") return COLS / 4; // buttons → up to four per row
   if (c.kind !== "field") return COLS; // content / ai-note / divider / spacer → full row
   if (c.component === "Textarea") return COLS; // textareas read better full-width
   return COLS / 2; // ordinary fields → two per row (the column advantage)
@@ -126,7 +129,11 @@ export function FormBuilderTool() {
   const [mobileConfigOpen, setMobileConfigOpen] = React.useState(false);
   const [tab, setTab] = React.useState<"canvas" | "preview" | "json">("canvas");
   const [jsonError, setJsonError] = React.useState<string | null>(null);
-  const [payload, setPayload] = React.useState<{ data: Record<string, unknown>; meta: SubmissionMeta } | null>(null);
+  const [payload, setPayload] = React.useState<{ data: Record<string, unknown>; meta: SubmissionMeta | ActionMeta } | null>(null);
+  // Tracks whether a submit/custom/api action has fired at least once, so the
+  // (collapsed-by-default) Preview tab "Submission" section auto-opens to reveal
+  // the action payload instead of leaving the user to find the toggle themselves.
+  const [actionSeen, setActionSeen] = React.useState(false);
   const [previewW, setPreviewW] = React.useState(1100);
   const [canvasW, setCanvasW] = React.useState(390);
   const [copied, setCopied] = React.useState(false);
@@ -145,6 +152,25 @@ export function FormBuilderTool() {
   // Memoize to keep a stable reference: onPayloadChange fires on config changes,
   // so an unstable formConfig would create an infinite re-render loop.
   const formConfig = React.useMemo(() => cardsToFormConfig(groups, cards), [groups, cards]);
+
+  // Preview-only echo fetcher: no network, just returns the request body back with a
+  // timestamp — lets an `api` button's `responseMap` be demoed without a real backend.
+  const echoFetcher = React.useCallback(
+    async (req: { url: string; body?: unknown }) => ({ echoedAt: new Date().toISOString(), received: req.body }),
+    [],
+  );
+  // Shared onSubmit/onAction handler for both Preview ConfigForm instances: writes the
+  // action's payload into the same `payload` state the SubmissionPanel(s) read (an action
+  // firing overwrites the live onPayloadChange value), and reveals the Preview tab's
+  // collapsed-by-default Submission section the first time an action fires.
+  const handleSubmit = (p: { data: Record<string, unknown>; meta: ActionMeta }) => {
+    setPayload(p);
+    setActionSeen(true);
+  };
+  const handleAction = (_name: string, p: { data: Record<string, unknown>; meta: ActionMeta; response?: unknown }) => {
+    setPayload({ data: p.data, meta: p.meta });
+    setActionSeen(true);
+  };
 
   // Apply a drag/resize patch to the dragged card, then resolve overlaps (push + compact up).
   const placeDragged = (id: string, p: Partial<Card>) =>
@@ -492,10 +518,11 @@ export function FormBuilderTool() {
                 <ConfigForm
                   config={formConfig}
                   locale="en"
-                  fetcher={sampleFetcher}
+                  fetcher={echoFetcher}
                   uploadHandler={sampleUploader}
                   onPayloadChange={setPayload}
-                  onSubmit={() => {}}
+                  onSubmit={handleSubmit}
+                  onAction={handleAction}
                 />
               </ResponsivePreview>
               <SubmissionPanel compact payload={payload} />
@@ -508,13 +535,14 @@ export function FormBuilderTool() {
             <ConfigForm
               config={formConfig}
               locale="en"
-              fetcher={sampleFetcher}
+              fetcher={echoFetcher}
               uploadHandler={sampleUploader}
               onPayloadChange={setPayload}
-              onSubmit={() => {}}
+              onSubmit={handleSubmit}
+              onAction={handleAction}
             />
           </ResponsivePreview>
-          <Section title="Submission" defaultOpen={false}>
+          <Section key={actionSeen ? "submission-open" : "submission-closed"} title="Submission" defaultOpen={actionSeen}>
             <SubmissionPanel payload={payload} />
           </Section>
         </div>

--- a/apps/web/src/tools/form-builder/ui.tsx
+++ b/apps/web/src/tools/form-builder/ui.tsx
@@ -27,7 +27,7 @@ import { ConfigForm } from "@rfjs/form-builder-ui";
 import type { ActionMeta, SubmissionMeta } from "@rfjs/form-builder-ui";
 import type { Card, Group, Kind, Component } from "./model";
 import { cardsToFormConfig, jsonToCards, cardLabel, componentDataType, formConfigToCards } from "./model";
-import { SAMPLE_CONFIG, sampleUploader } from "./sample";
+import { SAMPLE_CONFIG, sampleUploader, sampleFetcher } from "./sample";
 import { resolveCards, moveItem } from "./layout-grid";
 import { SettingsPanel } from "./inspector/settings-panel";
 import { Section } from "./inspector/section";
@@ -46,6 +46,23 @@ const ROW_H = 84;
 const GAP = 8;
 const DRAG_THRESHOLD = 4; // px the pointer must travel before a press becomes a drag (a click just selects)
 const clamp = (v: number, lo: number, hi: number) => Math.max(lo, Math.min(hi, v));
+
+// Merged preview fetcher: echoes api-action requests (body shaped { data, meta }),
+// otherwise delegates to sampleFetcher for dataSource requests (e.g. /api/countries).
+// Detects api-action by checking if req.body has both 'data' and 'meta' properties.
+export async function createPreviewFetcher(req: { url: string; body?: unknown }) {
+  if (
+    req.body &&
+    typeof req.body === "object" &&
+    "data" in req.body &&
+    "meta" in req.body
+  ) {
+    // api-action request: echo it back with a timestamp
+    return { echoedAt: new Date().toISOString(), received: req.body };
+  }
+  // dataSource request: delegate to sampleFetcher
+  return sampleFetcher(req);
+}
 
 const KIND_META: Record<
   Kind,
@@ -153,12 +170,8 @@ export function FormBuilderTool() {
   // so an unstable formConfig would create an infinite re-render loop.
   const formConfig = React.useMemo(() => cardsToFormConfig(groups, cards), [groups, cards]);
 
-  // Preview-only echo fetcher: no network, just returns the request body back with a
-  // timestamp — lets an `api` button's `responseMap` be demoed without a real backend.
-  const echoFetcher = React.useCallback(
-    async (req: { url: string; body?: unknown }) => ({ echoedAt: new Date().toISOString(), received: req.body }),
-    [],
-  );
+  // Memoized wrapper of createPreviewFetcher for stable reference across renders
+  const previewFetcher = React.useCallback(createPreviewFetcher, []);
   // Shared onSubmit/onAction handler for both Preview ConfigForm instances: writes the
   // action's payload into the same `payload` state the SubmissionPanel(s) read (an action
   // firing overwrites the live onPayloadChange value), and reveals the Preview tab's
@@ -518,7 +531,7 @@ export function FormBuilderTool() {
                 <ConfigForm
                   config={formConfig}
                   locale="en"
-                  fetcher={echoFetcher}
+                  fetcher={previewFetcher}
                   uploadHandler={sampleUploader}
                   onPayloadChange={setPayload}
                   onSubmit={handleSubmit}
@@ -535,7 +548,7 @@ export function FormBuilderTool() {
             <ConfigForm
               config={formConfig}
               locale="en"
-              fetcher={echoFetcher}
+              fetcher={previewFetcher}
               uploadHandler={sampleUploader}
               onPayloadChange={setPayload}
               onSubmit={handleSubmit}

--- a/docs/superpowers/plans/2026-07-07-form-action-model.md
+++ b/docs/superpowers/plans/2026-07-07-form-action-model.md
@@ -1,0 +1,1257 @@
+# form-builder 動作/按鈕模型 — 實作計畫
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** form-builder 新增可配置按鈕(item kind `button`,動作 submit/reset/clear/custom/api)+ 統一 `{ data, meta }` 信封 + builder 配置 UI。
+
+**Architecture:** engine(`@rfjs/form-builder`)只加型別與 zod schema;renderer(`@rfjs/form-builder-ui` ConfigForm)負責渲染按鈕與執行動作;工具(apps/web form-builder)加 palette 卡/inspector 面板/SubmissionPanel 顯示。規格見 `docs/superpowers/specs/2026-07-07-form-action-model-design.md`(**每個任務開工前先讀 spec 對應章節**)。
+
+**Tech Stack:** zod v4、react-hook-form + zodResolver、Next.js(apps/web)、vitest + testing-library、Playwright e2e(port 3002)。
+
+## Global Constraints
+
+- 工作目錄:worktree `/home/royfw/_/code/royfw/rfjs/.claude/worktrees/feat-form-actions`,分支 `feat-form-actions`。
+- Commit:英文 conventional commits,subject 全小寫開頭,結尾附 `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`。
+- **Changeset 規則**:`@rfjs/form-builder` **minor**(可發布,會上 npm)、`@rfjs/form-builder-ui` **minor**(private,version-only);apps/web 不寫。changeset 檔用手寫 markdown(`.changeset/<slug>.md`),不跑互動 CLI。
+- 測試指令:`pnpm -F @rfjs/form-builder vitest:run`、`pnpm -F @rfjs/form-builder-ui vitest:run`、`pnpm -F web vitest:run <path>`(worktree 根執行)。
+- **form-builder-ui 是 transpilePackages 原始碼直接消費** —— 改 engine 後 apps/web 的型別檢查要先 `pnpm build:packages`(engine 走 dist)。
+- 相容底線:FormConfig 無 button item 時,ConfigForm 行為與現在一致(尾端預設 Submit);既有測試除 onSubmit 信封簽名外不得因此變動語義。
+- Breaking(已裁決):`onSubmit` 簽名 `(values) => void` → `({ data, meta }) => void`;現有呼叫端都是 `onSubmit={() => {}}`(no-op,型別相容),不需連動修改。
+- inspector/palette 文案沿用既有慣例(硬編英文,與 settings-panel/KIND_META 一致);範例按鈕 label 用 LocalizedLabel(en + zh-TW)。
+- web-ui Button variants:`default | destructive | outline | secondary | ghost | link`;engine `variant: 'primary'` 對映 web-ui `'default'`。
+
+---
+
+### Task 1: Engine — ButtonItem/ButtonAction 型別 + zod schema + changeset
+
+**Files:**
+- Modify: `packages/form-builder/src/types.ts`(ItemKind:84、FormItem:103、FormConfig:125、DataSourceRequest:7)
+- Modify: `packages/form-builder/src/config-schema.ts`(formItemSchema:143、FormConfigSchema:170)
+- Modify: `packages/form-builder/src/config-schema.spec.ts`(追加)
+- Create: `.changeset/form-action-model-engine.md`
+
+**Interfaces:**
+- Produces(後續任務全依賴):
+  - `type ButtonActionType = 'submit' | 'reset' | 'clear' | 'custom' | 'api'`
+  - `type ButtonAction`(discriminated union on `type`,見下)
+  - `interface ButtonItem { id: string; kind: 'button'; label: LocalizedLabel; action: ButtonAction; variant?: 'primary'|'outline'|'ghost'|'destructive'; validate?: boolean }`
+  - `FormConfig` 新增 `id?: string`、`meta?: Record<string, unknown>`
+  - `DataSourceRequest.method` 聯集加 `'PATCH'`
+
+- [ ] **Step 1: 寫失敗測試** — `config-schema.spec.ts` 追加:
+
+```ts
+describe('button items', () => {
+  const base = { version: 1, sections: [{ id: 's1', rows: [{ id: 'r1', items: [] as unknown[] }] }] };
+  const withItem = (item: unknown) => ({ ...base, sections: [{ id: 's1', rows: [{ id: 'r1', items: [item] }] }] });
+
+  it('accepts each action variant', () => {
+    const actions = [
+      { type: 'submit' },
+      { type: 'reset' },
+      { type: 'clear', fields: ['a'] },
+      { type: 'custom', name: 'save-draft' },
+      { type: 'api', url: '/x', method: 'PATCH', fields: ['a'], responseMap: { 'r.total': 'total' }, messages: { success: 'ok', error: { en: 'no', 'zh-TW': '失敗' } } },
+    ];
+    for (const action of actions) {
+      const r = formConfigSchema.safeParse(withItem({ id: 'b1', kind: 'button', label: 'Go', action }));
+      expect(r.success, JSON.stringify(action)).toBe(true);
+    }
+  });
+
+  it('rejects invalid buttons: clear w/o fields, custom empty name, api w/o url, unknown type', () => {
+    const bad = [
+      { type: 'clear', fields: [] },
+      { type: 'custom', name: '' },
+      { type: 'api' },
+      { type: 'nope' },
+    ];
+    for (const action of bad) {
+      const r = formConfigSchema.safeParse(withItem({ id: 'b1', kind: 'button', label: 'Go', action }));
+      expect(r.success, JSON.stringify(action)).toBe(false);
+    }
+  });
+
+  it('accepts optional variant/validate and top-level id/meta', () => {
+    const cfg = {
+      ...withItem({ id: 'b1', kind: 'button', label: 'Go', action: { type: 'submit' }, variant: 'outline', validate: false }),
+      id: 'leave-form',
+      meta: { source: 'web' },
+    };
+    const r = formConfigSchema.safeParse(cfg);
+    expect(r.success).toBe(true);
+  });
+});
+```
+
+（`formConfigSchema` 已由該 spec 檔既有 import 取得;若無則補 import。）
+
+- [ ] **Step 2: 跑測試確認失敗**
+
+Run: `pnpm -F @rfjs/form-builder vitest:run src/config-schema.spec.ts`
+Expected: FAIL —— button kind 不在 discriminated union。
+
+- [ ] **Step 3: 實作**
+
+`types.ts` —— `DataSourceRequest.method`(第 9 行)改為 `'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'`;`ItemKind`(84)改:
+
+```ts
+export type ItemKind = 'field' | 'content' | 'divider' | 'spacer' | 'ai-note' | 'button';
+```
+
+`AiNoteItem`(102)之後、`FormItem`(103)之前插入:
+
+```ts
+export type ButtonActionType = 'submit' | 'reset' | 'clear' | 'custom' | 'api';
+
+export type ButtonAction =
+  | { type: 'submit' }
+  | { type: 'reset' }
+  | { type: 'clear'; fields: string[] }
+  | { type: 'custom'; name: string }
+  | {
+      type: 'api';
+      url: string;
+      method?: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';   // default POST
+      fields?: string[];                                       // omit = all visible fields
+      responseMap?: Record<string, string>;                    // response dot-path → target field key
+      messages?: { success?: LocalizedLabel; error?: LocalizedLabel };
+    };
+
+export interface ButtonItem {
+  id: string;
+  kind: 'button';
+  label: LocalizedLabel;
+  action: ButtonAction;
+  variant?: 'primary' | 'outline' | 'ghost' | 'destructive';   // default: submit→primary, others→outline
+  validate?: boolean;   // default: submit→true, api/custom→false; ignored for reset/clear
+}
+```
+
+`FormItem` 聯集加 `| ButtonItem`;`FormConfig` 加:
+
+```ts
+export interface FormConfig {
+  version: number;
+  id?: string;                        // → ActionMeta.formId
+  meta?: Record<string, unknown>;     // → ActionMeta.custom
+  fields?: FieldConfig[];
+  sections?: FormSection[];
+  columns?: 1 | 2 | 3 | 4;
+  responsive?: { stackBelow?: number };
+}
+```
+
+`config-schema.ts` —— 在 `aiNoteItemSchema`(137)之後加(`localizedLabelSchema`:檔內已有給 label 用的 union schema 就複用;若無,補 `const localizedLabelSchema = z.union([z.string(), z.record(z.string(), z.string())]);`):
+
+```ts
+const buttonActionSchema = z.discriminatedUnion('type', [
+  z.object({ type: z.literal('submit') }),
+  z.object({ type: z.literal('reset') }),
+  z.object({ type: z.literal('clear'), fields: z.array(z.string().min(1)).min(1) }),
+  z.object({ type: z.literal('custom'), name: z.string().min(1) }),
+  z.object({
+    type: z.literal('api'),
+    url: z.string().min(1),
+    method: z.enum(['GET', 'POST', 'PUT', 'PATCH', 'DELETE']).optional(),
+    fields: z.array(z.string().min(1)).optional(),
+    responseMap: z.record(z.string(), z.string()).optional(),
+    messages: z.object({ success: localizedLabelSchema.optional(), error: localizedLabelSchema.optional() }).optional(),
+  }),
+]);
+
+const buttonItemSchema = z.object({
+  id: z.string().min(1),
+  kind: z.literal('button'),
+  label: localizedLabelSchema,
+  action: buttonActionSchema,
+  variant: z.enum(['primary', 'outline', 'ghost', 'destructive']).optional(),
+  validate: z.boolean().optional(),
+});
+```
+
+`formItemSchema` 的 discriminatedUnion 陣列加入 `buttonItemSchema`;`FormConfigSchema`(170)物件加 `id: z.string().min(1).optional()` 與 `meta: z.record(z.string(), z.unknown()).optional()`。DataSource 的 zod method enum(`config-schema.ts` 內 dataSourceSchema.request)同步加 `'PATCH'`。
+
+`.changeset/form-action-model-engine.md`:
+
+```md
+---
+"@rfjs/form-builder": minor
+---
+
+Add configurable button items: `ButtonItem` (`kind: 'button'`) with a `ButtonAction` union (`submit` / `reset` / `clear` / `custom` / `api`), plus optional top-level `FormConfig.id` and `FormConfig.meta` for the action payload envelope. `DataSourceRequest.method` now also accepts `PATCH`.
+```
+
+- [ ] **Step 4: 跑測試確認通過**
+
+Run: `pnpm -F @rfjs/form-builder vitest:run && pnpm -F @rfjs/form-builder typecheck`
+Expected: 全 PASS(既有測試不受影響)。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/form-builder/src/types.ts packages/form-builder/src/config-schema.ts packages/form-builder/src/config-schema.spec.ts .changeset/form-action-model-engine.md
+git commit -m "feat(form-builder): add button item and action union to config model
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Renderer — ActionMeta 信封 + onSubmit 簽名 + metaProvider + changeset
+
+**Files:**
+- Modify: `packages/form-builder-ui/src/config-form.tsx`(SubmissionMeta:30、ConfigFormProps:77、handleSubmit:338)
+- Modify: `packages/form-builder-ui/src/config-form.spec.tsx`(既有 onSubmit 斷言改信封 + 新測試)
+- Create: `.changeset/form-action-model-ui.md`
+
+**Interfaces:**
+- Consumes: Task 1 的 `ButtonActionType`、`FormConfig.id/meta`。
+- Produces(Task 3/4/7 依賴):
+  - `interface ActionMeta extends SubmissionMeta { formId?: string; timestamp: string; action: { type: ButtonActionType; name?: string }; custom?: Record<string, unknown>; apiError?: string; [key: string]: unknown }`
+  - `ConfigFormProps.onSubmit: (payload: { data: Record<string, unknown>; meta: ActionMeta }) => void`
+  - `ConfigFormProps.metaProvider?: () => Record<string, unknown>`
+  - `ConfigFormProps.onAction?: (name: string, payload: { data: Record<string, unknown>; meta: ActionMeta; response?: unknown }) => void`(本任務先宣告型別,行為 Task 3/4 實作)
+  - 內部 helper `buildActionMeta`(export 供測試)
+
+- [ ] **Step 1: 寫失敗測試** — `config-form.spec.tsx` 追加(既有 submit 測試若斷言 `onSubmit` 收到裸 values,改成解構 `payload.data` 斷言,語義不變):
+
+```tsx
+describe('action meta envelope', () => {
+  const cfg: FormConfig = {
+    version: 1,
+    id: 'leave-form',
+    meta: { source: 'web' },
+    fields: [{ key: 'name', label: 'Name', component: 'Input', dataType: 'string' }],
+  };
+
+  it('default submit emits { data, meta } with formId/timestamp/action/custom', async () => {
+    const onSubmit = vi.fn();
+    render(<ConfigForm config={cfg} onSubmit={onSubmit} />);
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Roy' } });
+    fireEvent.click(screen.getByRole('button', { name: /submit/i }));
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    const payload = onSubmit.mock.calls[0]![0] as { data: Record<string, unknown>; meta: Record<string, unknown> };
+    expect(payload.data).toEqual({ name: 'Roy' });
+    expect(payload.meta).toMatchObject({
+      formId: 'leave-form',
+      action: { type: 'submit' },
+      custom: { source: 'web' },
+      valid: true,
+      schemaVersion: 1,
+    });
+    expect(typeof payload.meta.timestamp).toBe('string');
+    expect(Number.isNaN(Date.parse(payload.meta.timestamp as string))).toBe(false);
+  });
+
+  it('metaProvider values merge in but cannot override reserved keys', async () => {
+    const onSubmit = vi.fn();
+    render(
+      <ConfigForm
+        config={cfg}
+        onSubmit={onSubmit}
+        metaProvider={() => ({ user: 'roy', action: 'HACKED', timestamp: 'HACKED' })}
+      />,
+    );
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'x' } });
+    fireEvent.click(screen.getByRole('button', { name: /submit/i }));
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    const meta = onSubmit.mock.calls[0]![0].meta as Record<string, unknown>;
+    expect(meta.user).toBe('roy');
+    expect(meta.action).toEqual({ type: 'submit' });   // 保留鍵未被覆蓋
+    expect(meta.timestamp).not.toBe('HACKED');
+  });
+});
+```
+
+- [ ] **Step 2: 跑測試確認失敗**
+
+Run: `pnpm -F @rfjs/form-builder-ui vitest:run src/config-form.spec.tsx`
+Expected: FAIL —— payload 仍是裸 values。
+
+- [ ] **Step 3: 實作** — `config-form.tsx`:
+
+`SubmissionMeta` 之後加:
+
+```ts
+import type { ButtonActionType } from '@rfjs/form-builder';
+
+export interface ActionMeta extends SubmissionMeta {
+  /** FormConfig.id (when set). */
+  formId?: string;
+  /** ISO timestamp at the moment the action fired. */
+  timestamp: string;
+  /** Which action fired (name only for `custom`). */
+  action: { type: ButtonActionType; name?: string };
+  /** FormConfig.meta, passed through verbatim. */
+  custom?: Record<string, unknown>;
+  /** Set when an `api` action's fetcher rejected. */
+  apiError?: string;
+  /** metaProvider-injected runtime keys. */
+  [key: string]: unknown;
+}
+
+/** Builds the meta envelope for an action. Reserved keys always win over metaProvider output. */
+export function buildActionMeta(opts: {
+  config: FormConfig;
+  data: Record<string, unknown>;
+  action: { type: ButtonActionType; name?: string };
+  metaProvider?: () => Record<string, unknown>;
+}): ActionMeta {
+  const { config, data, action, metaProvider } = opts;
+  const visibleFieldItems = collectFieldItems(config).filter((f) => evaluateConditional(f.conditional, data));
+  const parsed = configToZod({ version: config.version, fields: visibleFieldItems }).safeParse(data);
+  const errors: Record<string, string> = {};
+  if (!parsed.success) {
+    for (const issue of parsed.error.issues) {
+      const k = String(issue.path[0]);
+      if (k && !errors[k]) errors[k] = issue.message;
+    }
+  }
+  return {
+    ...(metaProvider ? metaProvider() : {}),
+    valid: parsed.success,
+    errors,
+    visibleKeys: Object.keys(data),
+    schemaVersion: config.version,
+    ...(config.id !== undefined ? { formId: config.id } : {}),
+    timestamp: new Date().toISOString(),
+    action,
+    ...(config.meta !== undefined ? { custom: config.meta } : {}),
+  };
+}
+```
+
+`ConfigFormProps`:`onSubmit` 型別改 `(payload: { data: Record<string, unknown>; meta: ActionMeta }) => void`;加 `metaProvider?: () => Record<string, unknown>;` 與 `onAction?: (name: string, payload: { data: Record<string, unknown>; meta: ActionMeta; response?: unknown }) => void;`(JSDoc 各一句)。函式簽名解構加 `metaProvider, onAction`。
+
+`handleSubmit` callback(338)改:
+
+```tsx
+onSubmit={handleSubmit((all) => {
+  const data = computePayload(all as Record<string, unknown>, config);
+  onSubmit({ data, meta: buildActionMeta({ config, data, action: { type: 'submit' }, metaProvider }) });
+})}
+```
+
+（`onPayloadChange` 的既有 effect 邏輯與 `buildActionMeta` 有部分重複 —— 允許該 effect 內改用 `buildActionMeta` 的 valid/errors 計算段抽共用,但 `onPayloadChange` 的對外型別維持 `SubmissionMeta` 不變。）
+
+`.changeset/form-action-model-ui.md`:
+
+```md
+---
+"@rfjs/form-builder-ui": minor
+---
+
+ConfigForm renders configurable button items and emits a unified `{ data, meta: ActionMeta }` envelope for submit/custom/api actions (breaking: `onSubmit` now receives the envelope instead of bare values). New props: `onAction`, `metaProvider`.
+```
+
+- [ ] **Step 4: 跑測試確認通過**
+
+Run: `pnpm -F @rfjs/form-builder-ui vitest:run && pnpm -F @rfjs/form-builder-ui typecheck`
+Expected: 全 PASS(既有 submit 相關測試已同步改信封斷言)。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/form-builder-ui/src/config-form.tsx packages/form-builder-ui/src/config-form.spec.tsx .changeset/form-action-model-ui.md
+git commit -m "feat(form-builder-ui): emit { data, meta } action envelope from configform submit
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Renderer — 按鈕渲染 + submit/reset/clear/custom 動作
+
+**Files:**
+- Modify: `packages/form-builder-ui/src/config-form.tsx`(renderItem:236、預設 Submit 區:409)
+- Modify: `packages/form-builder-ui/src/config-form.spec.tsx`
+
+**Interfaces:**
+- Consumes: Task 1 `ButtonItem`;Task 2 `buildActionMeta`/`onAction`/`metaProvider`。
+- Produces: 按鈕渲染與動作分發(Task 4 的 api 分支掛在同一個 `runAction`;Task 5-7 的工具層依賴此行為)。
+
+- [ ] **Step 1: 寫失敗測試** — `config-form.spec.tsx` 追加:
+
+```tsx
+describe('button items', () => {
+  const btn = (action: ButtonAction, extra?: Partial<ButtonItem>): FormConfig => ({
+    version: 1,
+    sections: [{
+      id: 's1',
+      rows: [{
+        id: 'r1',
+        items: [
+          { id: 'f1', kind: 'field', key: 'name', label: 'Name', component: 'Input', dataType: 'string', required: true },
+          { id: 'f2', kind: 'field', key: 'note', label: 'Note', component: 'Input', dataType: 'string', defaultValue: 'keep' },
+          { id: 'b1', kind: 'button', label: 'Go', action, ...extra },
+        ],
+      }],
+    }],
+  });
+
+  it('renders configured buttons and suppresses the default submit', () => {
+    render(<ConfigForm config={btn({ type: 'custom', name: 'x' })} onSubmit={vi.fn()} />);
+    expect(screen.getByRole('button', { name: 'Go' })).toBeTruthy();
+    expect(screen.queryByRole('button', { name: /^submit$/i })).toBeNull();
+  });
+
+  it('submit button validates by default and blocks invalid submit', async () => {
+    const onSubmit = vi.fn();
+    render(<ConfigForm config={btn({ type: 'submit' })} onSubmit={onSubmit} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Go' }));
+    await waitFor(() => expect(screen.getByText(/required|expected|invalid/i)).toBeTruthy());
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('submit button with valid values emits the envelope with action.type submit', async () => {
+    const onSubmit = vi.fn();
+    render(<ConfigForm config={btn({ type: 'submit' })} onSubmit={onSubmit} />);
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Roy' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Go' }));
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    expect(onSubmit.mock.calls[0]![0].meta.action).toEqual({ type: 'submit' });
+  });
+
+  it('custom button skips validation by default and calls onAction with the envelope', async () => {
+    const onAction = vi.fn();
+    render(<ConfigForm config={btn({ type: 'custom', name: 'save-draft' })} onSubmit={vi.fn()} onAction={onAction} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Go' }));   // name 空著也能發(不驗)
+    await waitFor(() => expect(onAction).toHaveBeenCalledTimes(1));
+    const [name, payload] = onAction.mock.calls[0]!;
+    expect(name).toBe('save-draft');
+    expect(payload.meta.action).toEqual({ type: 'custom', name: 'save-draft' });
+    expect(payload.meta.valid).toBe(false);   // meta 照實回報
+  });
+
+  it('custom button with validate: true blocks when invalid', async () => {
+    const onAction = vi.fn();
+    render(<ConfigForm config={btn({ type: 'custom', name: 'x' }, { validate: true })} onSubmit={vi.fn()} onAction={onAction} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Go' }));
+    await waitFor(() => expect(screen.getByText(/required|expected|invalid/i)).toBeTruthy());
+    expect(onAction).not.toHaveBeenCalled();
+  });
+
+  it('clear resets only the listed fields', async () => {
+    render(<ConfigForm config={btn({ type: 'clear', fields: ['name'] })} onSubmit={vi.fn()} defaultValues={{ name: 'Roy', note: 'keep' }} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Go' }));
+    await waitFor(() => expect((screen.getByLabelText('Name') as HTMLInputElement).value).toBe(''));
+    expect((screen.getByLabelText('Note') as HTMLInputElement).value).toBe('keep');
+  });
+
+  it('reset restores defaultValues', async () => {
+    render(<ConfigForm config={btn({ type: 'reset' })} onSubmit={vi.fn()} defaultValues={{ name: 'init', note: 'keep' }} />);
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'changed' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Go' }));
+    await waitFor(() => expect((screen.getByLabelText('Name') as HTMLInputElement).value).toBe('init'));
+  });
+});
+```
+
+（`ButtonAction`/`ButtonItem` 型別 import 自 `@rfjs/form-builder`。）
+
+- [ ] **Step 2: 跑測試確認失敗**
+
+Run: `pnpm -F @rfjs/form-builder-ui vitest:run src/config-form.spec.tsx`
+Expected: FAIL —— button item 不渲染(renderItem 無此分支)且預設 Submit 仍在。
+
+- [ ] **Step 3: 實作** — `config-form.tsx`:
+
+useForm 解構補 `trigger, getValues, setValue`。加 variant 對映與動作執行器(元件內,`renderItem` 之前):
+
+```tsx
+const BUTTON_VARIANT: Record<NonNullable<ButtonItem['variant']>, 'default' | 'outline' | 'ghost' | 'destructive'> = {
+  primary: 'default',
+  outline: 'outline',
+  ghost: 'ghost',
+  destructive: 'destructive',
+};
+// 文字類元件 clear 後給 "",其餘 undefined(受控 input 需要字串空值)。
+const TEXT_COMPONENTS = new Set(['Input', 'Textarea', 'Email']);
+
+async function runAction(item: ButtonItem) {
+  const { action } = item;
+  if (action.type === 'reset') {
+    reset(defaultValues ?? {});
+    return;
+  }
+  if (action.type === 'clear') {
+    const byKey = new Map(collectFieldItems(config).map((f) => [f.key, f]));
+    for (const key of action.fields) {
+      const comp = byKey.get(key)?.component ?? 'Input';
+      setValue(key, TEXT_COMPONENTS.has(comp) ? '' : undefined, { shouldDirty: true });
+    }
+    return;
+  }
+  const doValidate = item.validate ?? (action.type === 'submit');
+  if (doValidate) {
+    const ok = await trigger();
+    if (!ok) return;   // RHF 顯示欄位錯誤,動作不發
+  }
+  const data = computePayload(getValues() as Record<string, unknown>, config);
+  if (action.type === 'submit') {
+    onSubmit({ data, meta: buildActionMeta({ config, data, action: { type: 'submit' }, metaProvider }) });
+    return;
+  }
+  if (action.type === 'custom') {
+    onAction?.(action.name, {
+      data,
+      meta: buildActionMeta({ config, data, action: { type: 'custom', name: action.name }, metaProvider }),
+    });
+    return;
+  }
+  // action.type === 'api' — Task 4
+}
+```
+
+`renderItem` 加分支(`content` 分支之後、field 之前):
+
+```tsx
+if (item.kind === 'button') {
+  const variant = BUTTON_VARIANT[item.variant ?? (item.action.type === 'submit' ? 'primary' : 'outline')];
+  return (
+    <div key={item.id} data-item={item.id} className="flex min-w-0 items-end" style={place ? placementStyle(place) : fieldSpanStyle(undefined, flow, cols)}>
+      <Button type="button" variant={variant} disabled={pendingCaptures.size > 0} onClick={() => void runAction(item)}>
+        {resolveLabel(item.label, locale)}
+      </Button>
+    </div>
+  );
+}
+```
+
+預設 Submit 區(409)改成僅在無任何 button item 時渲染:
+
+```tsx
+const hasButtons = React.useMemo(
+  () => normalizeToSections(config).some((s) => s.rows.some((r) => r.items.some((i) => i.kind === 'button'))),
+  [config],
+);
+```
+
+```tsx
+{!hasButtons && (
+  <div style={{ gridColumn: '1 / -1' }}>
+    <Button type="submit" disabled={pendingCaptures.size > 0} className="self-start border-0 text-white" style={{ background: 'linear-gradient(180deg,#5b8cff,#4a78ee)', boxShadow: '0 6px 16px rgba(74,120,238,.3)' }}>
+      {submitLabel}
+    </Button>
+  </div>
+)}
+```
+
+- [ ] **Step 4: 跑測試確認通過**
+
+Run: `pnpm -F @rfjs/form-builder-ui vitest:run`
+Expected: 全 PASS。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/form-builder-ui/src/config-form.tsx packages/form-builder-ui/src/config-form.spec.tsx
+git commit -m "feat(form-builder-ui): render button items with submit/reset/clear/custom actions
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Renderer — api 動作(fetcher/pending/訊息/responseMap)
+
+**Files:**
+- Modify: `packages/form-builder-ui/src/config-form.tsx`
+- Modify: `packages/form-builder-ui/src/config-form.spec.tsx`
+
+**Interfaces:**
+- Consumes: Task 3 的 `runAction`(補 api 分支)、既有 `fetcher?: DataSourceFetcher`。
+- Produces: api 行為契約(Task 7 preview echo fetcher 依賴):fetcher 收 `{ url, method(預設 'POST'), body: { data, meta } }`;成功 `onAction('api', { data, meta, response })`;失敗 `onAction('api', { data, meta: { ...meta, apiError }, response: undefined })`。
+
+- [ ] **Step 1: 寫失敗測試** — `config-form.spec.tsx` 追加(沿用 Task 3 的 `btn` helper):
+
+```tsx
+describe('api action', () => {
+  const apiCfg = (over?: Partial<Extract<ButtonAction, { type: 'api' }>>) =>
+    btn({ type: 'api', url: '/api/echo', ...over });
+
+  it('sends { url, method, body: { data, meta } } through the injected fetcher', async () => {
+    const fetcher = vi.fn().mockResolvedValue({ ok: true });
+    render(<ConfigForm config={apiCfg()} onSubmit={vi.fn()} fetcher={fetcher} defaultValues={{ name: 'Roy', note: 'n' }} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Go' }));
+    await waitFor(() => expect(fetcher).toHaveBeenCalledTimes(1));
+    const req = fetcher.mock.calls[0]![0];
+    expect(req.url).toBe('/api/echo');
+    expect(req.method).toBe('POST');
+    expect(req.body.data).toEqual({ name: 'Roy', note: 'n' });
+    expect(req.body.meta.action).toEqual({ type: 'api' });
+  });
+
+  it('fields narrows the sent data', async () => {
+    const fetcher = vi.fn().mockResolvedValue({});
+    render(<ConfigForm config={apiCfg({ fields: ['name'] })} onSubmit={vi.fn()} fetcher={fetcher} defaultValues={{ name: 'Roy', note: 'n' }} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Go' }));
+    await waitFor(() => expect(fetcher).toHaveBeenCalledTimes(1));
+    expect(fetcher.mock.calls[0]![0].body.data).toEqual({ name: 'Roy' });
+  });
+
+  it('success: shows message, maps response into fields, reports via onAction', async () => {
+    const fetcher = vi.fn().mockResolvedValue({ result: { display: 'mapped!' } });
+    const onAction = vi.fn();
+    render(
+      <ConfigForm
+        config={apiCfg({ responseMap: { 'result.display': 'note', 'missing.path': 'name' } })}
+        onSubmit={vi.fn()} onAction={onAction} fetcher={fetcher} defaultValues={{ name: 'keep', note: '' }}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Go' }));
+    await waitFor(() => expect(screen.getByText(/success/i)).toBeTruthy());
+    expect((screen.getByLabelText('Note') as HTMLInputElement).value).toBe('mapped!');
+    expect((screen.getByLabelText('Name') as HTMLInputElement).value).toBe('keep');   // 取不到 → 跳過
+    expect(onAction).toHaveBeenCalledWith('api', expect.objectContaining({ response: { result: { display: 'mapped!' } } }));
+  });
+
+  it('failure: shows error message and reports apiError via onAction', async () => {
+    const fetcher = vi.fn().mockRejectedValue(new Error('boom'));
+    const onAction = vi.fn();
+    render(<ConfigForm config={apiCfg()} onSubmit={vi.fn()} onAction={onAction} fetcher={fetcher} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Go' }));
+    await waitFor(() => expect(screen.getByText(/failed/i)).toBeTruthy());
+    const payload = onAction.mock.calls[0]![1];
+    expect(payload.meta.apiError).toBe('boom');
+    expect(payload.response).toBeUndefined();
+  });
+
+  it('pending: button disabled while in flight', async () => {
+    let resolve!: (v: unknown) => void;
+    const fetcher = vi.fn().mockReturnValue(new Promise((r) => { resolve = r; }));
+    render(<ConfigForm config={apiCfg()} onSubmit={vi.fn()} fetcher={fetcher} />);
+    const button = screen.getByRole('button', { name: 'Go' });
+    fireEvent.click(button);
+    await waitFor(() => expect(button).toHaveProperty('disabled', true));
+    resolve({});
+    await waitFor(() => expect(button).toHaveProperty('disabled', false));
+  });
+
+  it('no fetcher: api button renders disabled', () => {
+    render(<ConfigForm config={apiCfg()} onSubmit={vi.fn()} />);
+    expect(screen.getByRole('button', { name: 'Go' })).toHaveProperty('disabled', true);
+  });
+});
+```
+
+- [ ] **Step 2: 跑測試確認失敗**
+
+Run: `pnpm -F @rfjs/form-builder-ui vitest:run src/config-form.spec.tsx`
+Expected: FAIL —— api 分支未實作。
+
+- [ ] **Step 3: 實作** — `config-form.tsx`:
+
+state(pendingCaptures 旁):
+
+```tsx
+// api 動作狀態:同表單同時只允許一顆 in-flight。
+const [apiState, setApiState] = React.useState<{ itemId: string; status: 'pending' | 'success' | 'error' } | null>(null);
+```
+
+dot-path 取值 helper(module-level):
+
+```ts
+function getPath(obj: unknown, path: string): unknown {
+  return path.split('.').reduce<unknown>((acc, key) => (acc != null && typeof acc === 'object' ? (acc as Record<string, unknown>)[key] : undefined), obj);
+}
+```
+
+`runAction` 的 api 分支:
+
+```tsx
+if (action.type === 'api') {
+  if (!fetcher || apiState?.status === 'pending') return;
+  const sent = action.fields ? Object.fromEntries(Object.entries(data).filter(([k]) => action.fields!.includes(k))) : data;
+  const meta = buildActionMeta({ config, data: sent, action: { type: 'api' }, metaProvider });
+  setApiState({ itemId: item.id, status: 'pending' });
+  try {
+    const response = await fetcher({ url: action.url, method: action.method ?? 'POST', body: { data: sent, meta } });
+    for (const [path, targetKey] of Object.entries(action.responseMap ?? {})) {
+      const v = getPath(response, path);
+      if (v !== undefined) setValue(targetKey, v, { shouldDirty: true });
+    }
+    setApiState({ itemId: item.id, status: 'success' });
+    onAction?.('api', { data: sent, meta, response });
+  } catch (err) {
+    setApiState({ itemId: item.id, status: 'error' });
+    onAction?.('api', { data: sent, meta: { ...meta, apiError: err instanceof Error ? err.message : String(err) }, response: undefined });
+  }
+}
+```
+
+renderItem 的 button 分支改(pending/disabled/訊息;`Loader2` 自 `lucide-react`,form-builder-ui 已有此依賴):
+
+```tsx
+if (item.kind === 'button') {
+  const variant = BUTTON_VARIANT[item.variant ?? (item.action.type === 'submit' ? 'primary' : 'outline')];
+  const isApi = item.action.type === 'api';
+  const mine = apiState?.itemId === item.id ? apiState : null;
+  const pending = mine?.status === 'pending';
+  const apiDisabled = isApi && (!fetcher || apiState?.status === 'pending');
+  const msg =
+    mine?.status === 'success' ? resolveLabel((item.action as { messages?: { success?: LocalizedLabel } }).messages?.success ?? 'Success', locale)
+    : mine?.status === 'error' ? resolveLabel((item.action as { messages?: { error?: LocalizedLabel } }).messages?.error ?? 'Request failed', locale)
+    : null;
+  return (
+    <div key={item.id} data-item={item.id} className="flex min-w-0 items-center gap-2" style={place ? placementStyle(place) : fieldSpanStyle(undefined, flow, cols)}>
+      <Button
+        type="button"
+        variant={variant}
+        disabled={pendingCaptures.size > 0 || apiDisabled}
+        title={isApi && !fetcher ? 'No fetcher provided' : undefined}
+        onClick={() => void runAction(item)}
+      >
+        {pending && <Loader2 className="mr-1 size-4 animate-spin" />}
+        {resolveLabel(item.label, locale)}
+      </Button>
+      {msg && <span className={`text-xs ${mine?.status === 'error' ? 'text-destructive' : 'text-muted-foreground'}`}>{msg}</span>}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: 跑測試確認通過**
+
+Run: `pnpm -F @rfjs/form-builder-ui vitest:run && pnpm -F @rfjs/form-builder-ui typecheck && pnpm -F @rfjs/form-builder-ui lint`
+Expected: 全 PASS。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/form-builder-ui/src/config-form.tsx packages/form-builder-ui/src/config-form.spec.tsx
+git commit -m "feat(form-builder-ui): add api button action with fetcher, response mapping and status ui
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: 工具 — model.ts button kind + palette 卡
+
+**Files:**
+- Modify: `apps/web/src/tools/form-builder/model.ts`(Kind:8、Card:12、cardToItem:74、formConfigToCards:129)
+- Modify: `apps/web/src/tools/form-builder/model.spec.ts`
+- Modify: `apps/web/src/tools/form-builder/ui.tsx`(KIND_META:49、PALETTE:339、addCard:278)
+
+**Interfaces:**
+- Consumes: Task 1 `ButtonAction`/`ButtonItem`。
+- Produces: `Card` 加 `action?: ButtonAction; buttonVariant?: 'primary'|'outline'|'ghost'|'destructive'; validate?: boolean`(命名 `buttonVariant` 避免與未來欄位撞名);cards↔FormConfig 雙向攜帶(Task 6/7 依賴)。
+
+- [ ] **Step 1: 寫失敗測試** — `model.spec.ts` 追加:
+
+```ts
+describe('button cards', () => {
+  it('round-trips a button card through FormConfig', () => {
+    const groups = [{ id: 'g1', title: 'G', collapsed: false }];
+    const cards = [{
+      id: 'b1', groupId: 'g1', kind: 'button' as const, label: 'Save draft',
+      action: { type: 'custom' as const, name: 'save-draft' }, buttonVariant: 'outline' as const, validate: true,
+      col: 1, span: 3, row: 1,
+    }];
+    const config = cardsToFormConfig(groups, cards);
+    const item = config.sections![0]!.rows[0]!.items[0]!;
+    expect(item).toMatchObject({ kind: 'button', label: 'Save draft', action: { type: 'custom', name: 'save-draft' }, variant: 'outline', validate: true });
+    const back = formConfigToCards(config);
+    expect(back.cards[0]).toMatchObject({ kind: 'button', action: { type: 'custom', name: 'save-draft' }, buttonVariant: 'outline', validate: true });
+  });
+
+  it('button card without explicit action defaults to custom', () => {
+    const groups = [{ id: 'g1', title: 'G', collapsed: false }];
+    const cards = [{ id: 'b1', groupId: 'g1', kind: 'button' as const, label: 'Button', col: 1, span: 3, row: 1 }];
+    const item = cardsToFormConfig(groups, cards).sections![0]!.rows[0]!.items[0]!;
+    expect(item).toMatchObject({ kind: 'button', action: { type: 'custom', name: 'action-1' } });
+  });
+});
+```
+
+- [ ] **Step 2: 跑測試確認失敗**
+
+Run: `pnpm -F web vitest:run src/tools/form-builder/model.spec.ts`
+Expected: FAIL —— Kind 無 "button"(型別錯誤或 cardToItem switch 無分支)。
+
+- [ ] **Step 3: 實作**
+
+`model.ts`:
+
+```ts
+export type Kind = "field" | "content" | "divider" | "spacer" | "ai-note" | "button";
+```
+
+`Card` 介面加(`size` 之後):
+
+```ts
+  action?: ButtonAction;      // button
+  buttonVariant?: "primary" | "outline" | "ghost" | "destructive"; // button
+  validate?: boolean;         // button
+```
+
+（import 補 `type ButtonAction`。）`cardToItem` switch 加:
+
+```ts
+    case "button":
+      return {
+        id: c.id, kind: "button", label: c.label,
+        action: c.action ?? { type: "custom", name: "action-1" },
+        ...(c.buttonVariant ? { variant: c.buttonVariant } : {}),
+        ...(c.validate !== undefined ? { validate: c.validate } : {}),
+      };
+```
+
+`formConfigToCards` 的分支鏈(content 之後)加:
+
+```ts
+      } else if (item.kind === "button") {
+        cards.push({ ...base, kind: "button", label: item.label, action: item.action, buttonVariant: item.variant, validate: item.validate });
+```
+
+`ui.tsx`:import 補 `MousePointerClick`(lucide-react);`KIND_META` 加:
+
+```ts
+  button: { color: "#10b981", icon: MousePointerClick, label: "Button" },
+```
+
+`PALETTE` 改 `["field", "content", "divider", "spacer", "ai-note", "button"]`。`addCard` 對 button 不需特例(`label: KIND_META.button.label` = "Button",action 由 `cardToItem` 預設補上;若 addCard 建的 Card 需要顯式 action,加 `...(kind === "button" ? { action: { type: "custom", name: "action-1" } } : {})`,以 inspector 能立即顯示為準)。
+
+- [ ] **Step 4: 跑測試確認通過**
+
+Run: `pnpm -F web vitest:run src/tools/form-builder/model.spec.ts src/tools/form-builder/ui.spec.tsx`
+Expected: 全 PASS(ui.spec 既有測試不受 palette 增項影響;若有 palette 數量斷言,同步更新並在報告註明)。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/tools/form-builder/model.ts apps/web/src/tools/form-builder/model.spec.ts apps/web/src/tools/form-builder/ui.tsx
+git commit -m "feat(web): add button card kind to form-builder canvas model and palette
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: 工具 — inspector Action 面板
+
+**Files:**
+- Create: `apps/web/src/tools/form-builder/inspector/action.tsx`
+- Create: `apps/web/src/tools/form-builder/inspector/action.spec.tsx`
+- Modify: `apps/web/src/tools/form-builder/inspector/settings-panel.tsx`(掛入新 Section;Basics 的 field-only 欄位對 button 隱藏)
+
+**Interfaces:**
+- Consumes: Task 5 的 `Card.action/buttonVariant/validate`、既有 `Section`(`./section`)、`onChange: (p: Partial<Card>) => void`、`siblingFields`(既有 prop,提供 field key 清單)。
+- Produces: `ActionSection({ card, onChange, siblingFields })` 元件。
+
+- [ ] **Step 1: 寫失敗測試** — `action.spec.tsx`(比照既有 inspector spec 的 render 模式,如 `validation.spec.tsx`):
+
+```tsx
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { Card } from "../model";
+import { ActionSection } from "./action";
+
+const btnCard = (over?: Partial<Card>): Card => ({
+  id: "b1", groupId: "g1", kind: "button", label: "Go",
+  action: { type: "custom", name: "save-draft" },
+  col: 1, span: 3, row: 1, ...over,
+});
+
+const fields = [{ key: "name", dataType: "string" }, { key: "amount", dataType: "numeric" }];
+
+describe("ActionSection", () => {
+  it("switching type to clear shows the field multi-select and writes a valid clear action", () => {
+    const onChange = vi.fn();
+    render(<ActionSection card={btnCard()} onChange={onChange} siblingFields={fields} />);
+    fireEvent.change(screen.getByLabelText(/action type/i), { target: { value: "clear" } });
+    expect(onChange).toHaveBeenCalledWith({ action: { type: "clear", fields: [] } });
+  });
+
+  it("clear: toggling a field key adds it to action.fields", () => {
+    const onChange = vi.fn();
+    render(<ActionSection card={btnCard({ action: { type: "clear", fields: [] } })} onChange={onChange} siblingFields={fields} />);
+    fireEvent.click(screen.getByLabelText("name"));
+    expect(onChange).toHaveBeenCalledWith({ action: { type: "clear", fields: ["name"] } });
+  });
+
+  it("custom: renders the name input", () => {
+    const onChange = vi.fn();
+    render(<ActionSection card={btnCard()} onChange={onChange} siblingFields={fields} />);
+    fireEvent.change(screen.getByLabelText(/event name/i), { target: { value: "notify" } });
+    expect(onChange).toHaveBeenCalledWith({ action: { type: "custom", name: "notify" } });
+  });
+
+  it("api: renders url/method and responseMap editor", () => {
+    const onChange = vi.fn();
+    render(<ActionSection card={btnCard({ action: { type: "api", url: "/x" } })} onChange={onChange} siblingFields={fields} />);
+    fireEvent.change(screen.getByLabelText(/url/i), { target: { value: "/api/y" } });
+    expect(onChange).toHaveBeenCalledWith({ action: { type: "api", url: "/api/y" } });
+    expect(screen.getByText(/response map/i)).toBeTruthy();
+  });
+
+  it("validate switch writes through", () => {
+    const onChange = vi.fn();
+    render(<ActionSection card={btnCard()} onChange={onChange} siblingFields={fields} />);
+    fireEvent.click(screen.getByLabelText(/validate before run/i));
+    expect(onChange).toHaveBeenCalledWith({ validate: true });
+  });
+});
+```
+
+- [ ] **Step 2: 跑測試確認失敗**
+
+Run: `pnpm -F web vitest:run src/tools/form-builder/inspector/action.spec.tsx`
+Expected: FAIL —— 模組不存在。
+
+- [ ] **Step 3: 實作**
+
+`action.tsx`(樣式沿用 inspector 慣例:`INPUT_CLS` 同 settings-panel 的 input class —— 從該檔抽出共用常數或本檔複製一份;label 用原生 `<label>` + text-xs 模式):
+
+```tsx
+"use client";
+import * as React from "react";
+
+import type { ButtonAction } from "@rfjs/form-builder";
+import type { Card } from "../model";
+
+const INPUT_CLS = "rounded-md border border-input bg-background px-2 py-1.5 text-sm";
+const TYPES: ButtonAction["type"][] = ["submit", "reset", "clear", "custom", "api"];
+const METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE"] as const;
+
+/** 依 type 切換的預設 action 值(切換時舊參數不保留 —— 各型別參數互不相容)。 */
+function defaultAction(type: ButtonAction["type"]): ButtonAction {
+  switch (type) {
+    case "submit": return { type: "submit" };
+    case "reset": return { type: "reset" };
+    case "clear": return { type: "clear", fields: [] };
+    case "custom": return { type: "custom", name: "action-1" };
+    case "api": return { type: "api", url: "" };
+  }
+}
+
+export function ActionSection({
+  card, onChange, siblingFields = [],
+}: { card: Card; onChange: (p: Partial<Card>) => void; siblingFields?: { key: string; dataType: string }[] }) {
+  const action = card.action ?? { type: "custom" as const, name: "action-1" };
+  const patch = (a: ButtonAction) => onChange({ action: a });
+
+  return (
+    <div className="flex flex-col gap-2">
+      <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+        Action type
+        <select className={INPUT_CLS} value={action.type} onChange={(e) => patch(defaultAction(e.target.value as ButtonAction["type"]))}>
+          {TYPES.map((t) => <option key={t} value={t}>{t}</option>)}
+        </select>
+      </label>
+
+      {action.type === "clear" && (
+        <fieldset className="flex flex-col gap-1 text-xs text-muted-foreground">
+          <legend>Fields to clear</legend>
+          {siblingFields.map((f) => (
+            <label key={f.key} className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                aria-label={f.key}
+                checked={action.fields.includes(f.key)}
+                onChange={(e) =>
+                  patch({ type: "clear", fields: e.target.checked ? [...action.fields, f.key] : action.fields.filter((k) => k !== f.key) })
+                }
+              />
+              <span className="font-mono">{f.key}</span>
+            </label>
+          ))}
+        </fieldset>
+      )}
+
+      {action.type === "custom" && (
+        <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+          Event name
+          <input className={`${INPUT_CLS} font-mono`} value={action.name} onChange={(e) => patch({ type: "custom", name: e.target.value })} />
+        </label>
+      )}
+
+      {action.type === "api" && (
+        <>
+          <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+            URL
+            <input className={`${INPUT_CLS} font-mono`} value={action.url} onChange={(e) => patch({ ...action, url: e.target.value })} />
+          </label>
+          <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+            Method
+            <select className={INPUT_CLS} value={action.method ?? "POST"} onChange={(e) => patch({ ...action, method: e.target.value as (typeof METHODS)[number] })}>
+              {METHODS.map((m) => <option key={m} value={m}>{m}</option>)}
+            </select>
+          </label>
+          <fieldset className="flex flex-col gap-1 text-xs text-muted-foreground">
+            <legend>Send fields (empty = all visible)</legend>
+            {siblingFields.map((f) => {
+              const sel = action.fields ?? [];
+              return (
+                <label key={f.key} className="flex items-center gap-2">
+                  <input
+                    type="checkbox"
+                    aria-label={`send ${f.key}`}
+                    checked={sel.includes(f.key)}
+                    onChange={(e) => {
+                      const next = e.target.checked ? [...sel, f.key] : sel.filter((k) => k !== f.key);
+                      patch({ ...action, fields: next.length ? next : undefined });
+                    }}
+                  />
+                  <span className="font-mono">{f.key}</span>
+                </label>
+              );
+            })}
+          </fieldset>
+          <ResponseMapEditor action={action} patch={patch} siblingFields={siblingFields} />
+          <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+            Success message
+            <input className={INPUT_CLS} value={typeof action.messages?.success === "string" ? action.messages.success : ""} onChange={(e) => patch({ ...action, messages: { ...action.messages, success: e.target.value || undefined } })} />
+          </label>
+          <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+            Error message
+            <input className={INPUT_CLS} value={typeof action.messages?.error === "string" ? action.messages.error : ""} onChange={(e) => patch({ ...action, messages: { ...action.messages, error: e.target.value || undefined } })} />
+          </label>
+        </>
+      )}
+
+      {(action.type === "submit" || action.type === "custom" || action.type === "api") && (
+        <label className="flex items-center gap-2 text-xs text-muted-foreground">
+          <input
+            type="checkbox"
+            aria-label="Validate before run"
+            checked={card.validate ?? action.type === "submit"}
+            onChange={(e) => onChange({ validate: e.target.checked })}
+          />
+          Validate before run
+        </label>
+      )}
+
+      <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+        Variant
+        <select className={INPUT_CLS} value={card.buttonVariant ?? (action.type === "submit" ? "primary" : "outline")} onChange={(e) => onChange({ buttonVariant: e.target.value as Card["buttonVariant"] })}>
+          {(["primary", "outline", "ghost", "destructive"] as const).map((v) => <option key={v} value={v}>{v}</option>)}
+        </select>
+      </label>
+    </div>
+  );
+}
+
+/** responseMap 的 key-value 列表編輯(path → field key)。 */
+function ResponseMapEditor({
+  action, patch, siblingFields,
+}: { action: Extract<ButtonAction, { type: "api" }>; patch: (a: ButtonAction) => void; siblingFields: { key: string; dataType: string }[] }) {
+  const entries = Object.entries(action.responseMap ?? {});
+  const write = (next: [string, string][]) =>
+    patch({ ...action, responseMap: next.length ? Object.fromEntries(next) : undefined });
+  return (
+    <fieldset className="flex flex-col gap-1 text-xs text-muted-foreground">
+      <legend>Response map (path → field)</legend>
+      {entries.map(([path, target], i) => (
+        <div key={i} className="flex items-center gap-1">
+          <input className={`${INPUT_CLS} min-w-0 flex-1 font-mono`} aria-label={`response path ${i}`} value={path} onChange={(e) => write(entries.map((en, j) => (j === i ? [e.target.value, en[1]] : en)) as [string, string][])} />
+          <span>→</span>
+          <select className={`${INPUT_CLS} min-w-0 flex-1`} aria-label={`target field ${i}`} value={target} onChange={(e) => write(entries.map((en, j) => (j === i ? [en[0], e.target.value] : en)) as [string, string][])}>
+            {siblingFields.map((f) => <option key={f.key} value={f.key}>{f.key}</option>)}
+          </select>
+          <button type="button" aria-label={`remove mapping ${i}`} className="text-muted-foreground hover:text-foreground" onClick={() => write(entries.filter((_, j) => j !== i) as [string, string][])}>×</button>
+        </div>
+      ))}
+      <button
+        type="button"
+        className="self-start rounded-md border border-input px-2 py-1 hover:bg-accent"
+        onClick={() => write([...entries, ["", siblingFields[0]?.key ?? ""]] as [string, string][])}
+        disabled={siblingFields.length === 0}
+      >
+        + mapping
+      </button>
+    </fieldset>
+  );
+}
+```
+
+`settings-panel.tsx`:import `ActionSection`;`isField` 旁加 `const isButton = card.kind === "button";`;Basics 區的 Width/Group 保留、field-only 欄位照舊由 `isField` gate;在 Validation Section 之前插入:
+
+```tsx
+      {isButton ? (
+        <Section title="Action">
+          <ActionSection card={card} onChange={onChange} siblingFields={siblingFields} />
+        </Section>
+      ) : null}
+```
+
+- [ ] **Step 4: 跑測試確認通過**
+
+Run: `pnpm -F web vitest:run src/tools/form-builder/inspector/`
+Expected: 全 PASS(既有 inspector spec 不受影響)。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/tools/form-builder/inspector/action.tsx apps/web/src/tools/form-builder/inspector/action.spec.tsx apps/web/src/tools/form-builder/inspector/settings-panel.tsx
+git commit -m "feat(web): add button action inspector panel to form-builder
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: 工具 — SubmissionPanel 動作顯示 + Preview 接線 + 範例
+
+**Files:**
+- Modify: `apps/web/src/tools/form-builder/submission-panel.tsx`(meta 型別改 `ActionMeta`,顯示 action/apiError)
+- Modify: `apps/web/src/tools/form-builder/submission-panel.spec.tsx`
+- Modify: `apps/web/src/tools/form-builder/ui.tsx`(Preview 分頁的兩處 `<ConfigForm>`:490、506 —— 接 `onSubmit`/`onAction`/echo fetcher)
+- Modify: `apps/web/src/tools/form-builder/ui.spec.tsx`
+- Modify: `apps/web/src/tools/form-builder/sample.ts`(範例加按鈕)
+
+**Interfaces:**
+- Consumes: Task 2 `ActionMeta`;Task 3/4 的動作行為;Task 5 的 button card。
+- Produces: 使用者可在 Preview 直接看到動作 payload。
+
+- [ ] **Step 1: 寫失敗測試**
+
+`submission-panel.spec.tsx` 追加:
+
+```tsx
+it('shows the firing action and apiError when present', () => {
+  render(
+    <SubmissionPanel
+      payload={{
+        data: { a: 1 },
+        meta: { valid: true, errors: {}, visibleKeys: ['a'], schemaVersion: 1, timestamp: 't', action: { type: 'custom', name: 'save-draft' }, apiError: 'boom' },
+      }}
+    />,
+  );
+  expect(screen.getByText(/custom/)).toBeTruthy();
+  expect(screen.getByText(/save-draft/)).toBeTruthy();
+  expect(screen.getByText(/boom/)).toBeTruthy();
+});
+```
+
+`ui.spec.tsx` 追加(沿用該檔既有 render/mock 模式;Preview 分頁切換的既有測試已示範路徑):
+
+```tsx
+it('preview: clicking a custom button surfaces the action in the submission panel', async () => {
+  renderTool();
+  fireEvent.click(screen.getByRole('button', { name: /preview/i }));
+  fireEvent.click(await screen.findByRole('button', { name: /save draft/i }));
+  await waitFor(() => expect(screen.getAllByText(/save-draft/).length).toBeGreaterThan(0));
+});
+```
+
+- [ ] **Step 2: 跑測試確認失敗**
+
+Run: `pnpm -F web vitest:run src/tools/form-builder/submission-panel.spec.tsx src/tools/form-builder/ui.spec.tsx`
+Expected: FAIL —— SubmissionPanel 不顯示 action;範例無 Save draft 按鈕。
+
+- [ ] **Step 3: 實作**
+
+`submission-panel.tsx`:props 型別改 `payload: { data: Record<string, unknown>; meta: SubmissionMeta | ActionMeta } | null`(import `ActionMeta`);Metadata 區塊在 Status Badge 之後加:
+
+```tsx
+{'action' in meta && meta.action != null && (
+  <div className="mb-3 space-y-1">
+    <p className="text-xs font-medium text-muted-foreground">Action:</p>
+    <p className="font-mono text-xs text-foreground">
+      {(meta as ActionMeta).action.type}
+      {(meta as ActionMeta).action.name ? ` — ${(meta as ActionMeta).action.name}` : ''}
+    </p>
+  </div>
+)}
+{'apiError' in meta && (meta as ActionMeta).apiError && (
+  <p className="mb-3 text-xs text-red-600 dark:text-red-400">API error: {(meta as ActionMeta).apiError}</p>
+)}
+```
+
+`ui.tsx` Preview 區:加 state 與 echo fetcher(元件內):
+
+```tsx
+const [lastPayload, setLastPayload] = React.useState<{ data: Record<string, unknown>; meta: SubmissionMeta } | null>(null);
+// Preview 用 echo fetcher:回傳收到的 body 加上 echoedAt,讓 responseMap 可示範。
+const echoFetcher = React.useCallback(async (req: { url: string; body?: unknown }) => ({ echoedAt: new Date().toISOString(), received: req.body }), []);
+```
+
+兩處 `<ConfigForm>` 改:
+
+```tsx
+onSubmit={(p) => setLastPayload(p)}
+onAction={(_name, p) => setLastPayload({ data: p.data, meta: p.meta })}
+fetcher={echoFetcher}
+```
+
+（既有 `onPayloadChange` → SubmissionPanel 的 live 顯示照舊;動作 payload 與 live payload 若共用同一 state,以「動作觸發後覆蓋 live 值」的現有 UX 決策為準 —— 實作時對照現檔:如果 SubmissionPanel 目前吃 `onPayloadChange` 的 state,則動作 payload 寫入同一個 state。）
+
+`sample.ts`:在最後一個 section 的 row 追加三顆按鈕 item(id 唯一、layout placements 同步加 —— 對齊該檔既有 placement 結構):
+
+```ts
+{ id: "btn_submit", kind: "button", label: { en: "Submit request", "zh-TW": "送出申請" }, action: { type: "submit" }, variant: "primary" },
+{ id: "btn_draft", kind: "button", label: { en: "Save draft", "zh-TW": "存草稿" }, action: { type: "custom", name: "save-draft" } },
+{ id: "btn_clear", kind: "button", label: { en: "Clear", "zh-TW": "清除" }, action: { type: "clear", fields: ["<key1>", "<key2>"] }, variant: "ghost" },
+```
+
+（**先讀 sample.ts**:`<key1>`/`<key2>` 填該檔頭兩個 field 的實際 key 值 —— 不得留空陣列(schema 要求 min 1)。placements:三顆各 span 3、同一新 row,row 值 = 該 section 現有最大 row + 1。）
+
+- [ ] **Step 4: 跑測試確認通過**
+
+Run: `pnpm -F web vitest:run src/tools/form-builder/ && pnpm -F web check-types && pnpm -F web lint`
+Expected: 全 PASS(check-types 失敗且訊息為 @rfjs/* 解析 → 先 `pnpm build:packages` 再重跑)。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/tools/form-builder/submission-panel.tsx apps/web/src/tools/form-builder/submission-panel.spec.tsx apps/web/src/tools/form-builder/ui.tsx apps/web/src/tools/form-builder/ui.spec.tsx apps/web/src/tools/form-builder/sample.ts
+git commit -m "feat(web): surface action payloads in form-builder preview with sample buttons
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 8: e2e + 全套驗證
+
+**Files:**
+- Modify: `apps/web/e2e/form-builder.e2e.ts`(若無此檔,建立;先 `ls apps/web/e2e/` 對照現有命名)
+
+**Interfaces:**
+- Consumes: Task 7 的範例按鈕(accessible name "Save draft")與 SubmissionPanel 顯示。
+
+- [ ] **Step 1: 追加 e2e 測試**:
+
+```ts
+test("preview: custom action button surfaces its payload in the submission panel", async ({ page }) => {
+  await page.goto("/en/tools/form-builder");
+  await page.getByRole("button", { name: /preview/i }).click();
+  await page.getByRole("button", { name: /save draft/i }).click();
+  await expect(page.getByText(/save-draft/).first()).toBeVisible({ timeout: 15_000 });
+});
+```
+
+- [ ] **Step 2: 跑 e2e**
+
+Run: `pnpm -F web test:e2e`
+Expected: 全 PASS(含既有全部 e2e;port 3002 被占時 `E2E_PORT=3012`)。
+
+- [ ] **Step 3: 全套單元 + 型別**
+
+Run: `pnpm -F @rfjs/form-builder test && pnpm -F @rfjs/form-builder-ui test && pnpm -F web test && pnpm typecheck`
+Expected: 全 PASS。
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/e2e/
+git commit -m "test(web): cover form-builder action buttons in e2e
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 9: 真渲染驗證 + PR(主 session 執行,非 subagent)
+
+**Files:** 無程式變更;產出截圖供使用者驗收。
+
+- [ ] **Step 1:** `pnpm -F web build` → `cd apps/web && pnpm exec next start -p 3005`。
+- [ ] **Step 2:** Playwright 腳本截圖(存 scratchpad;light + dark):
+  - Canvas 分頁:palette 有「Button」卡、畫布上三顆範例按鈕、inspector 開啟 button 卡顯示 Action 面板(type select/validate/variant)。
+  - Preview 分頁:按「Save draft」→ SubmissionPanel 顯示 `action: custom — save-draft` 與 data/meta;按 Submit(空必填)→ 擋下顯示錯誤。
+- [ ] **Step 3:** 截圖貼給使用者確認後 push + `gh pr create`(HOLD 不 merge)。PR 描述(英文)要點:button item kind + five actions、`{ data, meta }` envelope(breaking `onSubmit`,private packages)、api via injected fetcher + responseMap、inspector panel、changesets(form-builder minor 會發 npm)。

--- a/docs/superpowers/specs/2026-07-07-form-action-model-design.md
+++ b/docs/superpowers/specs/2026-07-07-form-action-model-design.md
@@ -118,7 +118,7 @@ metaProvider?: () => Record<string, unknown>;
   - clear:multi-select 現有 field keys;custom:name 輸入框;api:url、method select、fields multi-select、responseMap key-value 列表編輯、success/error 訊息文字。
 - Preview 分頁 `SubmissionPanel`:顯示最後一次動作的完整 `{ data, meta }`(含 `meta.action` 標示哪顆按鈕);api 在 preview 用內建 echo fetcher(回傳收到的 body,加 `{ echoedAt }`)讓 responseMap 可示範。
 - `SAMPLE_CONFIG` 加示範:主送出(submit)+ 存草稿(custom "save-draft")+ 搜尋列 inline 清除(clear)。
-- i18n:tool messages 加 palette/inspector 新鍵(en + zh-TW);engine 內建訊息(api 成功/失敗預設文案)走 LocalizedLabel 預設值。
+- i18n:palette/inspector 文案**沿用既有慣例(硬編英文)** —— 現有 settings-panel 與 KIND_META 全是英文,只為新面板 i18n 會不一致(整個 inspector 的 i18n 化留待日後一次做)。範例按鈕的 label 用 LocalizedLabel(en + zh-TW);api 成功/失敗訊息可配置 LocalizedLabel,缺省用英文預設文案。
 
 ## 5. 測試策略
 

--- a/docs/superpowers/specs/2026-07-07-form-action-model-design.md
+++ b/docs/superpowers/specs/2026-07-07-form-action-model-design.md
@@ -1,0 +1,138 @@
+# form-builder ② 動作/按鈕模型 — 設計規格
+
+日期:2026-07-07
+分支:`feat-form-actions`(獨立 worktree,基於 `origin/main` @ `fcfdc88`)
+狀態:設計已與使用者逐點確認(v1 動作全包含 api;按鈕 = item kind A 案;api 回應寫回欄位;metadata 全配置;驗證每顆可設)
+
+## 目標
+
+form-builder 系列(engine `@rfjs/form-builder` → renderer `@rfjs/form-builder-ui` → 工具 `apps/web/src/tools/form-builder`)新增**可配置按鈕**:
+
+1. **按鈕成為畫布 item**(新 `ItemKind: 'button'`):可拖放位置、可多顆、可與欄位同列。
+2. **五種動作**:`submit` / `reset` / `clear`(指定欄位)/ `custom`(命名事件)/ `api`(送值到 URL,回應可寫回欄位)。
+3. **統一 payload 信封**:所有帶資料的動作送 `{ data, meta }`;meta 含自動鍵 + 配置靜態鍵 + 執行期注入。
+4. **驗證語義**:每顆按鈕 `validate?: boolean`(submit 預設驗、api/custom 預設不驗、reset/clear 不適用)。
+5. **Builder 支援**:palette 按鈕卡 + inspector 依動作型別的配置面板 + SubmissionPanel 顯示動作 payload + 範例示範。
+
+## 非目標(v1 明確不做)
+
+- 不做 footer/actions 專屬區(B 案)—— 按鈕只以 item 形式存在;無按鈕時的預設 Submit 提供等效便利。
+- api 動作不內建 http client —— 一律走既有注入式 `fetcher`(`DataSourceFetcher`);無 fetcher 時 api 按鈕 disabled 並顯示提示。
+- 不做按鈕級權限/條件顯示(可用既有 item 條件顯示機制,如已存在;不另加)。
+- 不動 workbench、不動其他工具。
+
+## 相容性決策
+
+- `FormConfig` 新增欄位全部**選填**(`id?`、`meta?`、button item);舊 config 零遷移。
+- **表單中沒有任何 `button` item → ConfigForm 照現行為渲染預設 Submit 按鈕**(`submitLabel` prop 續用),完全向下相容。
+- **Breaking(已接受)**:`ConfigForm` 的 `onSubmit` 簽名由 `(values) => void` 改為 `({ data, meta }) => void`。影響面 = apps/web 自己(form-builder 系列為 private workspace package,不發布);apps/web 內所有呼叫端同 PR 修正。
+
+## 1. Engine schema(`packages/form-builder/src/types.ts` + zod schema)
+
+```ts
+export type ButtonActionType = 'submit' | 'reset' | 'clear' | 'custom' | 'api';
+
+export type ButtonAction =
+  | { type: 'submit' }
+  | { type: 'reset' }
+  | { type: 'clear'; fields: string[] }                 // 要清空的 field keys(至少 1)
+  | { type: 'custom'; name: string }                    // 宿主事件名(至少 1 字元)
+  | {
+      type: 'api';
+      url: string;
+      method?: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';  // 預設 POST
+      fields?: string[];                                 // 送出的 field keys;缺省 = 全部可見欄位
+      responseMap?: Record<string, string>;              // { "response 內取值路徑(dot path)": "目標 field key" }
+      messages?: { success?: LocalizedLabel; error?: LocalizedLabel };  // 缺省用內建文案
+    };
+
+export interface ButtonItem {
+  kind: 'button';
+  label: LocalizedLabel;
+  action: ButtonAction;
+  variant?: 'primary' | 'outline' | 'ghost' | 'destructive';  // 預設 primary(submit)/outline(其他)
+  validate?: boolean;  // 缺省:action.type === 'submit' → true,api/custom → false;reset/clear 忽略此欄
+}
+```
+
+- `ItemKind` 聯集加 `'button'`;`FormItem` 聯集加 `ButtonItem`;zod schema(`schema.ts`)同步以 discriminated union 驗證 `action`。
+- `FormConfig` 頂層新增:`id?: string`(→ `meta.formId`)、`meta?: Record<string, unknown>`(→ `meta.custom`)。
+- `config-to-zod` 不受影響(button 不是資料欄位,不進 zod 物件)。
+
+## 2. Payload 信封(`SubmissionMeta` 擴充,`form-builder-ui`)
+
+既有 `SubmissionMeta`(valid/errors/visibleKeys/schemaVersion)**擴充**:
+
+```ts
+export interface ActionMeta extends SubmissionMeta {
+  formId?: string;                       // config.id
+  timestamp: string;                     // ISO,動作觸發當下
+  action: { type: ButtonActionType; name?: string };  // name 僅 custom
+  custom?: Record<string, unknown>;      // config.meta 原樣
+  [key: string]: unknown;                // metaProvider 展開的動態鍵
+}
+```
+
+- 適用動作:`submit` / `custom` / `api` 的 payload 一律為 `{ data, meta: ActionMeta }`;`data` 沿用 `computePayload`(可見欄位)。
+- `metaProvider?: () => Record<string, unknown>` 為 ConfigForm 新 prop,執行期動態值(user、session…),展開合併進 meta(自動鍵優先,metaProvider 不得覆蓋 timestamp/action 等保留鍵)。
+- 預設 Submit(無 button item 的相容路徑)也走同一信封:`action: { type: 'submit' }`。
+- `onPayloadChange` 維持現行為與型別(live seam,不含 action)—— 不改,避免雙重 breaking。
+
+## 3. Renderer 行為(`packages/form-builder-ui/src/config-form.tsx`)
+
+新 props:
+
+```ts
+onSubmit: (payload: { data: Record<string, unknown>; meta: ActionMeta }) => void;   // 簽名變更
+onAction?: (name: string, payload: { data; meta: ActionMeta; response?: unknown }) => void;
+metaProvider?: () => Record<string, unknown>;
+```
+
+動作執行規則:
+
+| 動作 | 驗證(validate 生效時) | 行為 |
+|---|---|---|
+| `submit` | 預設驗 | RHF handleSubmit → `onSubmit({ data, meta })` |
+| `reset` | 不驗 | `form.reset(defaultValues)` |
+| `clear` | 不驗 | 指定 keys 逐一 `setValue`(文字類 `""`、其餘 `undefined`),`shouldDirty: true` |
+| `custom` | 預設不驗 | `onAction(action.name, { data, meta })` |
+| `api` | 預設不驗 | 見下 |
+
+- **驗證失敗** → RHF 顯示欄位錯誤,動作不發(與現行 submit 行為一致)。
+- **api 流程**:
+  1. 取值:`fields` 有列 → 只取列出的 keys(仍限可見欄位);缺省 → 全部可見欄位。
+  2. 經 `fetcher` 送出:複用 `DataSourceFetcher` 介面,request 帶 `{ url, method, body: { data, meta } }`(GET 時 data 掛 query 由宿主 fetcher 自行處理 —— 我們只傳結構,不拼 URL)。
+  3. 按鈕 pending:disabled + spinner(lucide `Loader2`);同表單同時只允許一顆 api 按鈕 in-flight。
+  4. 成功:按鈕旁顯示 `messages.success`(預設文案);`responseMap` 逐項以 dot path 取回應值 → `setValue` 到目標 field key(路徑取不到 → 跳過該項,不報錯);`onAction?.('api', { data, meta, response })`。
+  5. 失敗(fetcher throw / reject):按鈕旁顯示 `messages.error`(預設文案);**不另設失敗 callback** —— 統一走 `onAction('api', { data, meta, response: undefined })`,並在 meta 加 `apiError: string`(錯誤訊息)。
+  6. 無 `fetcher` prop:api 按鈕 render 成 disabled + title 提示(不 throw)。
+- **無任何 button item** → 尾端渲染預設 Submit(現行為),onSubmit 走新信封。
+
+## 4. Builder 工具(`apps/web/src/tools/form-builder/`)
+
+- `model.ts`:`Kind` 加 `"button"`;`KIND_META` 加按鈕卡(icon `MousePointerClick` 或類似,預設 span 3);cards↔FormConfig 對映攜帶 `button` 資料。
+- palette 加「按鈕」;新按鈕預設 `{ label: "Button", action: { type: "custom", name: "action-1" } }`。
+- inspector 新面板(依 `action.type` 切換):
+  - 共通:label(i18n 欄)、variant select、validate switch(reset/clear 時隱藏)。
+  - type select:submit/reset/clear/custom/api。
+  - clear:multi-select 現有 field keys;custom:name 輸入框;api:url、method select、fields multi-select、responseMap key-value 列表編輯、success/error 訊息文字。
+- Preview 分頁 `SubmissionPanel`:顯示最後一次動作的完整 `{ data, meta }`(含 `meta.action` 標示哪顆按鈕);api 在 preview 用內建 echo fetcher(回傳收到的 body,加 `{ echoedAt }`)讓 responseMap 可示範。
+- `SAMPLE_CONFIG` 加示範:主送出(submit)+ 存草稿(custom "save-draft")+ 搜尋列 inline 清除(clear)。
+- i18n:tool messages 加 palette/inspector 新鍵(en + zh-TW);engine 內建訊息(api 成功/失敗預設文案)走 LocalizedLabel 預設值。
+
+## 5. 測試策略
+
+- **engine**(`packages/form-builder`):zod schema 各 action 變體(合法/非法:clear 空 fields、custom 空 name、api 缺 url);ButtonItem 預設值語義。
+- **renderer**(`packages/form-builder-ui`):
+  - 無 button item → 預設 Submit + 新信封格式(formId/timestamp/action/custom/metaProvider 合併與保留鍵保護)。
+  - 各動作:submit 驗證擋下/通過、reset 回預設、clear 只清指定欄、custom 呼叫 onAction、validate=true 的 api 驗證擋下。
+  - api:mock fetcher —— 成功訊息 + responseMap 寫回(含 dot path 取不到跳過)、失敗訊息 + meta.apiError、pending disabled、無 fetcher 時 disabled。
+- **工具**(apps/web):palette 加按鈕卡、inspector 面板切換、SubmissionPanel 顯示 meta.action、範例含三顆按鈕。
+- **e2e**:一條 —— 進 form-builder Preview → 按 custom 按鈕 → submission panel 出現 `"action"` 與按鈕名。
+- 真渲染:`next build` + `next start` 截圖(light/dark)驗 palette/inspector/preview。
+
+## 6. 慣例
+
+- 獨立 worktree `feat-form-actions`;commit/PR 英文 conventional(subject 全小寫),結尾 `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`。
+- form-builder 系列為 private package → **無 changeset**。
+- PR 開好後 HOLD,使用者自行 merge。

--- a/docs/superpowers/specs/2026-07-07-form-action-model-design.md
+++ b/docs/superpowers/specs/2026-07-07-form-action-model-design.md
@@ -134,5 +134,8 @@ metaProvider?: () => Record<string, unknown>;
 ## 6. 慣例
 
 - 獨立 worktree `feat-form-actions`;commit/PR 英文 conventional(subject 全小寫),結尾 `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`。
-- form-builder 系列為 private package → **無 changeset**。
+- **Changeset(本次修正的規則,取代先前「private 無 changeset」慣例)**:有異動的 package 就寫 changeset —
+  - `@rfjs/form-builder`:**minor**(新增 ButtonItem/action schema;可發布,npm metadata 已齊備,下次 release 會上 npm)。
+  - `@rfjs/form-builder-ui`:**minor**(`"private": true`,changesets 只 version 不 publish;留下版本軌跡)。
+  - `apps/web` 為 app 非 package,不寫。
 - PR 開好後 HOLD,使用者自行 merge。

--- a/packages/form-builder-ui/src/config-form.spec.tsx
+++ b/packages/form-builder-ui/src/config-form.spec.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import { ConfigForm } from './config-form';
-import type { FormConfig, DataSource, UploadHandler, FileRef, SignatureTransport } from '@rfjs/form-builder';
+import type { FormConfig, DataSource, UploadHandler, FileRef, SignatureTransport, ButtonAction, ButtonItem } from '@rfjs/form-builder';
 
 // ---------------------------------------------------------------------------
 // Controllable ResizeObserver mock (used by responsive tests below).
@@ -976,5 +976,78 @@ describe('action meta envelope', () => {
     expect(meta.user).toBe('roy');
     expect(meta.action).toEqual({ type: 'submit' });   // 保留鍵未被覆蓋
     expect(meta.timestamp).not.toBe('HACKED');
+  });
+});
+
+describe('button items', () => {
+  const btn = (action: ButtonAction, extra?: Partial<ButtonItem>): FormConfig => ({
+    version: 1,
+    sections: [{
+      id: 's1',
+      rows: [{
+        id: 'r1',
+        items: [
+          { id: 'f1', kind: 'field', key: 'name', label: 'Name', component: 'Input', dataType: 'string', required: true },
+          { id: 'f2', kind: 'field', key: 'note', label: 'Note', component: 'Input', dataType: 'string', defaultValue: 'keep' },
+          { id: 'b1', kind: 'button', label: 'Go', action, ...extra },
+        ],
+      }],
+    }],
+  });
+
+  it('renders configured buttons and suppresses the default submit', () => {
+    render(<ConfigForm config={btn({ type: 'custom', name: 'x' })} onSubmit={vi.fn()} />);
+    expect(screen.getByRole('button', { name: 'Go' })).toBeTruthy();
+    expect(screen.queryByRole('button', { name: /^submit$/i })).toBeNull();
+  });
+
+  it('submit button validates by default and blocks invalid submit', async () => {
+    const onSubmit = vi.fn();
+    render(<ConfigForm config={btn({ type: 'submit' })} onSubmit={onSubmit} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Go' }));
+    await waitFor(() => expect(screen.getByText(/required|expected|invalid/i)).toBeTruthy());
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('submit button with valid values emits the envelope with action.type submit', async () => {
+    const onSubmit = vi.fn();
+    render(<ConfigForm config={btn({ type: 'submit' })} onSubmit={onSubmit} />);
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Roy' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Go' }));
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    expect(onSubmit.mock.calls[0]![0].meta.action).toEqual({ type: 'submit' });
+  });
+
+  it('custom button skips validation by default and calls onAction with the envelope', async () => {
+    const onAction = vi.fn();
+    render(<ConfigForm config={btn({ type: 'custom', name: 'save-draft' })} onSubmit={vi.fn()} onAction={onAction} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Go' }));   // name 空著也能發(不驗)
+    await waitFor(() => expect(onAction).toHaveBeenCalledTimes(1));
+    const [name, payload] = onAction.mock.calls[0]!;
+    expect(name).toBe('save-draft');
+    expect(payload.meta.action).toEqual({ type: 'custom', name: 'save-draft' });
+    expect(payload.meta.valid).toBe(false);   // meta 照實回報
+  });
+
+  it('custom button with validate: true blocks when invalid', async () => {
+    const onAction = vi.fn();
+    render(<ConfigForm config={btn({ type: 'custom', name: 'x' }, { validate: true })} onSubmit={vi.fn()} onAction={onAction} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Go' }));
+    await waitFor(() => expect(screen.getByText(/required|expected|invalid/i)).toBeTruthy());
+    expect(onAction).not.toHaveBeenCalled();
+  });
+
+  it('clear resets only the listed fields', async () => {
+    render(<ConfigForm config={btn({ type: 'clear', fields: ['name'] })} onSubmit={vi.fn()} defaultValues={{ name: 'Roy', note: 'keep' }} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Go' }));
+    await waitFor(() => expect((screen.getByLabelText('Name') as HTMLInputElement).value).toBe(''));
+    expect((screen.getByLabelText('Note') as HTMLInputElement).value).toBe('keep');
+  });
+
+  it('reset restores defaultValues', async () => {
+    render(<ConfigForm config={btn({ type: 'reset' })} onSubmit={vi.fn()} defaultValues={{ name: 'init', note: 'keep' }} />);
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'changed' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Go' }));
+    await waitFor(() => expect((screen.getByLabelText('Name') as HTMLInputElement).value).toBe('init'));
   });
 });

--- a/packages/form-builder-ui/src/config-form.spec.tsx
+++ b/packages/form-builder-ui/src/config-form.spec.tsx
@@ -1117,5 +1117,46 @@ describe('button items', () => {
       render(<ConfigForm config={apiCfg()} onSubmit={vi.fn()} />);
       expect(screen.getByRole('button', { name: 'Go' })).toHaveProperty('disabled', true);
     });
+
+    it('config change while in flight resets pending state and drops the late result', async () => {
+      let resolve!: (v: unknown) => void;
+      const fetcher = vi.fn().mockReturnValue(new Promise((r) => { resolve = r; }));
+      const onAction = vi.fn();
+      const cfg1 = apiCfg();
+      const { rerender } = render(
+        <ConfigForm config={cfg1} onSubmit={vi.fn()} onAction={onAction} fetcher={fetcher} />,
+      );
+      const button = screen.getByRole('button', { name: 'Go' });
+      fireEvent.click(button);
+      await waitFor(() => expect(button).toHaveProperty('disabled', true));
+
+      // Swap config mid-flight (different object identity, extra field) — simulates
+      // a parent re-render (e.g. wizard step change) while the api call is in flight.
+      const cfg2: FormConfig = {
+        ...cfg1,
+        sections: [{
+          ...cfg1.sections![0]!,
+          rows: [{
+            ...cfg1.sections![0]!.rows[0]!,
+            items: [
+              ...cfg1.sections![0]!.rows[0]!.items,
+              { id: 'f3', kind: 'field', key: 'extra', label: 'Extra', component: 'Input', dataType: 'string' },
+            ],
+          }],
+        }],
+      };
+      rerender(<ConfigForm config={cfg2} onSubmit={vi.fn()} onAction={onAction} fetcher={fetcher} />);
+
+      // pending state must be cleared by the config-change effect — button re-enabled.
+      await waitFor(() => expect(screen.getByRole('button', { name: 'Go' })).toHaveProperty('disabled', false));
+
+      // Late resolution must be dropped: no onAction, no success message.
+      await act(async () => {
+        resolve({});
+        await new Promise((r) => setTimeout(r, 0));
+      });
+      expect(onAction).not.toHaveBeenCalled();
+      expect(screen.queryByText(/success/i)).toBeNull();
+    });
   });
 });

--- a/packages/form-builder-ui/src/config-form.spec.tsx
+++ b/packages/form-builder-ui/src/config-form.spec.tsx
@@ -59,7 +59,9 @@ describe('ConfigForm', () => {
     render(<ConfigForm config={config} onSubmit={onSubmit} />);
     fireEvent.change(screen.getByRole('textbox', { name: 'Name' }), { target: { value: 'Ada' } });
     fireEvent.click(screen.getByRole('button', { name: /submit/i }));
-    await waitFor(() => expect(onSubmit).toHaveBeenCalledWith({ name: 'Ada', bio: undefined }));
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledOnce());
+    const payload = onSubmit.mock.calls[0]![0] as { data: Record<string, unknown> };
+    expect(payload.data).toEqual({ name: 'Ada', bio: undefined });
   });
 });
 
@@ -302,11 +304,9 @@ describe('conditional show/hide', () => {
     await waitFor(() => expect(screen.queryByLabelText('Admin Code')).toBeNull());
     // Submit → payload should NOT contain adminCode
     fireEvent.click(screen.getByRole('button', { name: /submit/i }));
-    await waitFor(() =>
-      expect(onSubmit).toHaveBeenCalledWith(
-        expect.not.objectContaining({ adminCode: expect.anything() }),
-      ),
-    );
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledOnce());
+    const payload = onSubmit.mock.calls[0]![0] as { data: Record<string, unknown> };
+    expect(payload.data).not.toHaveProperty('adminCode');
   });
 });
 
@@ -548,9 +548,9 @@ describe('FileUpload field', () => {
     await waitFor(() => expect(uploadHandler).toHaveBeenCalledOnce());
 
     fireEvent.click(screen.getByRole('button', { name: /submit/i }));
-    await waitFor(() =>
-      expect(onSubmit).toHaveBeenCalledWith({ doc: fileRef }),
-    );
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledOnce());
+    const payload = onSubmit.mock.calls[0]![0] as { data: Record<string, unknown> };
+    expect(payload.data).toEqual({ doc: fileRef });
   });
 
   it('calls onFileError when uploadHandler rejects', async () => {
@@ -930,5 +930,51 @@ describe('responsive container collapse', () => {
     // placed item (row 1) must appear before orphan (MAX_SAFE_INTEGER fallback)
     expect(items[0]!.getAttribute('data-item')).toBe('placed');
     expect(items[1]!.getAttribute('data-item')).toBe('orphan');
+  });
+});
+
+describe('action meta envelope', () => {
+  const cfg: FormConfig = {
+    version: 1,
+    id: 'leave-form',
+    meta: { source: 'web' },
+    fields: [{ key: 'name', label: 'Name', component: 'Input', dataType: 'string' }],
+  };
+
+  it('default submit emits { data, meta } with formId/timestamp/action/custom', async () => {
+    const onSubmit = vi.fn();
+    render(<ConfigForm config={cfg} onSubmit={onSubmit} />);
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Roy' } });
+    fireEvent.click(screen.getByRole('button', { name: /submit/i }));
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    const payload = onSubmit.mock.calls[0]![0] as { data: Record<string, unknown>; meta: Record<string, unknown> };
+    expect(payload.data).toEqual({ name: 'Roy' });
+    expect(payload.meta).toMatchObject({
+      formId: 'leave-form',
+      action: { type: 'submit' },
+      custom: { source: 'web' },
+      valid: true,
+      schemaVersion: 1,
+    });
+    expect(typeof payload.meta.timestamp).toBe('string');
+    expect(Number.isNaN(Date.parse(payload.meta.timestamp as string))).toBe(false);
+  });
+
+  it('metaProvider values merge in but cannot override reserved keys', async () => {
+    const onSubmit = vi.fn();
+    render(
+      <ConfigForm
+        config={cfg}
+        onSubmit={onSubmit}
+        metaProvider={() => ({ user: 'roy', action: 'HACKED', timestamp: 'HACKED' })}
+      />,
+    );
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'x' } });
+    fireEvent.click(screen.getByRole('button', { name: /submit/i }));
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    const meta = onSubmit.mock.calls[0]![0].meta as Record<string, unknown>;
+    expect(meta.user).toBe('roy');
+    expect(meta.action).toEqual({ type: 'submit' });   // 保留鍵未被覆蓋
+    expect(meta.timestamp).not.toBe('HACKED');
   });
 });

--- a/packages/form-builder-ui/src/config-form.spec.tsx
+++ b/packages/form-builder-ui/src/config-form.spec.tsx
@@ -1050,4 +1050,72 @@ describe('button items', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Go' }));
     await waitFor(() => expect((screen.getByLabelText('Name') as HTMLInputElement).value).toBe('init'));
   });
+
+  describe('api action', () => {
+    const apiCfg = (over?: Partial<Extract<ButtonAction, { type: 'api' }>>) =>
+      btn({ type: 'api', url: '/api/echo', ...over });
+
+    it('sends { url, method, body: { data, meta } } through the injected fetcher', async () => {
+      const fetcher = vi.fn().mockResolvedValue({ ok: true });
+      render(<ConfigForm config={apiCfg()} onSubmit={vi.fn()} fetcher={fetcher} defaultValues={{ name: 'Roy', note: 'n' }} />);
+      fireEvent.click(screen.getByRole('button', { name: 'Go' }));
+      await waitFor(() => expect(fetcher).toHaveBeenCalledTimes(1));
+      const req = fetcher.mock.calls[0]![0];
+      expect(req.url).toBe('/api/echo');
+      expect(req.method).toBe('POST');
+      expect(req.body.data).toEqual({ name: 'Roy', note: 'n' });
+      expect(req.body.meta.action).toEqual({ type: 'api' });
+    });
+
+    it('fields narrows the sent data', async () => {
+      const fetcher = vi.fn().mockResolvedValue({});
+      render(<ConfigForm config={apiCfg({ fields: ['name'] })} onSubmit={vi.fn()} fetcher={fetcher} defaultValues={{ name: 'Roy', note: 'n' }} />);
+      fireEvent.click(screen.getByRole('button', { name: 'Go' }));
+      await waitFor(() => expect(fetcher).toHaveBeenCalledTimes(1));
+      expect(fetcher.mock.calls[0]![0].body.data).toEqual({ name: 'Roy' });
+    });
+
+    it('success: shows message, maps response into fields, reports via onAction', async () => {
+      const fetcher = vi.fn().mockResolvedValue({ result: { display: 'mapped!' } });
+      const onAction = vi.fn();
+      render(
+        <ConfigForm
+          config={apiCfg({ responseMap: { 'result.display': 'note', 'missing.path': 'name' } })}
+          onSubmit={vi.fn()} onAction={onAction} fetcher={fetcher} defaultValues={{ name: 'keep', note: '' }}
+        />,
+      );
+      fireEvent.click(screen.getByRole('button', { name: 'Go' }));
+      await waitFor(() => expect(screen.getByText(/success/i)).toBeTruthy());
+      expect((screen.getByLabelText('Note') as HTMLInputElement).value).toBe('mapped!');
+      expect((screen.getByLabelText('Name') as HTMLInputElement).value).toBe('keep');   // 取不到 → 跳過
+      expect(onAction).toHaveBeenCalledWith('api', expect.objectContaining({ response: { result: { display: 'mapped!' } } }));
+    });
+
+    it('failure: shows error message and reports apiError via onAction', async () => {
+      const fetcher = vi.fn().mockRejectedValue(new Error('boom'));
+      const onAction = vi.fn();
+      render(<ConfigForm config={apiCfg()} onSubmit={vi.fn()} onAction={onAction} fetcher={fetcher} />);
+      fireEvent.click(screen.getByRole('button', { name: 'Go' }));
+      await waitFor(() => expect(screen.getByText(/failed/i)).toBeTruthy());
+      const payload = onAction.mock.calls[0]![1];
+      expect(payload.meta.apiError).toBe('boom');
+      expect(payload.response).toBeUndefined();
+    });
+
+    it('pending: button disabled while in flight', async () => {
+      let resolve!: (v: unknown) => void;
+      const fetcher = vi.fn().mockReturnValue(new Promise((r) => { resolve = r; }));
+      render(<ConfigForm config={apiCfg()} onSubmit={vi.fn()} fetcher={fetcher} />);
+      const button = screen.getByRole('button', { name: 'Go' });
+      fireEvent.click(button);
+      await waitFor(() => expect(button).toHaveProperty('disabled', true));
+      resolve({});
+      await waitFor(() => expect(button).toHaveProperty('disabled', false));
+    });
+
+    it('no fetcher: api button renders disabled', () => {
+      render(<ConfigForm config={apiCfg()} onSubmit={vi.fn()} />);
+      expect(screen.getByRole('button', { name: 'Go' })).toHaveProperty('disabled', true);
+    });
+  });
 });

--- a/packages/form-builder-ui/src/config-form.tsx
+++ b/packages/form-builder-ui/src/config-form.tsx
@@ -19,12 +19,22 @@ import {
   type SignatureTransport,
   type ButtonActionType,
   type ButtonItem,
+  type LocalizedLabel,
 } from '@rfjs/form-builder';
 import { useDataSource } from './use-data-source';
 import { useContainerBreakpoint } from './use-container-breakpoint';
 import { Label } from '@rfjs/web-ui/components/label';
 import { Button } from '@rfjs/web-ui/components/button';
 import { FieldControl } from './field-control';
+import { Loader2 } from 'lucide-react';
+
+// ---------------------------------------------------------------------------
+// getPath — dot-path lookup into an arbitrary (typically API response) value.
+// Returns undefined as soon as it walks off the object graph.
+// ---------------------------------------------------------------------------
+function getPath(obj: unknown, path: string): unknown {
+  return path.split('.').reduce<unknown>((acc, key) => (acc != null && typeof acc === 'object' ? (acc as Record<string, unknown>)[key] : undefined), obj);
+}
 
 // ---------------------------------------------------------------------------
 // SubmissionMeta — shape of the meta object emitted by onPayloadChange.
@@ -200,6 +210,9 @@ export function ConfigForm({ config, defaultValues, onSubmit, submitLabel = 'Sub
   // gate the submit button while a capture is pending.
   const [pendingCaptures, setPendingCaptures] = React.useState<Set<string>>(new Set());
 
+  // api 動作狀態:同表單同時只允許一顆 in-flight。
+  const [apiState, setApiState] = React.useState<{ itemId: string; status: 'pending' | 'success' | 'error' } | null>(null);
+
   const handleSignatureStatus = React.useCallback((fieldKey: string, status: string) => {
     setPendingCaptures((prev) => {
       const next = new Set(prev);
@@ -329,7 +342,24 @@ export function ConfigForm({ config, defaultValues, onSubmit, submitLabel = 'Sub
       });
       return;
     }
-    // action.type === 'api' — Task 4
+    if (action.type === 'api') {
+      if (!fetcher || apiState?.status === 'pending') return;
+      const sent = action.fields ? Object.fromEntries(Object.entries(data).filter(([k]) => action.fields!.includes(k))) : data;
+      const meta = buildActionMeta({ config, data: sent, action: { type: 'api' }, metaProvider });
+      setApiState({ itemId: item.id, status: 'pending' });
+      try {
+        const response = await fetcher({ url: action.url, method: action.method ?? 'POST', body: { data: sent, meta } });
+        for (const [path, targetKey] of Object.entries(action.responseMap ?? {})) {
+          const v = getPath(response, path);
+          if (v !== undefined) setValue(targetKey, v, { shouldDirty: true });
+        }
+        setApiState({ itemId: item.id, status: 'success' });
+        onAction?.('api', { data: sent, meta, response });
+      } catch (err) {
+        setApiState({ itemId: item.id, status: 'error' });
+        onAction?.('api', { data: sent, meta: { ...meta, apiError: err instanceof Error ? err.message : String(err) }, response: undefined });
+      }
+    }
   }
 
   function renderItem(item: FormItem, flow: 'v1' | 'section', cols: number, place?: { colStart: number; colSpan: number; row: number; rowSpan?: number }) {
@@ -365,11 +395,27 @@ export function ConfigForm({ config, defaultValues, onSubmit, submitLabel = 'Sub
 
     if (item.kind === 'button') {
       const variant = BUTTON_VARIANT[item.variant ?? (item.action.type === 'submit' ? 'primary' : 'outline')];
+      const isApi = item.action.type === 'api';
+      const mine = apiState?.itemId === item.id ? apiState : null;
+      const pending = mine?.status === 'pending';
+      const apiDisabled = isApi && (!fetcher || apiState?.status === 'pending');
+      const msg =
+        mine?.status === 'success' ? resolveLabel((item.action as { messages?: { success?: LocalizedLabel } }).messages?.success ?? 'Success', locale)
+        : mine?.status === 'error' ? resolveLabel((item.action as { messages?: { error?: LocalizedLabel } }).messages?.error ?? 'Request failed', locale)
+        : null;
       return (
-        <div key={item.id} data-item={item.id} className="flex min-w-0 items-end" style={place ? placementStyle(place) : fieldSpanStyle(undefined, flow, cols)}>
-          <Button type="button" variant={variant} disabled={pendingCaptures.size > 0} onClick={() => void runAction(item)}>
+        <div key={item.id} data-item={item.id} className="flex min-w-0 items-center gap-2" style={place ? placementStyle(place) : fieldSpanStyle(undefined, flow, cols)}>
+          <Button
+            type="button"
+            variant={variant}
+            disabled={pendingCaptures.size > 0 || apiDisabled}
+            title={isApi && !fetcher ? 'No fetcher provided' : undefined}
+            onClick={() => void runAction(item)}
+          >
+            {pending && <Loader2 className="mr-1 size-4 animate-spin" />}
             {resolveLabel(item.label, locale)}
           </Button>
+          {msg && <span className={`text-xs ${mine?.status === 'error' ? 'text-destructive' : 'text-muted-foreground'}`}>{msg}</span>}
         </div>
       );
     }

--- a/packages/form-builder-ui/src/config-form.tsx
+++ b/packages/form-builder-ui/src/config-form.tsx
@@ -18,6 +18,7 @@ import {
   type UploadHandler,
   type SignatureTransport,
   type ButtonActionType,
+  type ButtonItem,
 } from '@rfjs/form-builder';
 import { useDataSource } from './use-data-source';
 import { useContainerBreakpoint } from './use-container-breakpoint';
@@ -193,7 +194,7 @@ export function ConfigForm({ config, defaultValues, onSubmit, submitLabel = 'Sub
     return zodResolver(configToZod(visibleConfig))(values, ctx, opts);
   }, []);
 
-  const { control, handleSubmit, reset, watch, setError, formState: { errors } } = useForm({ resolver, defaultValues });
+  const { control, handleSubmit, reset, watch, setError, trigger, getValues, setValue, formState: { errors } } = useForm({ resolver, defaultValues });
 
   // Track which Signature fields have an active capture in progress — used to
   // gate the submit button while a capture is pending.
@@ -288,6 +289,49 @@ export function ConfigForm({ config, defaultValues, onSubmit, submitLabel = 'Sub
     return { gridColumn: `span ${span} / span ${span}`, minWidth: 0 };
   }
 
+  const BUTTON_VARIANT: Record<NonNullable<ButtonItem['variant']>, 'default' | 'outline' | 'ghost' | 'destructive'> = {
+    primary: 'default',
+    outline: 'outline',
+    ghost: 'ghost',
+    destructive: 'destructive',
+  };
+  // 文字類元件 clear 後給 ""，其餘 undefined（受控 input 需要字串空值）。
+  const TEXT_COMPONENTS = new Set(['Input', 'Textarea', 'Email']);
+
+  async function runAction(item: ButtonItem) {
+    const { action } = item;
+    if (action.type === 'reset') {
+      reset(defaultValues ?? {});
+      return;
+    }
+    if (action.type === 'clear') {
+      const byKey = new Map(collectFieldItems(config).map((f) => [f.key, f]));
+      for (const key of action.fields) {
+        const comp = byKey.get(key)?.component ?? 'Input';
+        setValue(key, TEXT_COMPONENTS.has(comp) ? '' : undefined, { shouldDirty: true });
+      }
+      return;
+    }
+    const doValidate = item.validate ?? (action.type === 'submit');
+    if (doValidate) {
+      const ok = await trigger();
+      if (!ok) return;   // RHF 顯示欄位錯誤，動作不發
+    }
+    const data = computePayload(getValues() as Record<string, unknown>, config);
+    if (action.type === 'submit') {
+      onSubmit({ data, meta: buildActionMeta({ config, data, action: { type: 'submit' }, metaProvider }) });
+      return;
+    }
+    if (action.type === 'custom') {
+      onAction?.(action.name, {
+        data,
+        meta: buildActionMeta({ config, data, action: { type: 'custom', name: action.name }, metaProvider }),
+      });
+      return;
+    }
+    // action.type === 'api' — Task 4
+  }
+
   function renderItem(item: FormItem, flow: 'v1' | 'section', cols: number, place?: { colStart: number; colSpan: number; row: number; rowSpan?: number }) {
     const vals = values as Record<string, unknown>;
 
@@ -315,6 +359,17 @@ export function ConfigForm({ config, defaultValues, onSubmit, submitLabel = 'Sub
           ) : (
             resolveLabel(item.text, locale)
           )}
+        </div>
+      );
+    }
+
+    if (item.kind === 'button') {
+      const variant = BUTTON_VARIANT[item.variant ?? (item.action.type === 'submit' ? 'primary' : 'outline')];
+      return (
+        <div key={item.id} data-item={item.id} className="flex min-w-0 items-end" style={place ? placementStyle(place) : fieldSpanStyle(undefined, flow, cols)}>
+          <Button type="button" variant={variant} disabled={pendingCaptures.size > 0} onClick={() => void runAction(item)}>
+            {resolveLabel(item.label, locale)}
+          </Button>
         </div>
       );
     }
@@ -360,6 +415,12 @@ export function ConfigForm({ config, defaultValues, onSubmit, submitLabel = 'Sub
   const sections = normalizeToSections(config);
   // v1 (fields[]) → flat grid (one field per implicit row); v2 (sections[]) → flex rows.
   const isV2 = config.sections !== undefined;
+  // When the config declares any button item, it owns the action affordances —
+  // the default gradient Submit button is suppressed in favor of configured buttons.
+  const hasButtons = React.useMemo(
+    () => normalizeToSections(config).some((s) => s.rows.some((r) => r.items.some((i) => i.kind === 'button'))),
+    [config],
+  );
   // Use the first section's columns for the overall form grid (v1 back-compat).
   const columns = config.columns ?? sections[0]?.columns ?? 1;
 
@@ -462,16 +523,18 @@ export function ConfigForm({ config, defaultValues, onSubmit, submitLabel = 'Sub
           </React.Fragment>
         );
       })}
-      <div style={{ gridColumn: '1 / -1' }}>
-        <Button
-          type="submit"
-          disabled={pendingCaptures.size > 0}
-          className="self-start border-0 text-white"
-          style={{ background: 'linear-gradient(180deg,#5b8cff,#4a78ee)', boxShadow: '0 6px 16px rgba(74,120,238,.3)' }}
-        >
-          {submitLabel}
-        </Button>
-      </div>
+      {!hasButtons && (
+        <div style={{ gridColumn: '1 / -1' }}>
+          <Button
+            type="submit"
+            disabled={pendingCaptures.size > 0}
+            className="self-start border-0 text-white"
+            style={{ background: 'linear-gradient(180deg,#5b8cff,#4a78ee)', boxShadow: '0 6px 16px rgba(74,120,238,.3)' }}
+          >
+            {submitLabel}
+          </Button>
+        </div>
+      )}
     </form>
   );
 }

--- a/packages/form-builder-ui/src/config-form.tsx
+++ b/packages/form-builder-ui/src/config-form.tsx
@@ -19,7 +19,6 @@ import {
   type SignatureTransport,
   type ButtonActionType,
   type ButtonItem,
-  type LocalizedLabel,
 } from '@rfjs/form-builder';
 import { useDataSource } from './use-data-source';
 import { useContainerBreakpoint } from './use-container-breakpoint';
@@ -213,6 +212,13 @@ export function ConfigForm({ config, defaultValues, onSubmit, submitLabel = 'Sub
   // api 動作狀態:同表單同時只允許一顆 in-flight。
   const [apiState, setApiState] = React.useState<{ itemId: string; status: 'pending' | 'success' | 'error' } | null>(null);
 
+  // Bumps whenever `config` changes or the component unmounts. `runAction`'s api branch
+  // captures the epoch before its `await fetcher(...)` and bails out (no setState/onAction)
+  // if the epoch has moved on by the time the promise settles — guards against a stale
+  // continuation acting after unmount or a config swap (same pattern as use-data-source's
+  // `active` flag, generalized to also cover config changes, not just unmount).
+  const runEpoch = React.useRef(0);
+
   const handleSignatureStatus = React.useCallback((fieldKey: string, status: string) => {
     setPendingCaptures((prev) => {
       const next = new Set(prev);
@@ -232,7 +238,18 @@ export function ConfigForm({ config, defaultValues, onSubmit, submitLabel = 'Sub
   React.useEffect(() => {
     reset(defaultValues ?? {});
     setPendingCaptures(new Set());
+    // A config swap invalidates any in-flight api action: clear its pending/success/error
+    // state (otherwise the button stays disabled forever) and bump the epoch so a late
+    // fetcher resolution can't resurrect it.
+    setApiState(null);
+    runEpoch.current += 1;
   }, [config]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Also bump the epoch on unmount so an in-flight api action's continuation never calls
+  // setState/onAction after the component is gone.
+  React.useEffect(() => () => {
+    runEpoch.current += 1;
+  }, []);
 
   // Subscribe to all form values to decide which items to RENDER (live show/hide).
   const values = watch();
@@ -346,9 +363,11 @@ export function ConfigForm({ config, defaultValues, onSubmit, submitLabel = 'Sub
       if (!fetcher || apiState?.status === 'pending') return;
       const sent = action.fields ? Object.fromEntries(Object.entries(data).filter(([k]) => action.fields!.includes(k))) : data;
       const meta = buildActionMeta({ config, data: sent, action: { type: 'api' }, metaProvider });
+      const epoch = runEpoch.current;
       setApiState({ itemId: item.id, status: 'pending' });
       try {
         const response = await fetcher({ url: action.url, method: action.method ?? 'POST', body: { data: sent, meta } });
+        if (epoch !== runEpoch.current) return;   // unmounted or config swapped mid-flight — drop the result
         for (const [path, targetKey] of Object.entries(action.responseMap ?? {})) {
           const v = getPath(response, path);
           if (v !== undefined) setValue(targetKey, v, { shouldDirty: true });
@@ -356,6 +375,7 @@ export function ConfigForm({ config, defaultValues, onSubmit, submitLabel = 'Sub
         setApiState({ itemId: item.id, status: 'success' });
         onAction?.('api', { data: sent, meta, response });
       } catch (err) {
+        if (epoch !== runEpoch.current) return;   // unmounted or config swapped mid-flight — drop the result
         setApiState({ itemId: item.id, status: 'error' });
         onAction?.('api', { data: sent, meta: { ...meta, apiError: err instanceof Error ? err.message : String(err) }, response: undefined });
       }
@@ -399,9 +419,10 @@ export function ConfigForm({ config, defaultValues, onSubmit, submitLabel = 'Sub
       const mine = apiState?.itemId === item.id ? apiState : null;
       const pending = mine?.status === 'pending';
       const apiDisabled = isApi && (!fetcher || apiState?.status === 'pending');
+      const apiMessages = item.action.type === 'api' ? item.action.messages : undefined;
       const msg =
-        mine?.status === 'success' ? resolveLabel((item.action as { messages?: { success?: LocalizedLabel } }).messages?.success ?? 'Success', locale)
-        : mine?.status === 'error' ? resolveLabel((item.action as { messages?: { error?: LocalizedLabel } }).messages?.error ?? 'Request failed', locale)
+        mine?.status === 'success' ? resolveLabel(apiMessages?.success ?? 'Success', locale)
+        : mine?.status === 'error' ? resolveLabel(apiMessages?.error ?? 'Request failed', locale)
         : null;
       return (
         <div key={item.id} data-item={item.id} className="flex min-w-0 items-center gap-2" style={place ? placementStyle(place) : fieldSpanStyle(undefined, flow, cols)}>

--- a/packages/form-builder-ui/src/config-form.tsx
+++ b/packages/form-builder-ui/src/config-form.tsx
@@ -17,6 +17,7 @@ import {
   type DataSourceFetcher,
   type UploadHandler,
   type SignatureTransport,
+  type ButtonActionType,
 } from '@rfjs/form-builder';
 import { useDataSource } from './use-data-source';
 import { useContainerBreakpoint } from './use-container-breakpoint';
@@ -32,6 +33,56 @@ export interface SubmissionMeta {
   errors: Record<string, string>;
   visibleKeys: string[];
   schemaVersion?: number;
+}
+
+// ---------------------------------------------------------------------------
+// ActionMeta — envelope emitted alongside `data` for onSubmit/onAction. Extends
+// SubmissionMeta with action provenance (which button fired), the form's
+// identity/custom metadata, and a timestamp.
+// ---------------------------------------------------------------------------
+export interface ActionMeta extends SubmissionMeta {
+  /** FormConfig.id (when set). */
+  formId?: string;
+  /** ISO timestamp at the moment the action fired. */
+  timestamp: string;
+  /** Which action fired (name only for `custom`). */
+  action: { type: ButtonActionType; name?: string };
+  /** FormConfig.meta, passed through verbatim. */
+  custom?: Record<string, unknown>;
+  /** Set when an `api` action's fetcher rejected. */
+  apiError?: string;
+  /** metaProvider-injected runtime keys. */
+  [key: string]: unknown;
+}
+
+/** Builds the meta envelope for an action. Reserved keys always win over metaProvider output. */
+export function buildActionMeta(opts: {
+  config: FormConfig;
+  data: Record<string, unknown>;
+  action: { type: ButtonActionType; name?: string };
+  metaProvider?: () => Record<string, unknown>;
+}): ActionMeta {
+  const { config, data, action, metaProvider } = opts;
+  const visibleFieldItems = collectFieldItems(config).filter((f) => evaluateConditional(f.conditional, data));
+  const parsed = configToZod({ version: config.version, fields: visibleFieldItems }).safeParse(data);
+  const errors: Record<string, string> = {};
+  if (!parsed.success) {
+    for (const issue of parsed.error.issues) {
+      const k = String(issue.path[0]);
+      if (k && !errors[k]) errors[k] = issue.message;
+    }
+  }
+  return {
+    ...(metaProvider ? metaProvider() : {}),
+    valid: parsed.success,
+    errors,
+    visibleKeys: Object.keys(data),
+    schemaVersion: config.version,
+    ...(config.id !== undefined ? { formId: config.id } : {}),
+    timestamp: new Date().toISOString(),
+    action,
+    ...(config.meta !== undefined ? { custom: config.meta } : {}),
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -82,7 +133,7 @@ export interface ConfigFormProps {
    */
   config: FormConfig;
   defaultValues?: Record<string, unknown>;
-  onSubmit: (values: Record<string, unknown>) => void;
+  onSubmit: (payload: { data: Record<string, unknown>; meta: ActionMeta }) => void;
   submitLabel?: string;
   /** BCP-47 locale used to resolve `LocalizedLabel` field labels. Defaults to `'en'`. */
   locale?: string;
@@ -113,9 +164,13 @@ export interface ConfigFormProps {
    * Only wired up (and triggers an effect) when provided.
    */
   onPayloadChange?: (p: { data: Record<string, unknown>; meta: SubmissionMeta }) => void;
+  /** Supplies extra runtime keys (e.g. user/session info) merged into every `ActionMeta`. */
+  metaProvider?: () => Record<string, unknown>;
+  /** Called for `custom`/`api` button actions with the action name and its payload. */
+  onAction?: (name: string, payload: { data: Record<string, unknown>; meta: ActionMeta; response?: unknown }) => void;
 }
 
-export function ConfigForm({ config, defaultValues, onSubmit, submitLabel = 'Submit', locale = 'en', fetcher, uploadHandler, signatureTransport, onPayloadChange }: ConfigFormProps) {
+export function ConfigForm({ config, defaultValues, onSubmit, submitLabel = 'Submit', locale = 'en', fetcher, uploadHandler, signatureTransport, onPayloadChange, metaProvider, onAction }: ConfigFormProps) {
   // Container ref for ResizeObserver-driven responsive collapse.
   const rootRef = React.useRef<HTMLFormElement>(null);
   const stackBelow = config.responsive?.stackBelow ?? 640;
@@ -336,7 +391,8 @@ export function ConfigForm({ config, defaultValues, onSubmit, submitLabel = 'Sub
     <form
       ref={rootRef}
       onSubmit={handleSubmit((all) => {
-        onSubmit(computePayload(all as Record<string, unknown>, config));
+        const data = computePayload(all as Record<string, unknown>, config);
+        onSubmit({ data, meta: buildActionMeta({ config, data, action: { type: 'submit' }, metaProvider }) });
       })}
       className="grid gap-4"
       style={{

--- a/packages/form-builder-ui/src/item-editor.tsx
+++ b/packages/form-builder-ui/src/item-editor.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import * as React from 'react';
-import { Trash2, ChevronRight, Type, AlignLeft, Minus, MoveVertical, Sparkles } from 'lucide-react';
+import { Trash2, ChevronRight, Type, AlignLeft, Minus, MoveVertical, Sparkles, MousePointerClick } from 'lucide-react';
 import type { FieldItem, ContentItem, DividerItem, SpacerItem, AiNoteItem, FormItem, ItemKind, SpacerSize } from '@rfjs/form-builder';
 import { Input } from '@rfjs/web-ui/components/input';
 import { Textarea } from '@rfjs/web-ui/components/textarea';
@@ -35,6 +35,7 @@ const KIND_META: Record<ItemKind, KindMeta> = {
   'ai-note': { label: 'AI Note', Icon: Sparkles, color: '#d9a441' },
   divider: { label: 'Divider', Icon: Minus, color: '#6b7280' },
   spacer: { label: 'Spacer', Icon: MoveVertical, color: '#6b7280' },
+  button: { label: 'Button', Icon: MousePointerClick, color: '#10b981' },
 };
 
 const PILL_COLORS: Record<string, string> = {

--- a/packages/form-builder/src/config-schema.spec.ts
+++ b/packages/form-builder/src/config-schema.spec.ts
@@ -498,3 +498,45 @@ describe('FormConfig responsive', () => {
     expect(formConfigSchema.safeParse({ version: 1, sections: [{ id: 's', title: 'S', rows: [] }] }).success).toBe(true);
   });
 });
+
+describe('button items', () => {
+  const base = { version: 1, sections: [{ id: 's1', rows: [{ id: 'r1', items: [] as unknown[] }] }] };
+  const withItem = (item: unknown) => ({ ...base, sections: [{ id: 's1', rows: [{ id: 'r1', items: [item] }] }] });
+
+  it('accepts each action variant', () => {
+    const actions = [
+      { type: 'submit' },
+      { type: 'reset' },
+      { type: 'clear', fields: ['a'] },
+      { type: 'custom', name: 'save-draft' },
+      { type: 'api', url: '/x', method: 'PATCH', fields: ['a'], responseMap: { 'r.total': 'total' }, messages: { success: 'ok', error: { en: 'no', 'zh-TW': '失敗' } } },
+    ];
+    for (const action of actions) {
+      const r = formConfigSchema.safeParse(withItem({ id: 'b1', kind: 'button', label: 'Go', action }));
+      expect(r.success, JSON.stringify(action)).toBe(true);
+    }
+  });
+
+  it('rejects invalid buttons: clear w/o fields, custom empty name, api w/o url, unknown type', () => {
+    const bad = [
+      { type: 'clear', fields: [] },
+      { type: 'custom', name: '' },
+      { type: 'api' },
+      { type: 'nope' },
+    ];
+    for (const action of bad) {
+      const r = formConfigSchema.safeParse(withItem({ id: 'b1', kind: 'button', label: 'Go', action }));
+      expect(r.success, JSON.stringify(action)).toBe(false);
+    }
+  });
+
+  it('accepts optional variant/validate and top-level id/meta', () => {
+    const cfg = {
+      ...withItem({ id: 'b1', kind: 'button', label: 'Go', action: { type: 'submit' }, variant: 'outline', validate: false }),
+      id: 'leave-form',
+      meta: { source: 'web' },
+    };
+    const r = formConfigSchema.safeParse(cfg);
+    expect(r.success).toBe(true);
+  });
+});

--- a/packages/form-builder/src/config-schema.ts
+++ b/packages/form-builder/src/config-schema.ts
@@ -26,7 +26,7 @@ const conditionalSchema: ZodTypeAny = z.object({
 const dataSourceSchema = z.object({
   request: z.object({
     url: z.string(),
-    method: z.enum(['GET', 'POST', 'PUT', 'DELETE']).optional(),
+    method: z.enum(['GET', 'POST', 'PUT', 'PATCH', 'DELETE']).optional(),
     headers: z.record(z.string(), z.string()).optional(),
     body: z.unknown().optional(),
   }),
@@ -140,12 +140,37 @@ const aiNoteItemSchema = z.object({
   text: z.string(),
 });
 
+const buttonActionSchema = z.discriminatedUnion('type', [
+  z.object({ type: z.literal('submit') }),
+  z.object({ type: z.literal('reset') }),
+  z.object({ type: z.literal('clear'), fields: z.array(z.string().min(1)).min(1) }),
+  z.object({ type: z.literal('custom'), name: z.string().min(1) }),
+  z.object({
+    type: z.literal('api'),
+    url: z.string().min(1),
+    method: z.enum(['GET', 'POST', 'PUT', 'PATCH', 'DELETE']).optional(),
+    fields: z.array(z.string().min(1)).optional(),
+    responseMap: z.record(z.string(), z.string()).optional(),
+    messages: z.object({ success: localizedLabelSchema.optional(), error: localizedLabelSchema.optional() }).optional(),
+  }),
+]);
+
+const buttonItemSchema = z.object({
+  id: z.string().min(1),
+  kind: z.literal('button'),
+  label: localizedLabelSchema,
+  action: buttonActionSchema,
+  variant: z.enum(['primary', 'outline', 'ghost', 'destructive']).optional(),
+  validate: z.boolean().optional(),
+});
+
 const formItemSchema = z.discriminatedUnion('kind', [
   fieldItemSchema,
   contentItemSchema,
   dividerItemSchema,
   spacerItemSchema,
   aiNoteItemSchema,
+  buttonItemSchema,
 ]);
 const gridPlacementSchema = z.object({
   itemId: z.string().min(1),
@@ -170,6 +195,8 @@ const formSectionSchema = z.object({
 export const FormConfigSchema: ZodType<FormConfig> = z
   .object({
     version: z.number().int(),
+    id: z.string().min(1).optional(),
+    meta: z.record(z.string(), z.unknown()).optional(),
     fields: z.array(fieldConfigSchema).optional(),
     sections: z.array(formSectionSchema).optional(),
     columns: z.union([z.literal(1), z.literal(2), z.literal(3), z.literal(4)]).optional(),

--- a/packages/form-builder/src/tree-ops.spec.ts
+++ b/packages/form-builder/src/tree-ops.spec.ts
@@ -87,6 +87,11 @@ describe('makeItem', () => {
     const item = makeItem('ai-note');
     expect(item).toMatchObject({ kind: 'ai-note' });
   });
+
+  it('makeItem(button) has kind button with a custom default action (not submit)', () => {
+    const item = makeItem('button');
+    expect(item).toMatchObject({ kind: 'button', label: 'Button', action: { type: 'custom', name: 'action-1' } });
+  });
 });
 
 // --- addItem ---

--- a/packages/form-builder/src/tree-ops.ts
+++ b/packages/form-builder/src/tree-ops.ts
@@ -46,6 +46,8 @@ export function makeItem(kind: ItemKind, seed?: Omit<Partial<FieldItem>, 'id' | 
       return { id, kind: 'spacer' };
     case 'ai-note':
       return { id, kind: 'ai-note', text: '' };
+    case 'button':
+      return { id, kind: 'button', label: 'Button', action: { type: 'custom', name: 'action-1' } };
   }
 }
 

--- a/packages/form-builder/src/types.ts
+++ b/packages/form-builder/src/types.ts
@@ -6,7 +6,7 @@ export type ScalarType = 'string' | 'numeric' | 'date' | 'boolean';
 // --- DataSource types ---
 export interface DataSourceRequest {
   url: string;
-  method?: 'GET' | 'POST' | 'PUT' | 'DELETE';
+  method?: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
   headers?: Record<string, string>;
   body?: unknown;
 }
@@ -81,7 +81,7 @@ export interface FieldConfig {
   fileUpload?: { accept?: string; multiple?: boolean; maxSize?: number };
 }
 
-export type ItemKind = 'field' | 'content' | 'divider' | 'spacer' | 'ai-note';
+export type ItemKind = 'field' | 'content' | 'divider' | 'spacer' | 'ai-note' | 'button';
 export type SpacerSize = 'sm' | 'md' | 'lg';
 
 export interface FieldItem extends FieldConfig {
@@ -100,7 +100,33 @@ export interface ContentItem {
 export interface DividerItem { id: string; kind: 'divider'; conditional?: ConditionalRule; }
 export interface SpacerItem { id: string; kind: 'spacer'; size?: SpacerSize; conditional?: ConditionalRule; }
 export interface AiNoteItem { id: string; kind: 'ai-note'; text: string; }
-export type FormItem = FieldItem | ContentItem | DividerItem | SpacerItem | AiNoteItem;
+
+export type ButtonActionType = 'submit' | 'reset' | 'clear' | 'custom' | 'api';
+
+export type ButtonAction =
+  | { type: 'submit' }
+  | { type: 'reset' }
+  | { type: 'clear'; fields: string[] }
+  | { type: 'custom'; name: string }
+  | {
+      type: 'api';
+      url: string;
+      method?: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';   // default POST
+      fields?: string[];                                       // omit = all visible fields
+      responseMap?: Record<string, string>;                    // response dot-path → target field key
+      messages?: { success?: LocalizedLabel; error?: LocalizedLabel };
+    };
+
+export interface ButtonItem {
+  id: string;
+  kind: 'button';
+  label: LocalizedLabel;
+  action: ButtonAction;
+  variant?: 'primary' | 'outline' | 'ghost' | 'destructive';   // default: submit→primary, others→outline
+  validate?: boolean;   // default: submit→true, api/custom→false; ignored for reset/clear
+}
+
+export type FormItem = FieldItem | ContentItem | DividerItem | SpacerItem | AiNoteItem | ButtonItem;
 
 /** Explicit 12-column-grid placement of a single item (positioned by its `id`). */
 export interface GridPlacement {
@@ -124,6 +150,8 @@ export interface FormSection { id: string; title?: LocalizedLabel; rows: FormRow
 
 export interface FormConfig {
   version: number;
+  id?: string;                        // → ActionMeta.formId
+  meta?: Record<string, unknown>;     // → ActionMeta.custom
   fields?: FieldConfig[];          // v1 (back-compat)
   sections?: FormSection[];        // v2
   columns?: 1 | 2 | 3 | 4;        // v1 grid (back-compat)


### PR DESCRIPTION
## Summary

form-builder gains **configurable buttons**: a new engine item kind `button` whose `ButtonAction` decides what the button does, plus a unified `{ data, meta }` payload envelope for everything a form emits.

- **Engine (`@rfjs/form-builder`, minor)** — `ButtonItem` (`kind: 'button'`, label/variant/validate) with a `ButtonAction` union: `submit` / `reset` / `clear(fields)` / `custom(name)` / `api(url, method, fields, responseMap, messages)`; optional top-level `FormConfig.id` + `FormConfig.meta`; `DataSourceRequest.method` gains `PATCH`.
- **Renderer (`@rfjs/form-builder-ui`, minor)** — ConfigForm renders button items (variant-mapped to web-ui Button) and executes actions: per-button `validate` gating (submit defaults on, api/custom off), reset/clear semantics, `custom` → new `onAction(name, payload)` callback, `api` → injected `fetcher` with single-in-flight pending state, success/error messages, `responseMap` dot-path write-back into fields, `meta.apiError` on failure, and an epoch guard against unmount/config-swap races. **Breaking:** `onSubmit` now receives `{ data, meta: ActionMeta }` instead of bare values (all existing call sites were no-ops; envelope adds `formId`/`timestamp`/`action`/`custom` + `metaProvider` runtime injection with protected reserved keys). Forms with **no** button items keep the exact previous default-Submit behavior.
- **Tool (apps/web)** — Button palette card, inspector Action panel (per-type config incl. clear field picker and api responseMap editor), SubmissionPanel shows which action fired (+ apiError), Preview wires a merged fetcher (echo for api actions, sample data for dataSource), sample gains Submit request / Save draft / Clear buttons.

## Review notes (accepted, from final whole-branch review)

- Inspector's in-progress states (e.g. `clear` with no fields picked yet) are schema-invalid until completed — harmless on canvas/preview, but the JSON tab refuses to rebuild while one exists; noted for a follow-up.
- For `api` actions with a `fields` subset, `meta.valid/errors` describe the sent subset (not the whole form) — internally consistent, semantic edge noted.
- api action path is unit-covered (echo fetcher + responseMap tests); the sample has no api button, so no click-driven e2e for it.
- Minor style nits (quote style, a redundant useCallback) left for a cleanup pass.

## Test plan

- Unit: 662 specs pass — engine 169 (schema variants, makeItem), renderer 251 (envelope/reserved keys, all five actions, api success/failure/pending/no-fetcher/unmount-race), web 242 (model round-trip, inspector panels incl. response-map row regression, preview wiring).
- E2E: 11/11 (`pnpm -F web test:e2e`) incl. new "custom action button surfaces its payload".
- Real render verified (`next build` + `next start`, light + dark): palette card, canvas buttons, inspector Action panel, preview buttons with variants, submission panel showing `custom — save-draft`, invalid submit blocked with field errors.
- Changesets: `@rfjs/form-builder` **minor** (publishable — will go to npm on the next release train), `@rfjs/form-builder-ui` **minor** (private, version-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)