### PR TITLE
feat(form-builder): result item kind for api response display

### DIFF
--- a/.changeset/form-result-item-engine.md
+++ b/.changeset/form-result-item-engine.md
@@ -1,0 +1,5 @@
+---
+"@rfjs/form-builder": minor
+---
+
+Add `ResultItem` (`kind: 'result'`): an api-response display area with `mode: 'card' | 'json' | 'table'` (table reserved for @rfjs/table-builder), optional source button binding, dot-path extraction, and card item cap.

--- a/.changeset/form-result-item-ui.md
+++ b/.changeset/form-result-item-ui.md
@@ -1,0 +1,5 @@
+---
+"@rfjs/form-builder-ui": minor
+---
+
+ConfigForm renders `result` items: api-response display areas with card / json modes (table placeholder pending @rfjs/table-builder), source-button binding, dot-path extraction, and empty / loading / error states.

--- a/apps/web/e2e/form-builder.e2e.ts
+++ b/apps/web/e2e/form-builder.e2e.ts
@@ -8,3 +8,10 @@ test("preview: custom action button surfaces its payload in the submission panel
   await page.getByRole("button", { name: /save draft/i }).click();
   await expect(page.getByText(/save-draft/).first()).toBeVisible({ timeout: 15_000 });
 });
+
+test("preview: query api button renders the echoed response in the result card", async ({ page }) => {
+  await page.goto(URL);
+  await page.getByRole("button", { name: "Preview", exact: true }).click();
+  await page.getByRole("button", { name: /^query$/i }).click();
+  await expect(page.locator('[data-item="res_query"]')).toContainText("name", { timeout: 15_000 });
+});

--- a/apps/web/src/tools/form-builder/inspector/result.spec.tsx
+++ b/apps/web/src/tools/form-builder/inspector/result.spec.tsx
@@ -40,4 +40,21 @@ describe("ResultSection", () => {
     fireEvent.change(screen.getByLabelText(/empty text/i), { target: { value: "Nothing" } });
     expect(onChange).toHaveBeenCalledWith({ emptyText: "Nothing" });
   });
+
+  it("dangling sourceId renders a visible missing option", () => {
+    const onChange = vi.fn();
+    render(<ResultSection card={resCard({ sourceId: "ghost" })} onChange={onChange} apiButtons={apiButtons} />);
+    const select = screen.getByLabelText(/source/i) as HTMLSelectElement;
+    expect(select.value).toBe("ghost");
+    expect(screen.getByText("missing: ghost")).toBeTruthy();
+    fireEvent.change(select, { target: { value: "" } });
+    expect(onChange).toHaveBeenCalledWith({ sourceId: undefined });
+  });
+
+  it("maxItems rejects non-integers", () => {
+    const onChange = vi.fn();
+    render(<ResultSection card={resCard({ mode: "card" })} onChange={onChange} apiButtons={apiButtons} />);
+    fireEvent.change(screen.getByLabelText(/max items/i), { target: { value: "5.5" } });
+    expect(onChange).toHaveBeenCalledWith({ maxItems: undefined });
+  });
 });

--- a/apps/web/src/tools/form-builder/inspector/result.spec.tsx
+++ b/apps/web/src/tools/form-builder/inspector/result.spec.tsx
@@ -1,0 +1,43 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { Card } from "../model";
+import { ResultSection } from "./result";
+
+const resCard = (over?: Partial<Card>): Card => ({
+  id: "res1", groupId: "g1", kind: "result", label: "Result",
+  mode: "json", col: 1, span: 12, row: 1, ...over,
+});
+const apiButtons = [{ id: "btn_query", label: "Query" }];
+
+describe("ResultSection", () => {
+  it("mode select writes through; maxItems only visible for card mode", () => {
+    const onChange = vi.fn();
+    const { rerender } = render(<ResultSection card={resCard()} onChange={onChange} apiButtons={apiButtons} />);
+    expect(screen.queryByLabelText(/max items/i)).toBeNull();
+    fireEvent.change(screen.getByLabelText(/^mode$/i), { target: { value: "card" } });
+    expect(onChange).toHaveBeenCalledWith({ mode: "card" });
+    rerender(<ResultSection card={resCard({ mode: "card" })} onChange={onChange} apiButtons={apiButtons} />);
+    expect(screen.getByLabelText(/max items/i)).toBeTruthy();
+  });
+
+  it("source select lists api buttons plus the unbound option", () => {
+    const onChange = vi.fn();
+    render(<ResultSection card={resCard()} onChange={onChange} apiButtons={apiButtons} />);
+    const select = screen.getByLabelText(/source/i) as HTMLSelectElement;
+    expect([...select.options].map((o) => o.text)).toEqual(["Last api response", "Query"]);
+    fireEvent.change(select, { target: { value: "btn_query" } });
+    expect(onChange).toHaveBeenCalledWith({ sourceId: "btn_query" });
+    fireEvent.change(select, { target: { value: "" } });
+    expect(onChange).toHaveBeenCalledWith({ sourceId: undefined });
+  });
+
+  it("dataPath / empty text write through", () => {
+    const onChange = vi.fn();
+    render(<ResultSection card={resCard()} onChange={onChange} apiButtons={apiButtons} />);
+    fireEvent.change(screen.getByLabelText(/data path/i), { target: { value: "data.items" } });
+    expect(onChange).toHaveBeenCalledWith({ dataPath: "data.items" });
+    fireEvent.change(screen.getByLabelText(/empty text/i), { target: { value: "Nothing" } });
+    expect(onChange).toHaveBeenCalledWith({ emptyText: "Nothing" });
+  });
+});

--- a/apps/web/src/tools/form-builder/inspector/result.tsx
+++ b/apps/web/src/tools/form-builder/inspector/result.tsx
@@ -1,0 +1,60 @@
+"use client";
+import * as React from "react";
+
+import { INPUT_CLS } from "./constants";
+import type { Card } from "../model";
+
+const MODES = ["card", "json", "table"] as const;
+
+export function ResultSection({
+  card, onChange, apiButtons = [],
+}: { card: Card; onChange: (p: Partial<Card>) => void; apiButtons?: { id: string; label: string }[] }) {
+  const mode = card.mode ?? "json";
+  return (
+    <div className="flex flex-col gap-2">
+      <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+        Mode
+        <select className={INPUT_CLS} value={mode} onChange={(e) => onChange({ mode: e.target.value as Card["mode"] })}>
+          {MODES.map((m) => (
+            <option key={m} value={m}>{m === "table" ? "table (coming soon)" : m}</option>
+          ))}
+        </select>
+      </label>
+
+      <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+        Source
+        <select
+          className={INPUT_CLS}
+          value={card.sourceId ?? ""}
+          onChange={(e) => onChange({ sourceId: e.target.value || undefined })}
+        >
+          <option value="">Last api response</option>
+          {apiButtons.map((b) => (
+            <option key={b.id} value={b.id}>{b.label}</option>
+          ))}
+        </select>
+      </label>
+
+      <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+        Data path
+        <input className={`${INPUT_CLS} font-mono`} value={card.dataPath ?? ""} placeholder="e.g. data.items" onChange={(e) => onChange({ dataPath: e.target.value || undefined })} />
+      </label>
+
+      {mode === "card" && (
+        <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+          Max items
+          <input
+            className={INPUT_CLS} type="number" min={1}
+            value={card.maxItems ?? 10}
+            onChange={(e) => { const n = Number(e.target.value); onChange({ maxItems: Number.isFinite(n) && n >= 1 ? n : undefined }); }}
+          />
+        </label>
+      )}
+
+      <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+        Empty text
+        <input className={INPUT_CLS} value={card.emptyText ?? ""} placeholder="No result yet" onChange={(e) => onChange({ emptyText: e.target.value || undefined })} />
+      </label>
+    </div>
+  );
+}

--- a/apps/web/src/tools/form-builder/inspector/result.tsx
+++ b/apps/web/src/tools/form-builder/inspector/result.tsx
@@ -32,6 +32,9 @@ export function ResultSection({
           {apiButtons.map((b) => (
             <option key={b.id} value={b.id}>{b.label}</option>
           ))}
+          {card.sourceId && !apiButtons.some((b) => b.id === card.sourceId) && (
+            <option value={card.sourceId}>{`missing: ${card.sourceId}`}</option>
+          )}
         </select>
       </label>
 
@@ -46,7 +49,7 @@ export function ResultSection({
           <input
             className={INPUT_CLS} type="number" min={1}
             value={card.maxItems ?? 10}
-            onChange={(e) => { const n = Number(e.target.value); onChange({ maxItems: Number.isFinite(n) && n >= 1 ? n : undefined }); }}
+            onChange={(e) => { const n = Number(e.target.value); onChange({ maxItems: Number.isInteger(n) && n >= 1 ? n : undefined }); }}
           />
         </label>
       )}

--- a/apps/web/src/tools/form-builder/inspector/settings-panel.tsx
+++ b/apps/web/src/tools/form-builder/inspector/settings-panel.tsx
@@ -3,6 +3,7 @@ import * as React from "react";
 import { Trash2 } from "lucide-react";
 import { Section } from "./section";
 import { ActionSection } from "./action";
+import { ResultSection } from "./result";
 import { OptionsSection } from "./options";
 import { ValidationSection } from "./validation";
 import { AiNoteSection, ContentSection, SpacerSection } from "./misc-sections";
@@ -31,8 +32,8 @@ const Count = ({ n }: { n: number }) => (
 );
 
 export function SettingsPanel({
-  card, groups, onChange, onRemove, siblingFields = [],
-}: { card: Card | null; groups: Group[]; onChange: (p: Partial<Card>) => void; onRemove: () => void; siblingFields?: { key: string; dataType: string }[] }) {
+  card, groups, onChange, onRemove, siblingFields = [], apiButtons = [],
+}: { card: Card | null; groups: Group[]; onChange: (p: Partial<Card>) => void; onRemove: () => void; siblingFields?: { key: string; dataType: string }[]; apiButtons?: { id: string; label: string }[] }) {
   if (!card) {
     return (
       <div className="rounded-xl border border-dashed border-border bg-card/20 p-6 text-center text-sm text-muted-foreground">
@@ -42,6 +43,7 @@ export function SettingsPanel({
   }
   const isField = card.kind === "field";
   const isButton = card.kind === "button";
+  const isResult = card.kind === "result";
   const comp = card.component;
   return (
     <div className="flex flex-col gap-3">
@@ -100,6 +102,12 @@ export function SettingsPanel({
       {isButton ? (
         <Section title="Action">
           <ActionSection card={card} onChange={onChange} siblingFields={siblingFields} />
+        </Section>
+      ) : null}
+
+      {isResult ? (
+        <Section title="Result">
+          <ResultSection card={card} onChange={onChange} apiButtons={apiButtons} />
         </Section>
       ) : null}
 

--- a/apps/web/src/tools/form-builder/model.spec.ts
+++ b/apps/web/src/tools/form-builder/model.spec.ts
@@ -190,3 +190,26 @@ describe("button cards", () => {
     expect(item).toMatchObject({ kind: "button", action: { type: "custom", name: "action-1" } });
   });
 });
+
+describe('result cards', () => {
+  it('round-trips a result card through FormConfig', () => {
+    const groups = [{ id: 'g1', title: 'G', collapsed: false }];
+    const cards = [{
+      id: 'res1', groupId: 'g1', kind: 'result' as const, label: 'Result',
+      mode: 'card' as const, sourceId: 'btn1', dataPath: 'data.items', maxItems: 5, emptyText: 'Nothing',
+      col: 1, span: 12, row: 1,
+    }];
+    const config = cardsToFormConfig(groups, cards);
+    const item = config.sections![0]!.rows[0]!.items[0]!;
+    expect(item).toMatchObject({ kind: 'result', mode: 'card', sourceId: 'btn1', dataPath: 'data.items', maxItems: 5, emptyText: 'Nothing' });
+    const back = formConfigToCards(config);
+    expect(back.cards[0]).toMatchObject({ kind: 'result', mode: 'card', sourceId: 'btn1', dataPath: 'data.items', maxItems: 5, emptyText: 'Nothing' });
+  });
+
+  it('result card without mode defaults to json', () => {
+    const groups = [{ id: 'g1', title: 'G', collapsed: false }];
+    const cards = [{ id: 'res1', groupId: 'g1', kind: 'result' as const, label: 'Result', col: 1, span: 12, row: 1 }];
+    const item = cardsToFormConfig(groups, cards).sections![0]!.rows[0]!.items[0]!;
+    expect(item).toMatchObject({ kind: 'result', mode: 'json' });
+  });
+});

--- a/apps/web/src/tools/form-builder/model.ts
+++ b/apps/web/src/tools/form-builder/model.ts
@@ -7,7 +7,7 @@ import {
   type ButtonAction,
 } from "@rfjs/form-builder";
 
-export type Kind = "field" | "content" | "divider" | "spacer" | "ai-note" | "button";
+export type Kind = "field" | "content" | "divider" | "spacer" | "ai-note" | "button" | "result";
 // Canvas Component = full engine FieldComponent union.
 export type Component = FieldComponent;
 
@@ -36,6 +36,12 @@ export interface Card {
   action?: ButtonAction; // button
   buttonVariant?: "primary" | "outline" | "ghost" | "destructive"; // button
   validate?: boolean; // button
+  mode?: "card" | "json" | "table"; // result
+  sourceId?: string; // result
+  dataPath?: string; // result
+  maxItems?: number; // result
+  resultTable?: unknown; // result
+  emptyText?: string; // result
   col: number;
   span: number;
   row: number;
@@ -111,6 +117,15 @@ function cardToItem(c: Card): FormItem {
         ...(c.buttonVariant ? { variant: c.buttonVariant } : {}),
         ...(c.validate !== undefined ? { validate: c.validate } : {}),
       };
+    case "result":
+      return {
+        id: c.id, kind: "result", mode: c.mode ?? "json",
+        ...(c.sourceId ? { sourceId: c.sourceId } : {}),
+        ...(c.dataPath ? { dataPath: c.dataPath } : {}),
+        ...(c.maxItems !== undefined ? { maxItems: c.maxItems } : {}),
+        ...(c.resultTable !== undefined ? { table: c.resultTable } : {}),
+        ...(c.emptyText ? { emptyText: c.emptyText } : {}),
+      };
   }
 }
 
@@ -163,6 +178,13 @@ export function formConfigToCards(config: FormConfig): { groups: Group[]; cards:
         cards.push({ ...base, kind: "content", label: item.text, locked: item.locked });
       } else if (item.kind === "button") {
         cards.push({ ...base, kind: "button", label: item.label, action: item.action, buttonVariant: item.variant, validate: item.validate });
+      } else if (item.kind === "result") {
+        cards.push({
+          ...base, kind: "result", label: "Result",
+          mode: item.mode, sourceId: item.sourceId, dataPath: item.dataPath,
+          maxItems: item.maxItems, resultTable: item.table,
+          emptyText: typeof item.emptyText === "string" ? item.emptyText : undefined,
+        });
       } else if (item.kind === "ai-note") {
         cards.push({ ...base, kind: "ai-note", label: item.text });
       } else {

--- a/apps/web/src/tools/form-builder/sample.ts
+++ b/apps/web/src/tools/form-builder/sample.ts
@@ -173,6 +173,18 @@ export const SAMPLE_CONFIG: FormConfig = {
             { id: "btn_clear", kind: "button", label: { en: "Clear", "zh-TW": "清除" }, action: { type: "clear", fields: ["name", "email"] }, variant: "ghost" },
           ],
         },
+        {
+          id: "r_query",
+          items: [
+            { id: "btn_query", kind: "button", label: { en: "Query", "zh-TW": "查詢" }, action: { type: "api", url: "/api/search", fields: ["name", "email"] } },
+          ],
+        },
+        {
+          id: "r_result",
+          items: [
+            { id: "res_query", kind: "result", mode: "card", sourceId: "btn_query", dataPath: "received.data", emptyText: { en: "Run a query to see results", "zh-TW": "按查詢看結果" } },
+          ],
+        },
       ],
     },
   ],

--- a/apps/web/src/tools/form-builder/sample.ts
+++ b/apps/web/src/tools/form-builder/sample.ts
@@ -182,7 +182,7 @@ export const SAMPLE_CONFIG: FormConfig = {
         {
           id: "r_result",
           items: [
-            { id: "res_query", kind: "result", mode: "card", sourceId: "btn_query", dataPath: "received.data", emptyText: { en: "Run a query to see results", "zh-TW": "按查詢看結果" } },
+            { id: "res_query", kind: "result", mode: "card", sourceId: "btn_query", dataPath: "received.data", emptyText: "Run a query to see results" },
           ],
         },
       ],

--- a/apps/web/src/tools/form-builder/ui.spec.tsx
+++ b/apps/web/src/tools/form-builder/ui.spec.tsx
@@ -170,6 +170,15 @@ describe("FormBuilderTool preview tab integration", () => {
     fireEvent.click(await screen.findByRole("button", { name: /save draft/i }));
     await waitFor(() => expect(screen.getAllByText(/save-draft/).length).toBeGreaterThan(0));
   });
+
+  it("preview: query api button renders its echoed response into the result card", async () => {
+    renderTool();
+    fireEvent.click(screen.getByRole("button", { name: /^preview$/i }));
+    fireEvent.click(await screen.findByRole("button", { name: /^query$/i }));
+    // echo fetcher 回 { echoedAt, received: { data, meta } };result dataPath received.data → kv 卡出現欄位 key
+    const resultContainer = document.querySelector('[data-item="res_query"]') as HTMLElement;
+    await waitFor(() => expect(resultContainer.textContent).toMatch(/name/i));
+  });
 });
 
 describe("FormBuilderTool mobile config overlay (does not block canvas drag)", () => {

--- a/apps/web/src/tools/form-builder/ui.tsx
+++ b/apps/web/src/tools/form-builder/ui.tsx
@@ -579,6 +579,7 @@ export function FormBuilderTool() {
                     card={selectedCard}
                     groups={groups}
                     siblingFields={siblingFields}
+                    apiButtons={cards.filter((c) => c.kind === "button" && c.action?.type === "api").map((c) => ({ id: c.id, label: cardLabel(c.label) }))}
                     onChange={(p) => selectedCard && updateCard(selectedCard.id, p)}
                     onRemove={() => {
                       if (!selectedCard) return;

--- a/apps/web/src/tools/form-builder/ui.tsx
+++ b/apps/web/src/tools/form-builder/ui.tsx
@@ -22,6 +22,7 @@ import {
   Upload,
   PenLine,
   MousePointerClick,
+  PanelBottom,
 } from "lucide-react";
 
 import { ConfigForm } from "@rfjs/form-builder-ui";
@@ -77,6 +78,7 @@ const KIND_META: Record<
   divider: { color: "#6b7280", icon: Minus, label: "Divider" },
   spacer: { color: "#6b7280", icon: MoveVertical, label: "Spacer" },
   button: { color: "#10b981", icon: MousePointerClick, label: "Button" },
+  result: { color: "#0ea5e9", icon: PanelBottom, label: "Result" },
 };
 
 const fieldSub = (c: Card) => (c.kind === "field" ? `${c.key ?? "field"} · ${c.component ?? "Input"}` : undefined);
@@ -396,7 +398,7 @@ export function FormBuilderTool() {
     return () => window.removeEventListener("keydown", onKey);
   }, [selected]);
 
-  const PALETTE: Kind[] = ["field", "content", "divider", "spacer", "ai-note", "button"];
+  const PALETTE: Kind[] = ["field", "content", "divider", "spacer", "ai-note", "button", "result"];
   const TABS = [
     { id: "canvas", label: "Canvas" },
     { id: "preview", label: "Preview" },

--- a/docs/mockups/2026-07-08-form-result-item.html
+++ b/docs/mockups/2026-07-08-form-result-item.html
@@ -1,0 +1,143 @@
+<!doctype html>
+<html lang="zh-Hant">
+<head>
+<meta charset="utf-8" />
+<title>form-builder result item — mockup</title>
+<style>
+  :root {
+    --bg: #f8f9fb; --card: #ffffff; --border: #e4e6eb; --fg: #1a1d24;
+    --muted: #6b7280; --muted-bg: #f3f4f6; --accent: #5b8cff; --err: #dc2626;
+    --chip: #eef2ff;
+  }
+  .dark {
+    --bg: #0e1116; --card: #161a22; --border: #262b36; --fg: #e6e8ee;
+    --muted: #8b93a3; --muted-bg: #1d222c; --accent: #6d9aff; --err: #f87171;
+    --chip: #1e2637;
+  }
+  * { box-sizing: border-box; margin: 0; }
+  html { background: var(--bg); }
+  body { background: var(--bg); color: var(--fg); font: 14px/1.5 ui-sans-serif, system-ui, "Noto Sans TC", sans-serif; padding: 32px; transition: background .2s; }
+  h1 { font-size: 18px; margin-bottom: 4px; }
+  .sub { color: var(--muted); font-size: 12px; margin-bottom: 24px; }
+  .toggle { position: fixed; top: 24px; right: 24px; padding: 6px 14px; border: 1px solid var(--border); border-radius: 8px; background: var(--card); color: var(--fg); cursor: pointer; font-size: 12px; }
+  .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(340px, 1fr)); gap: 20px; max-width: 1200px; }
+  .panel { border: 1px solid var(--border); border-radius: 12px; background: var(--card); overflow: hidden; }
+  .panel > header { padding: 8px 14px; border-bottom: 1px solid var(--border); font-size: 11px; font-weight: 600; letter-spacing: .08em; text-transform: uppercase; color: var(--muted); display: flex; justify-content: space-between; align-items: center; }
+  .panel > header .mode { background: var(--chip); color: var(--accent); border-radius: 99px; padding: 1px 8px; font-size: 10px; letter-spacing: 0; text-transform: none; }
+  .panel > .body { padding: 14px; }
+
+  /* --- result: empty / loading / error --- */
+  .state { display: flex; align-items: center; justify-content: center; min-height: 96px; border: 1px dashed var(--border); border-radius: 8px; color: var(--muted); font-size: 13px; gap: 8px; background: color-mix(in srgb, var(--muted-bg) 40%, transparent); }
+  .state.error { color: var(--err); border-color: color-mix(in srgb, var(--err) 40%, transparent); }
+  .spin { width: 14px; height: 14px; border: 2px solid var(--border); border-top-color: var(--accent); border-radius: 50%; animation: r 1s linear infinite; }
+  @keyframes r { to { transform: rotate(360deg); } }
+
+  /* --- card mode --- */
+  .kv-card { border: 1px solid var(--border); border-radius: 8px; padding: 10px 12px; display: flex; flex-direction: column; gap: 6px; background: color-mix(in srgb, var(--muted-bg) 30%, transparent); }
+  .kv-card + .kv-card { margin-top: 8px; }
+  .kv { display: flex; gap: 12px; font-size: 13px; }
+  .kv .k { flex: 0 0 96px; color: var(--muted); font-family: ui-monospace, monospace; font-size: 12px; padding-top: 1px; }
+  .kv .v { flex: 1; min-width: 0; word-break: break-word; }
+  .kv .v.num { font-variant-numeric: tabular-nums; }
+  .kv .v.obj { font-family: ui-monospace, monospace; font-size: 12px; color: var(--muted); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .more { margin-top: 10px; text-align: center; font-size: 12px; color: var(--muted); padding: 6px; border: 1px dashed var(--border); border-radius: 8px; }
+
+  /* --- json mode --- */
+  pre.json { background: var(--muted-bg); border: 1px solid var(--border); border-radius: 8px; padding: 12px; font: 11.5px/1.6 ui-monospace, monospace; overflow: auto; max-height: 260px; color: var(--fg); }
+
+  /* --- table placeholder --- */
+  .placeholder { display: flex; flex-direction: column; align-items: center; justify-content: center; min-height: 96px; border: 1px dashed var(--border); border-radius: 8px; color: var(--muted); font-size: 12px; gap: 4px; }
+  .placeholder b { font-size: 13px; color: var(--fg); opacity: .7; }
+
+  .note { max-width: 1200px; margin-top: 24px; color: var(--muted); font-size: 12px; border-top: 1px solid var(--border); padding-top: 12px; }
+</style>
+</head>
+<body>
+<button class="toggle" onclick="document.documentElement.classList.toggle('dark')">切換 dark</button>
+<h1>result item — 狀態 × 模式</h1>
+<p class="sub">form-builder 查詢型表單:api 按鈕回應的展示區。每格 = 一個 result item 的一種狀態。</p>
+
+<div class="grid">
+
+  <div class="panel">
+    <header>空狀態(尚未查詢)<span class="mode">card</span></header>
+    <div class="body"><div class="state">No result yet</div></div>
+  </div>
+
+  <div class="panel">
+    <header>Loading(綁定按鈕 pending)<span class="mode">card</span></header>
+    <div class="body"><div class="state"><span class="spin"></span> Loading…</div></div>
+  </div>
+
+  <div class="panel">
+    <header>錯誤(api 失敗且無舊結果)<span class="mode">card</span></header>
+    <div class="body"><div class="state error">Request failed</div></div>
+  </div>
+
+  <div class="panel">
+    <header>card — 物件(單筆)<span class="mode">card · dataPath: received.data</span></header>
+    <div class="body">
+      <div class="kv-card">
+        <div class="kv"><span class="k">name</span><span class="v">王小明</span></div>
+        <div class="kv"><span class="k">email</span><span class="v">ming@example.com</span></div>
+        <div class="kv"><span class="k">days</span><span class="v num">3</span></div>
+        <div class="kv"><span class="k">approved</span><span class="v">true</span></div>
+        <div class="kv"><span class="k">detail</span><span class="v obj">{"dept":"HR","level":2}</span></div>
+      </div>
+    </div>
+  </div>
+
+  <div class="panel">
+    <header>card — 陣列(maxItems 截斷)<span class="mode">card · dataPath: data.items</span></header>
+    <div class="body">
+      <div class="kv-card">
+        <div class="kv"><span class="k">id</span><span class="v num">1001</span></div>
+        <div class="kv"><span class="k">applicant</span><span class="v">王小明</span></div>
+        <div class="kv"><span class="k">status</span><span class="v">approved</span></div>
+      </div>
+      <div class="kv-card">
+        <div class="kv"><span class="k">id</span><span class="v num">1002</span></div>
+        <div class="kv"><span class="k">applicant</span><span class="v">林美慧</span></div>
+        <div class="kv"><span class="k">status</span><span class="v">pending</span></div>
+      </div>
+      <div class="kv-card">
+        <div class="kv"><span class="k">id</span><span class="v num">1003</span></div>
+        <div class="kv"><span class="k">applicant</span><span class="v">陳建宏</span></div>
+        <div class="kv"><span class="k">status</span><span class="v">rejected</span></div>
+      </div>
+      <div class="more">+ 7 more</div>
+    </div>
+  </div>
+
+  <div class="panel">
+    <header>json 模式<span class="mode">json</span></header>
+    <div class="body">
+<pre class="json">{
+  "echoedAt": "2026-07-08T10:32:11.204Z",
+  "received": {
+    "data": { "keyword": "王", "days": 3 },
+    "meta": {
+      "formId": "leave-form",
+      "action": { "type": "api" },
+      "valid": true
+    }
+  }
+}</pre>
+    </div>
+  </div>
+
+  <div class="panel">
+    <header>table 模式(v1 占位)<span class="mode">table</span></header>
+    <div class="body">
+      <div class="placeholder"><b>Table view</b><span>pending @rfjs/table-builder</span></div>
+    </div>
+  </div>
+
+</div>
+
+<p class="note">
+  規則:card 值為非 scalar → 單行 monospace 截斷;陣列超過 maxItems(預設 10)→「+N more」;
+  dataPath 取不到 → 空狀態;綁定按鈕被刪 → 空狀態。樣式對齊 web-ui tokens(實作時用實際 CSS 變數)。
+</p>
+</body>
+</html>

--- a/docs/superpowers/plans/2026-07-08-form-result-item.md
+++ b/docs/superpowers/plans/2026-07-08-form-result-item.md
@@ -1,0 +1,942 @@
+# form-builder result item — 實作計畫
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** form-builder 新增 `result` item kind —— api 按鈕回應的展示區(card/json,table 預留),完成「條件欄位 + api 按鈕 + result 區」的查詢型表單。
+
+**Architecture:** engine 只加型別與 zod;renderer 在 ConfigForm 收存 api 成功回應(`apiResults`)並由新的純展示元件 `ResultView` 渲染;工具加 palette 卡/inspector 面板/範例。規格:`docs/superpowers/specs/2026-07-08-form-result-item-design.md`;視覺驗收基準:`docs/mockups/2026-07-08-form-result-item.html`(**每個任務開工前先讀 spec 對應章節**)。
+
+**Tech Stack:** zod v4、react-hook-form(既有)、vitest + testing-library、Playwright e2e。
+
+## Global Constraints
+
+- 工作目錄:worktree `/home/royfw/_/code/royfw/rfjs/.claude/worktrees/feat-form-result`,分支 `feat-form-result`(基於 `5ad3141`,已含 #232 action model 與 #233 ai-assist)。
+- **並行紅線 — 絕對不碰**:`packages/web-core/**`、`apps/web/src/tools/{index,messages}.ts`、`apps/web/src/tools/index.spec.ts`、`apps/web/next.config.js`、`apps/web/package.json`(歸 table-builder session)。本 session 只動 `packages/form-builder/**`、`packages/form-builder-ui/**`、`apps/web/src/tools/form-builder/**`、`apps/web/e2e/form-builder.e2e.ts`。
+- **card 保持零配置**:只有 `maxItems`;不得加欄位選取/排序/格式化(那是 table 模式 / table-builder 的事)。
+- Commit:英文 conventional commits(subject 全小寫),結尾 `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`。
+- Changesets:`@rfjs/form-builder` minor(Task 1)、`@rfjs/form-builder-ui` minor(Task 2);手寫 markdown,不跑互動 CLI;apps 不寫。
+- 測試指令:`pnpm -F @rfjs/form-builder vitest:run`、`pnpm -F @rfjs/form-builder-ui vitest:run`、`pnpm -F web vitest:run <path>`(worktree 根執行)。engine 改完先 `pnpm build:packages` 再驗 web/ui 型別。
+- 已知 baseline:`@rfjs/form-builder` typecheck 有 3 個 main 上就存在的錯誤(config-schema ZodType/DOM lib)—— 不是回歸,不要試圖修;判斷回歸一律與未改動 tree 比對。
+- inspector/palette 文案沿用硬編英文慣例;範例 label 用 LocalizedLabel(en + zh-TW)。
+- e2e 撞 port 3002 時用 `E2E_PORT=3013`(另一個並行 session 用 3012)。
+
+---
+
+### Task 1: Engine — ResultItem 型別 + zod + makeItem + changeset
+
+**Files:**
+- Modify: `packages/form-builder/src/types.ts`(ItemKind:84、FormItem:129、ButtonItem 之後插入)
+- Modify: `packages/form-builder/src/config-schema.ts`(formItemSchema 的 discriminatedUnion)
+- Modify: `packages/form-builder/src/config-schema.spec.ts`
+- Modify: `packages/form-builder/src/tree-ops.ts`(makeItem switch,`case 'button'` 在 :49)
+- Modify: `packages/form-builder/src/tree-ops.spec.ts`
+- Create: `.changeset/form-result-item-engine.md`
+
+**Interfaces:**
+- Produces(後續任務全依賴):
+
+```ts
+export interface ResultItem {
+  id: string;
+  kind: 'result';
+  mode: 'card' | 'json' | 'table';
+  /** 綁定的 api 按鈕 item id;缺省 = 顯示全域最後一次 api 成功回應。 */
+  sourceId?: string;
+  /** dot path 先取子節點再渲染(同 responseMap 語法);缺省渲染整包回應。 */
+  dataPath?: string;
+  /** card 模式陣列上限,預設 10。 */
+  maxItems?: number;
+  /** mode:'table' 預留:未來放 @rfjs/table-builder 的 TableConfig;v1 透傳不解讀。 */
+  table?: unknown;
+  /** 空狀態文案;缺省內建 'No result yet'。 */
+  emptyText?: LocalizedLabel;
+}
+```
+
+- `ItemKind` 加 `'result'`;`FormItem` 聯集加 `ResultItem`。
+
+- [ ] **Step 1: 寫失敗測試** — `config-schema.spec.ts` 追加:
+
+```ts
+describe('result items', () => {
+  const withItem = (item: unknown) => ({
+    version: 1,
+    sections: [{ id: 's1', rows: [{ id: 'r1', items: [item] }] }],
+  });
+
+  it('accepts minimal and full result items', () => {
+    const minimal = { id: 'res1', kind: 'result', mode: 'json' };
+    const full = {
+      id: 'res2', kind: 'result', mode: 'card',
+      sourceId: 'btn1', dataPath: 'data.items', maxItems: 5,
+      table: { anything: true }, emptyText: { en: 'Nothing', 'zh-TW': '沒有資料' },
+    };
+    for (const item of [minimal, full]) {
+      const r = formConfigSchema.safeParse(withItem(item));
+      expect(r.success, JSON.stringify(item)).toBe(true);
+    }
+  });
+
+  it('rejects invalid result items: missing mode, unknown mode, non-positive maxItems', () => {
+    const bad = [
+      { id: 'x', kind: 'result' },
+      { id: 'x', kind: 'result', mode: 'grid' },
+      { id: 'x', kind: 'result', mode: 'card', maxItems: 0 },
+    ];
+    for (const item of bad) {
+      const r = formConfigSchema.safeParse(withItem(item));
+      expect(r.success, JSON.stringify(item)).toBe(false);
+    }
+  });
+});
+```
+
+`tree-ops.spec.ts` 追加(比照既有 makeItem 測試寫法):
+
+```ts
+it("makeItem('result') gives a json-mode result item", () => {
+  const item = makeItem('result', 'res-1');
+  expect(item).toMatchObject({ id: 'res-1', kind: 'result', mode: 'json' });
+});
+```
+
+（`makeItem` 的實際簽名以 `tree-ops.ts` 現檔為準 —— 若第二參數不是 id,對照既有 button case 測試調整呼叫方式,斷言語義不變。）
+
+- [ ] **Step 2: 跑測試確認失敗**
+
+Run: `pnpm -F @rfjs/form-builder vitest:run src/config-schema.spec.ts src/tree-ops.spec.ts`
+Expected: FAIL —— result 不在 discriminated union / makeItem 無此 case。
+
+- [ ] **Step 3: 實作**
+
+`types.ts`:`ItemKind` 改為含 `'result'`;`ButtonItem`(:120)之後插入上方 Interfaces 區塊的 `ResultItem`;`FormItem` 聯集加 `| ResultItem`。
+
+`config-schema.ts`:`buttonItemSchema` 之後加(`localizedLabelSchema` 沿用檔內既有):
+
+```ts
+const resultItemSchema = z.object({
+  id: z.string().min(1),
+  kind: z.literal('result'),
+  mode: z.enum(['card', 'json', 'table']),
+  sourceId: z.string().min(1).optional(),
+  dataPath: z.string().min(1).optional(),
+  maxItems: z.number().int().positive().optional(),
+  table: z.unknown().optional(),
+  emptyText: localizedLabelSchema.optional(),
+});
+```
+
+加入 `formItemSchema` 的 discriminatedUnion 陣列。
+
+`tree-ops.ts` 的 `makeItem` switch 加:
+
+```ts
+    case 'result':
+      return { id, kind: 'result', mode: 'json' };
+```
+
+（對照現檔 button case 的實際回傳形狀/簽名。）
+
+`.changeset/form-result-item-engine.md`:
+
+```md
+---
+"@rfjs/form-builder": minor
+---
+
+Add `ResultItem` (`kind: 'result'`): an api-response display area with `mode: 'card' | 'json' | 'table'` (table reserved for @rfjs/table-builder), optional source button binding, dot-path extraction, and card item cap.
+```
+
+- [ ] **Step 4: 跑測試確認通過**
+
+Run: `pnpm -F @rfjs/form-builder vitest:run && pnpm build:packages`
+Expected: 全 PASS;build 成功(供後續任務吃新型別)。typecheck 僅剩 3 個既有 baseline 錯誤。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/form-builder/src/types.ts packages/form-builder/src/config-schema.ts packages/form-builder/src/config-schema.spec.ts packages/form-builder/src/tree-ops.ts packages/form-builder/src/tree-ops.spec.ts .changeset/form-result-item-engine.md
+git commit -m "feat(form-builder): add result item kind for api response display
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Renderer — ResultView 純展示元件 + changeset
+
+**Files:**
+- Create: `packages/form-builder-ui/src/result-view.tsx`
+- Create: `packages/form-builder-ui/src/result-view.spec.tsx`
+- Create: `.changeset/form-result-item-ui.md`
+
+（barrel `index.ts` 是 `export *`,新檔要補一行 `export * from './result-view';`。）
+
+**Interfaces:**
+- Consumes: Task 1 `ResultItem`(僅型別)、`LocalizedLabel`/`resolveLabel`(`@rfjs/form-builder`)、lucide `Loader2`。
+- Produces(Task 3 依賴):
+
+```ts
+export type ResultViewState = 'empty' | 'loading' | 'error' | 'ready';
+export function ResultView(props: {
+  mode: 'card' | 'json' | 'table';
+  state: ResultViewState;
+  value?: unknown;            // state==='ready' 時的展示值(已套 dataPath)
+  maxItems?: number;          // card 陣列上限,預設 10
+  emptyText?: LocalizedLabel;
+  locale?: string;
+}): React.JSX.Element;
+```
+
+- [ ] **Step 1: 寫失敗測試** — `result-view.spec.tsx`:
+
+```tsx
+import { render, screen } from '@testing-library/react';
+import * as React from 'react';
+import { describe, expect, it } from 'vitest';
+
+import { ResultView } from './result-view';
+
+describe('ResultView states', () => {
+  it('empty: shows default text or custom LocalizedLabel', () => {
+    const { rerender } = render(<ResultView mode="card" state="empty" />);
+    expect(screen.getByText('No result yet')).toBeTruthy();
+    rerender(<ResultView mode="card" state="empty" emptyText={{ en: 'Nothing', 'zh-TW': '沒有資料' }} locale="zh-TW" />);
+    expect(screen.getByText('沒有資料')).toBeTruthy();
+  });
+
+  it('loading: shows spinner text', () => {
+    render(<ResultView mode="card" state="loading" />);
+    expect(screen.getByText(/loading/i)).toBeTruthy();
+  });
+
+  it('error: shows failure text', () => {
+    render(<ResultView mode="card" state="error" />);
+    expect(screen.getByText(/request failed/i)).toBeTruthy();
+  });
+});
+
+describe('ResultView card mode', () => {
+  it('object → one key-value card; non-scalar values stringified', () => {
+    render(<ResultView mode="card" state="ready" value={{ name: 'Roy', days: 3, detail: { dept: 'HR' } }} />);
+    expect(screen.getByText('name')).toBeTruthy();
+    expect(screen.getByText('Roy')).toBeTruthy();
+    expect(screen.getByText('{"dept":"HR"}')).toBeTruthy();
+  });
+
+  it('array → stacked cards capped by maxItems with a "+N more" hint', () => {
+    const rows = Array.from({ length: 5 }, (_, i) => ({ id: i + 1 }));
+    render(<ResultView mode="card" state="ready" value={rows} maxItems={3} />);
+    expect(screen.getAllByText('id')).toHaveLength(3);
+    expect(screen.getByText('+ 2 more')).toBeTruthy();
+  });
+
+  it('array within default cap renders all items and no hint', () => {
+    render(<ResultView mode="card" state="ready" value={[{ a: 1 }, { a: 2 }]} />);
+    expect(screen.getAllByText('a')).toHaveLength(2);
+    expect(screen.queryByText(/more$/)).toBeNull();
+  });
+
+  it('scalar → single value card', () => {
+    render(<ResultView mode="card" state="ready" value={42} />);
+    expect(screen.getByText('42')).toBeTruthy();
+  });
+});
+
+describe('ResultView json / table modes', () => {
+  it('json: pretty prints', () => {
+    render(<ResultView mode="json" state="ready" value={{ a: 1 }} />);
+    expect(screen.getByText(/"a": 1/)).toBeTruthy();
+  });
+
+  it('table: renders the pending placeholder', () => {
+    render(<ResultView mode="table" state="ready" value={[]} />);
+    expect(screen.getByText(/pending .*table-builder/i)).toBeTruthy();
+  });
+});
+```
+
+- [ ] **Step 2: 跑測試確認失敗**
+
+Run: `pnpm -F @rfjs/form-builder-ui vitest:run src/result-view.spec.tsx`
+Expected: FAIL —— 模組不存在。
+
+- [ ] **Step 3: 實作** — `result-view.tsx`(視覺對齊 mockup:虛線狀態框、kv 卡 key 左 mono、+N more、pre 面板):
+
+```tsx
+'use client';
+
+import * as React from 'react';
+import { Loader2 } from 'lucide-react';
+import { resolveLabel, type LocalizedLabel } from '@rfjs/form-builder';
+
+export type ResultViewState = 'empty' | 'loading' | 'error' | 'ready';
+
+export interface ResultViewProps {
+  mode: 'card' | 'json' | 'table';
+  state: ResultViewState;
+  value?: unknown;
+  maxItems?: number;
+  emptyText?: LocalizedLabel;
+  locale?: string;
+}
+
+const isScalar = (v: unknown): v is string | number | boolean =>
+  v === null || ['string', 'number', 'boolean'].includes(typeof v);
+
+function KvCard({ value }: { value: unknown }) {
+  if (isScalar(value)) {
+    return <div className="rounded-md border border-input bg-muted/30 px-3 py-2 text-sm">{String(value)}</div>;
+  }
+  const entries = Object.entries((value ?? {}) as Record<string, unknown>);
+  return (
+    <div className="flex flex-col gap-1.5 rounded-md border border-input bg-muted/30 px-3 py-2.5">
+      {entries.map(([k, v]) => (
+        <div key={k} className="flex gap-3 text-sm">
+          <span className="w-24 shrink-0 pt-px font-mono text-xs text-muted-foreground">{k}</span>
+          {isScalar(v) ? (
+            <span className="min-w-0 break-words">{String(v)}</span>
+          ) : (
+            <span className="min-w-0 truncate font-mono text-xs text-muted-foreground">{JSON.stringify(v)}</span>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+const stateBox = 'flex min-h-24 items-center justify-center gap-2 rounded-md border border-dashed border-input bg-muted/20 text-sm text-muted-foreground';
+
+/** api 回應的純展示元件 —— card 刻意零配置(僅 maxItems);欄位級控制屬 table 模式(table-builder)。 */
+export function ResultView({ mode, state, value, maxItems, emptyText, locale = 'en' }: ResultViewProps) {
+  if (state === 'empty') {
+    return <div className={stateBox}>{emptyText ? resolveLabel(emptyText, locale) : 'No result yet'}</div>;
+  }
+  if (state === 'loading') {
+    return (
+      <div className={stateBox}>
+        <Loader2 className="size-4 animate-spin" /> Loading…
+      </div>
+    );
+  }
+  if (state === 'error') {
+    return <div className={`${stateBox} border-destructive/40 text-destructive`}>Request failed</div>;
+  }
+
+  if (mode === 'json') {
+    return (
+      <pre className="max-h-64 overflow-auto rounded-md border border-input bg-muted/30 p-3 font-mono text-xs leading-relaxed">
+        {JSON.stringify(value, null, 2)}
+      </pre>
+    );
+  }
+
+  if (mode === 'table') {
+    return (
+      <div className={`${stateBox} flex-col gap-1`}>
+        <span className="font-medium text-foreground/70">Table view</span>
+        <span className="text-xs">pending @rfjs/table-builder</span>
+      </div>
+    );
+  }
+
+  // mode === 'card'
+  if (Array.isArray(value)) {
+    const cap = maxItems ?? 10;
+    const shown = value.slice(0, cap);
+    const rest = value.length - shown.length;
+    return (
+      <div className="flex flex-col gap-2">
+        {shown.map((row, i) => (
+          <KvCard key={i} value={row} />
+        ))}
+        {rest > 0 && (
+          <div className="rounded-md border border-dashed border-input py-1.5 text-center text-xs text-muted-foreground">{`+ ${rest} more`}</div>
+        )}
+      </div>
+    );
+  }
+  return <KvCard value={value} />;
+}
+```
+
+`index.ts` 加 `export * from './result-view';`。
+
+`.changeset/form-result-item-ui.md`:
+
+```md
+---
+"@rfjs/form-builder-ui": minor
+---
+
+ConfigForm renders `result` items: api-response display areas with card / json modes (table placeholder pending @rfjs/table-builder), source-button binding, dot-path extraction, and empty / loading / error states.
+```
+
+- [ ] **Step 4: 跑測試確認通過**
+
+Run: `pnpm -F @rfjs/form-builder-ui vitest:run src/result-view.spec.tsx && pnpm -F @rfjs/form-builder-ui check-types`
+Expected: 測試全 PASS;check-types 0 錯誤。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/form-builder-ui/src/result-view.tsx packages/form-builder-ui/src/result-view.spec.tsx packages/form-builder-ui/src/index.ts .changeset/form-result-item-ui.md
+git commit -m "feat(form-builder-ui): add resultview display component for api responses
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Renderer — ConfigForm 接線(apiResults 狀態 + result 分支)
+
+**Files:**
+- Modify: `packages/form-builder-ui/src/config-form.tsx`(apiState:213 附近加狀態;api 成功分支:~:375;config-change effect;renderItem:385 加分支)
+- Modify: `packages/form-builder-ui/src/config-form.spec.tsx`
+
+**Interfaces:**
+- Consumes: Task 1 `ResultItem`、Task 2 `ResultView`、既有 `apiState`/`getPath`/`runAction`/epoch。
+- Produces: result item 在表單中的完整行為(Task 4-6 的工具層依賴)。
+
+- [ ] **Step 1: 寫失敗測試** — `config-form.spec.tsx` 追加(沿用檔內既有 `btn` helper 的寫法;`waitFor`/`fireEvent` 既有 import):
+
+```tsx
+describe('result items', () => {
+  const resultCfg = (result: Partial<import('@rfjs/form-builder').ResultItem>, apiOver?: object): FormConfig => ({
+    version: 1,
+    sections: [{
+      id: 's1',
+      rows: [{
+        id: 'r1',
+        items: [
+          { id: 'f1', kind: 'field', key: 'name', label: 'Name', component: 'Input', dataType: 'string' },
+          { id: 'b1', kind: 'button', label: 'Query', action: { type: 'api', url: '/x', ...apiOver } },
+          { id: 'b2', kind: 'button', label: 'Other', action: { type: 'api', url: '/y' } },
+          { id: 'res1', kind: 'result', mode: 'json', ...result },
+        ],
+      }],
+    }],
+  });
+
+  it('starts empty, renders the bound response after the api button succeeds', async () => {
+    const fetcher = vi.fn().mockResolvedValue({ hello: 'world' });
+    render(<ConfigForm config={resultCfg({ sourceId: 'b1' })} onSubmit={vi.fn()} fetcher={fetcher} />);
+    expect(screen.getByText('No result yet')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'Query' }));
+    await waitFor(() => expect(screen.getByText(/"hello": "world"/)).toBeTruthy());
+  });
+
+  it('bound result ignores other buttons; unbound shows the last response', async () => {
+    const fetcher = vi.fn()
+      .mockResolvedValueOnce({ from: 'other' });
+    render(
+      <ConfigForm
+        config={{
+          ...resultCfg({ sourceId: 'b1' }),
+          sections: [{
+            id: 's1',
+            rows: [{
+              id: 'r1',
+              items: [
+                { id: 'b1', kind: 'button', label: 'Query', action: { type: 'api', url: '/x' } },
+                { id: 'b2', kind: 'button', label: 'Other', action: { type: 'api', url: '/y' } },
+                { id: 'res1', kind: 'result', mode: 'json', sourceId: 'b1' },
+                { id: 'res2', kind: 'result', mode: 'json' },
+              ],
+            }],
+          }],
+        }}
+        onSubmit={vi.fn()}
+        fetcher={fetcher}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Other' }));
+    // 綁定 b1 的 res1 不顯示 b2 的回應;未綁定的 res2 顯示
+    await waitFor(() => expect(screen.getByText(/"from": "other"/)).toBeTruthy());
+    expect(screen.getByText('No result yet')).toBeTruthy(); // res1 仍空
+  });
+
+  it('dataPath extracts a sub-node; missing path falls back to empty', async () => {
+    const fetcher = vi.fn().mockResolvedValue({ data: { items: [{ id: 1 }] } });
+    const { rerender } = render(
+      <ConfigForm config={resultCfg({ sourceId: 'b1', mode: 'card', dataPath: 'data.items' })} onSubmit={vi.fn()} fetcher={fetcher} />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Query' }));
+    await waitFor(() => expect(screen.getByText('id')).toBeTruthy());
+    // 換一個取不到的 path,重新查詢:hasResponse 為真但 getPath undefined → 空狀態,不炸
+    rerender(<ConfigForm config={resultCfg({ sourceId: 'b1', mode: 'card', dataPath: 'no.such' })} onSubmit={vi.fn()} fetcher={fetcher} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Query' }));
+    await waitFor(() => expect(fetcher).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(screen.getByText('No result yet')).toBeTruthy());
+  });
+
+  it('shows loading while the bound button is pending and error on failure', async () => {
+    let reject!: (e: Error) => void;
+    const fetcher = vi.fn().mockReturnValue(new Promise((_r, rej) => { reject = rej; }));
+    render(<ConfigForm config={resultCfg({ sourceId: 'b1' })} onSubmit={vi.fn()} fetcher={fetcher} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Query' }));
+    await waitFor(() => expect(screen.getByText(/loading/i)).toBeTruthy());
+    reject(new Error('boom'));
+    await waitFor(() => expect(screen.getByText(/request failed/i)).toBeTruthy());
+  });
+
+  it('config change clears stored responses', async () => {
+    const fetcher = vi.fn().mockResolvedValue({ a: 1 });
+    const cfg = resultCfg({ sourceId: 'b1' });
+    const { rerender } = render(<ConfigForm config={cfg} onSubmit={vi.fn()} fetcher={fetcher} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Query' }));
+    await waitFor(() => expect(screen.getByText(/"a": 1/)).toBeTruthy());
+    rerender(<ConfigForm config={{ ...cfg }} onSubmit={vi.fn()} fetcher={fetcher} />);
+    await waitFor(() => expect(screen.getByText('No result yet')).toBeTruthy());
+  });
+});
+```
+
+- [ ] **Step 2: 跑測試確認失敗**
+
+Run: `pnpm -F @rfjs/form-builder-ui vitest:run src/config-form.spec.tsx`
+Expected: FAIL —— result item 不渲染。
+
+- [ ] **Step 3: 實作** — `config-form.tsx`:
+
+import 加 `ResultView`(自 `./result-view`)與 `type ResultItem`(自 `@rfjs/form-builder`)。
+
+`apiState` 旁加:
+
+```tsx
+// result item 的資料來源:各 api 按鈕的最新成功回應 + 全域最後一次。
+const [apiResults, setApiResults] = React.useState<{
+  byButtonId: Record<string, unknown>;
+  last?: { buttonId: string; response: unknown };
+}>({ byButtonId: {} });
+```
+
+api 成功分支(epoch check 之後、`setApiState({ status: 'success' })` 旁)加:
+
+```tsx
+setApiResults((prev) => ({
+  byButtonId: { ...prev.byButtonId, [item.id]: response },
+  last: { buttonId: item.id, response },
+}));
+```
+
+config-change effect(現有 `reset(...)`/`setApiState(null)` 處)加 `setApiResults({ byButtonId: {} });`。
+
+`renderItem` 加分支(button 分支之後、field fall-through 之前):
+
+```tsx
+if (item.kind === 'result') {
+  const raw = item.sourceId !== undefined ? apiResults.byButtonId[item.sourceId] : apiResults.last?.response;
+  const hasResponse = item.sourceId !== undefined ? item.sourceId in apiResults.byButtonId : apiResults.last !== undefined;
+  const value = hasResponse && item.dataPath ? getPath(raw, item.dataPath) : raw;
+  // 綁定時只理會來源按鈕的進行中/失敗;未綁定時理會任一 api 按鈕。
+  const watching = item.sourceId === undefined || apiState?.itemId === item.sourceId;
+  const state: ResultViewState =
+    watching && apiState?.status === 'pending' ? 'loading'
+    : watching && apiState?.status === 'error' && !hasResponse ? 'error'
+    : !hasResponse || value === undefined ? 'empty'
+    : 'ready';
+  return (
+    <div key={item.id} data-item={item.id} style={place ? placementStyle(place) : fieldSpanStyle(undefined, flow, cols)}>
+      <ResultView mode={item.mode} state={state} value={value} maxItems={item.maxItems} emptyText={item.emptyText} locale={locale} />
+    </div>
+  );
+}
+```
+
+（`ResultViewState` 型別 import 自 `./result-view`。）
+
+- [ ] **Step 4: 跑測試確認通過**
+
+Run: `pnpm -F @rfjs/form-builder-ui vitest:run && pnpm -F @rfjs/form-builder-ui check-types`
+Expected: 全 PASS;0 型別錯誤。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/form-builder-ui/src/config-form.tsx packages/form-builder-ui/src/config-form.spec.tsx
+git commit -m "feat(form-builder-ui): render result items from stored api responses
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: 工具 — model.ts result kind + palette
+
+**Files:**
+- Modify: `apps/web/src/tools/form-builder/model.ts`(Kind:8、Card、cardToItem、formConfigToCards)
+- Modify: `apps/web/src/tools/form-builder/model.spec.ts`
+- Modify: `apps/web/src/tools/form-builder/ui.tsx`(KIND_META、PALETTE、seedSpan)
+
+**Interfaces:**
+- Consumes: Task 1 `ResultItem`。
+- Produces: `Card` 加 `mode?: "card" | "json" | "table"; sourceId?: string; dataPath?: string; maxItems?: number; resultTable?: unknown; emptyText?: string`(工具層 emptyText 以 string 編輯,同 messages 慣例);cards↔FormConfig 雙向(Task 5/6 依賴)。
+
+- [ ] **Step 1: 寫失敗測試** — `model.spec.ts` 追加:
+
+```ts
+describe('result cards', () => {
+  it('round-trips a result card through FormConfig', () => {
+    const groups = [{ id: 'g1', title: 'G', collapsed: false }];
+    const cards = [{
+      id: 'res1', groupId: 'g1', kind: 'result' as const, label: 'Result',
+      mode: 'card' as const, sourceId: 'btn1', dataPath: 'data.items', maxItems: 5, emptyText: 'Nothing',
+      col: 1, span: 12, row: 1,
+    }];
+    const config = cardsToFormConfig(groups, cards);
+    const item = config.sections![0]!.rows[0]!.items[0]!;
+    expect(item).toMatchObject({ kind: 'result', mode: 'card', sourceId: 'btn1', dataPath: 'data.items', maxItems: 5, emptyText: 'Nothing' });
+    const back = formConfigToCards(config);
+    expect(back.cards[0]).toMatchObject({ kind: 'result', mode: 'card', sourceId: 'btn1', dataPath: 'data.items', maxItems: 5, emptyText: 'Nothing' });
+  });
+
+  it('result card without mode defaults to json', () => {
+    const groups = [{ id: 'g1', title: 'G', collapsed: false }];
+    const cards = [{ id: 'res1', groupId: 'g1', kind: 'result' as const, label: 'Result', col: 1, span: 12, row: 1 }];
+    const item = cardsToFormConfig(groups, cards).sections![0]!.rows[0]!.items[0]!;
+    expect(item).toMatchObject({ kind: 'result', mode: 'json' });
+  });
+});
+```
+
+- [ ] **Step 2: 跑測試確認失敗**
+
+Run: `pnpm -F web vitest:run src/tools/form-builder/model.spec.ts`
+Expected: FAIL(型別/缺 case)。
+
+- [ ] **Step 3: 實作**
+
+`model.ts`:`Kind` 加 `"result"`;`Card` 加上方 Interfaces 的六個選填欄位(import `ResultItem` 型別非必要,`mode` 直接字面聯集);`cardToItem` 加:
+
+```ts
+    case "result":
+      return {
+        id: c.id, kind: "result", mode: c.mode ?? "json",
+        ...(c.sourceId ? { sourceId: c.sourceId } : {}),
+        ...(c.dataPath ? { dataPath: c.dataPath } : {}),
+        ...(c.maxItems !== undefined ? { maxItems: c.maxItems } : {}),
+        ...(c.resultTable !== undefined ? { table: c.resultTable } : {}),
+        ...(c.emptyText ? { emptyText: c.emptyText } : {}),
+      };
+```
+
+`formConfigToCards` 分支鏈加:
+
+```ts
+      } else if (item.kind === "result") {
+        cards.push({
+          ...base, kind: "result", label: "Result",
+          mode: item.mode, sourceId: item.sourceId, dataPath: item.dataPath,
+          maxItems: item.maxItems, resultTable: item.table,
+          emptyText: typeof item.emptyText === "string" ? item.emptyText : undefined,
+        });
+```
+
+`ui.tsx`:import 加 `PanelBottom`(lucide-react);`KIND_META` 加:
+
+```ts
+  result: { color: "#0ea5e9", icon: PanelBottom, label: "Result" },
+```
+
+`PALETTE` 加 `"result"`(排在 `"button"` 之後);`seedSpan` 的非 field 分支已回傳 COLS(全寬)—— 確認 result 走到該分支即可,不用改。
+
+- [ ] **Step 4: 跑測試確認通過**
+
+Run: `pnpm -F web vitest:run src/tools/form-builder/model.spec.ts src/tools/form-builder/ui.spec.tsx && pnpm -F web check-types`
+Expected: 全 PASS(check-types 若因 Kind 擴充在其他 Record 報缺 key,一併補上並在報告註明 —— 比照 #232 的 item-editor 前例:`packages/form-builder-ui/src/item-editor.tsx` 的 `Record<ItemKind, KindMeta>` 也要加 `result` 一行,這是本任務的授權外掛)。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/tools/form-builder/model.ts apps/web/src/tools/form-builder/model.spec.ts apps/web/src/tools/form-builder/ui.tsx packages/form-builder-ui/src/item-editor.tsx
+git commit -m "feat(web): add result card kind to form-builder canvas model and palette
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+（item-editor.tsx 若未變動則不加入。）
+
+---
+
+### Task 5: 工具 — inspector Result 面板
+
+**Files:**
+- Create: `apps/web/src/tools/form-builder/inspector/result.tsx`
+- Create: `apps/web/src/tools/form-builder/inspector/result.spec.tsx`
+- Modify: `apps/web/src/tools/form-builder/inspector/settings-panel.tsx`(`isResult` gate)
+- Modify: `apps/web/src/tools/form-builder/ui.tsx`(SettingsPanel 呼叫端傳 `apiButtons`)
+
+**Interfaces:**
+- Consumes: Task 4 的 `Card` result 欄位;`Section`(`./section`)、`INPUT_CLS`(`./constants`,#232 前例)。
+- Produces:
+
+```tsx
+export function ResultSection(props: {
+  card: Card;
+  onChange: (p: Partial<Card>) => void;
+  apiButtons?: { id: string; label: string }[];   // 畫布上現有 api 按鈕
+}): React.JSX.Element;
+```
+
+`SettingsPanel` props 加 `apiButtons?: { id: string; label: string }[]`(透傳);ui.tsx 呼叫端計算:
+
+```tsx
+apiButtons={cards.filter((c) => c.kind === "button" && c.action?.type === "api").map((c) => ({ id: c.id, label: cardLabel(c.label) }))}
+```
+
+- [ ] **Step 1: 寫失敗測試** — `result.spec.tsx`:
+
+```tsx
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { Card } from "../model";
+import { ResultSection } from "./result";
+
+const resCard = (over?: Partial<Card>): Card => ({
+  id: "res1", groupId: "g1", kind: "result", label: "Result",
+  mode: "json", col: 1, span: 12, row: 1, ...over,
+});
+const apiButtons = [{ id: "btn_query", label: "Query" }];
+
+describe("ResultSection", () => {
+  it("mode select writes through; maxItems only visible for card mode", () => {
+    const onChange = vi.fn();
+    const { rerender } = render(<ResultSection card={resCard()} onChange={onChange} apiButtons={apiButtons} />);
+    expect(screen.queryByLabelText(/max items/i)).toBeNull();
+    fireEvent.change(screen.getByLabelText(/^mode$/i), { target: { value: "card" } });
+    expect(onChange).toHaveBeenCalledWith({ mode: "card" });
+    rerender(<ResultSection card={resCard({ mode: "card" })} onChange={onChange} apiButtons={apiButtons} />);
+    expect(screen.getByLabelText(/max items/i)).toBeTruthy();
+  });
+
+  it("source select lists api buttons plus the unbound option", () => {
+    const onChange = vi.fn();
+    render(<ResultSection card={resCard()} onChange={onChange} apiButtons={apiButtons} />);
+    const select = screen.getByLabelText(/source/i) as HTMLSelectElement;
+    expect([...select.options].map((o) => o.text)).toEqual(["Last api response", "Query"]);
+    fireEvent.change(select, { target: { value: "btn_query" } });
+    expect(onChange).toHaveBeenCalledWith({ sourceId: "btn_query" });
+    fireEvent.change(select, { target: { value: "" } });
+    expect(onChange).toHaveBeenCalledWith({ sourceId: undefined });
+  });
+
+  it("dataPath / empty text write through", () => {
+    const onChange = vi.fn();
+    render(<ResultSection card={resCard()} onChange={onChange} apiButtons={apiButtons} />);
+    fireEvent.change(screen.getByLabelText(/data path/i), { target: { value: "data.items" } });
+    expect(onChange).toHaveBeenCalledWith({ dataPath: "data.items" });
+    fireEvent.change(screen.getByLabelText(/empty text/i), { target: { value: "Nothing" } });
+    expect(onChange).toHaveBeenCalledWith({ emptyText: "Nothing" });
+  });
+});
+```
+
+- [ ] **Step 2: 跑測試確認失敗**
+
+Run: `pnpm -F web vitest:run src/tools/form-builder/inspector/result.spec.tsx`
+Expected: FAIL —— 模組不存在。
+
+- [ ] **Step 3: 實作** — `result.tsx`:
+
+```tsx
+"use client";
+import * as React from "react";
+
+import { INPUT_CLS } from "./constants";
+import type { Card } from "../model";
+
+const MODES = ["card", "json", "table"] as const;
+
+export function ResultSection({
+  card, onChange, apiButtons = [],
+}: { card: Card; onChange: (p: Partial<Card>) => void; apiButtons?: { id: string; label: string }[] }) {
+  const mode = card.mode ?? "json";
+  return (
+    <div className="flex flex-col gap-2">
+      <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+        Mode
+        <select className={INPUT_CLS} value={mode} onChange={(e) => onChange({ mode: e.target.value as Card["mode"] })}>
+          {MODES.map((m) => (
+            <option key={m} value={m}>{m === "table" ? "table (coming soon)" : m}</option>
+          ))}
+        </select>
+      </label>
+
+      <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+        Source
+        <select
+          className={INPUT_CLS}
+          value={card.sourceId ?? ""}
+          onChange={(e) => onChange({ sourceId: e.target.value || undefined })}
+        >
+          <option value="">Last api response</option>
+          {apiButtons.map((b) => (
+            <option key={b.id} value={b.id}>{b.label}</option>
+          ))}
+        </select>
+      </label>
+
+      <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+        Data path
+        <input className={`${INPUT_CLS} font-mono`} value={card.dataPath ?? ""} placeholder="e.g. data.items" onChange={(e) => onChange({ dataPath: e.target.value || undefined })} />
+      </label>
+
+      {mode === "card" && (
+        <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+          Max items
+          <input
+            className={INPUT_CLS} type="number" min={1}
+            value={card.maxItems ?? 10}
+            onChange={(e) => { const n = Number(e.target.value); onChange({ maxItems: Number.isFinite(n) && n >= 1 ? n : undefined }); }}
+          />
+        </label>
+      )}
+
+      <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+        Empty text
+        <input className={INPUT_CLS} value={card.emptyText ?? ""} placeholder="No result yet" onChange={(e) => onChange({ emptyText: e.target.value || undefined })} />
+      </label>
+    </div>
+  );
+}
+```
+
+`settings-panel.tsx`:import `ResultSection`;`isButton` 旁加 `const isResult = card.kind === "result";`;props 加 `apiButtons?: { id: string; label: string }[]`;Action Section 之後插入:
+
+```tsx
+      {isResult ? (
+        <Section title="Result">
+          <ResultSection card={card} onChange={onChange} apiButtons={apiButtons} />
+        </Section>
+      ) : null}
+```
+
+`ui.tsx` 的 `<SettingsPanel …>` 呼叫端加 `apiButtons={…}`(見 Interfaces)。
+
+- [ ] **Step 4: 跑測試確認通過**
+
+Run: `pnpm -F web vitest:run src/tools/form-builder/inspector/ && pnpm -F web check-types`
+Expected: 全 PASS。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/tools/form-builder/inspector/result.tsx apps/web/src/tools/form-builder/inspector/result.spec.tsx apps/web/src/tools/form-builder/inspector/settings-panel.tsx apps/web/src/tools/form-builder/ui.tsx
+git commit -m "feat(web): add result inspector panel to form-builder
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: 工具 — 範例 + Preview 驗證
+
+**Files:**
+- Modify: `apps/web/src/tools/form-builder/sample.ts`(`r_actions` row 之後加查詢按鈕 + result 區)
+- Modify: `apps/web/src/tools/form-builder/ui.spec.tsx`
+
+**Interfaces:**
+- Consumes: 既有 `previewFetcher`(echo:回 `{ echoedAt, received: body }`,body = `{ data, meta }`)。
+
+- [ ] **Step 1: 寫失敗測試** — `ui.spec.tsx` 追加(沿用檔內 renderTool/Preview 切換模式):
+
+```tsx
+it("preview: query api button renders its echoed response into the result card", async () => {
+  renderTool();
+  fireEvent.click(screen.getByRole("button", { name: "Preview", exact: true }));
+  fireEvent.click(await screen.findByRole("button", { name: /^query$/i }));
+  // echo fetcher 回 { echoedAt, received: { data, meta } };result dataPath received.data → kv 卡出現欄位 key
+  await waitFor(() => expect(screen.getAllByText("name").length).toBeGreaterThan(0));
+});
+```
+
+（若 `name` 撞到欄位 label 的 heading,改斷言 `data-item="res_query"` 容器內文字 —— 以實跑結果調整 selector,語義不變:result 卡渲染出 echo 的 data key。）
+
+- [ ] **Step 2: 跑測試確認失敗**
+
+Run: `pnpm -F web vitest:run src/tools/form-builder/ui.spec.tsx`
+Expected: FAIL —— 範例沒有 Query 按鈕。
+
+- [ ] **Step 3: 實作** — `sample.ts` 的 `r_actions` row 之後追加兩個 row(同 section):
+
+```ts
+        {
+          id: "r_query",
+          items: [
+            { id: "btn_query", kind: "button", label: { en: "Query", "zh-TW": "查詢" }, action: { type: "api", url: "/api/search", fields: ["name", "email"] } },
+          ],
+        },
+        {
+          id: "r_result",
+          items: [
+            { id: "res_query", kind: "result", mode: "card", sourceId: "btn_query", dataPath: "received.data", emptyText: { en: "Run a query to see results", "zh-TW": "按查詢看結果" } },
+          ],
+        },
+```
+
+- [ ] **Step 4: 跑測試確認通過**
+
+Run: `pnpm -F web vitest:run src/tools/form-builder/ && pnpm -F web check-types && pnpm -F web lint`
+Expected: 全 PASS。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/tools/form-builder/sample.ts apps/web/src/tools/form-builder/ui.spec.tsx
+git commit -m "feat(web): add query button and result card to form-builder sample
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: e2e + 全套驗證
+
+**Files:**
+- Modify: `apps/web/e2e/form-builder.e2e.ts`(追加一條)
+
+- [ ] **Step 1: 追加 e2e**:
+
+```ts
+test("preview: query api button renders the echoed response in the result card", async ({ page }) => {
+  await page.goto(URL);
+  await page.getByRole("button", { name: "Preview", exact: true }).click();
+  await page.getByRole("button", { name: /^query$/i }).click();
+  await expect(page.locator('[data-item="res_query"]')).toContainText("echoedAt", { timeout: 15_000 });
+});
+```
+
+（result 綁 `dataPath: 'received.data'` 時卡片內不含 `echoedAt` —— 斷言以實際渲染為準:應改為 `toContainText("name")`(data 內的欄位 key)。先跑一次確認,兩者擇一,不得放寬成 truthy。）
+
+- [ ] **Step 2: 跑 e2e**
+
+Run: `pnpm -F web test:e2e`(port 撞就 `E2E_PORT=3013`)
+Expected: 全 PASS(既有全部 + 新 1 條)。
+
+- [ ] **Step 3: 全套**
+
+Run: `pnpm -F @rfjs/form-builder test && pnpm -F @rfjs/form-builder-ui test && pnpm -F web test`
+Expected: 全 PASS。
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/e2e/form-builder.e2e.ts
+git commit -m "test(web): cover form-builder result card in e2e
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 8: 真渲染驗證 + PR(主 session 執行,非 subagent)
+
+**Files:** 無程式變更。
+
+- [ ] **Step 1:** `pnpm -F web build` → `next start -p 3007`(避開另一 session 可能占用的 3005/3006)。
+- [ ] **Step 2:** Playwright 截圖(light + dark,存 scratchpad),對照 mockup 驗收:
+  - Canvas:palette 有 Result 卡、畫布上 res_query 卡、inspector Result 面板(mode/source/dataPath/maxItems/emptyText)。
+  - Preview:初始空狀態文案 → 填 Name → 按 Query → result 卡渲染 echo data(kv 卡);切 json 模式確認 pretty print;錯誤/loading 狀態若可便捷觸發亦截。
+- [ ] **Step 3:** 截圖貼給使用者確認後 push + `gh pr create`(HOLD 不 merge)。PR 描述(英文)要點:result item kind(card/json,table reserved for @rfjs/table-builder)、binding/dataPath/maxItems、四狀態、card-stays-dumb boundary、changesets 兩枚 minor。

--- a/docs/superpowers/specs/2026-07-08-form-result-item-design.md
+++ b/docs/superpowers/specs/2026-07-08-form-result-item-design.md
@@ -1,0 +1,96 @@
+# form-builder result item(api 回應展示區)— 設計規格
+
+日期:2026-07-08
+分支:`feat-form-result`(獨立 worktree,基於 `origin/main` @ `5ad3141`)
+狀態:已與使用者確認(綁定 = sourceId 選填;dataPath 選填;card 陣列 = 卡片列表 + 上限;table 模式預留透傳)
+
+## 目標
+
+form-builder 系列新增 **`result` item kind**:表單內的 api 回應展示區。與 #232 的 api 按鈕動作銜接 —— 「條件欄位 + api 按鈕 + result 區」組成完整的查詢型表單。
+
+1. **Engine**:`ResultItem` 型別 + zod schema(`mode: 'card' | 'json' | 'table'`;table 為預留變體)。
+2. **Renderer(ConfigForm)**:api 動作成功後,回應餵給對應 result item 渲染;含空/loading/錯誤狀態。
+3. **工具**:palette「Result」卡、inspector 綁定面板、範例補 api 按鈕 + result 區。
+
+## 非目標(v1 明確不做)
+
+- **table 模式不實作渲染** —— schema 預留 `{ mode: 'table', table?: unknown }` 透傳(另一個並行 session 正在做 `@rfjs/data-schema` + `@rfjs/table-builder`;其 `TableConfig` 落地後由後續 PR 接上)。v1 遇 `mode: 'table'` 渲染占位卡(「Table view — pending table-builder」)。
+- 不做 inline 編輯、不做分頁控制(屬 table-builder 範疇)。
+- 不動 Submission 面板(它管 payload,result 管畫面)。
+- **並行紅線**:不碰 `packages/web-core/**`、`apps/web/src/tools/{index,messages}.ts`、`apps/web/src/tools/index.spec.ts`、`apps/web/next.config.js`、`apps/web/package.json`(歸 table-builder session);本 session 只動 `packages/form-builder*` + `apps/web/src/tools/form-builder/**` + `apps/web/e2e/form-builder.e2e.ts`。
+
+## 1. Engine schema(`packages/form-builder`)
+
+```ts
+export interface ResultItem {
+  id: string;
+  kind: 'result';
+  mode: 'card' | 'json' | 'table';
+  /** 綁定的 api 按鈕 item id;缺省 = 顯示全域最後一次 api 成功回應。 */
+  sourceId?: string;
+  /** dot path 先取子節點再渲染(同 api responseMap 的路徑語法);缺省渲染整包回應。 */
+  dataPath?: string;
+  /** card 模式陣列上限,預設 10;超過顯示「+N more」。 */
+  maxItems?: number;
+  /** mode:'table' 預留:未來放 @rfjs/table-builder 的 TableConfig;v1 透傳不解讀。 */
+  table?: unknown;
+  /** 空狀態文案;缺省內建英文 'No result yet'。 */
+  emptyText?: LocalizedLabel;
+}
+```
+
+- `ItemKind` 聯集加 `'result'`;`FormItem` 聯集加 `ResultItem`;zod schema 同步(`mode` enum 必填、`maxItems` 正整數、其餘選填;`table` 用 `z.unknown().optional()`)。
+- **`tree-ops` 的 `makeItem` 同步加 `'result'` case**(預設 `{ mode: 'json' }`)—— #232 的教訓,這次列進任務。
+- `config-to-zod` 不受影響(result 非資料欄位)。
+
+## 2. Renderer 行為(`packages/form-builder-ui` config-form.tsx)
+
+### 回應狀態
+
+```ts
+// api 成功後寫入;config 變更時清空(沿用既有 epoch/reset 慣例)。
+const [apiResults, setApiResults] = React.useState<{
+  byButtonId: Record<string, unknown>;   // 該按鈕最新成功回應
+  last?: { buttonId: string; response: unknown };  // 全域最後一次
+}>({ byButtonId: {} });
+```
+
+- 寫入點:`runAction` 的 api 成功分支(epoch guard 之後、`onAction` 之前)。
+- 失敗不寫入 `apiResults`;失敗狀態由既有 `apiState`(status:'error')驅動 result 的錯誤顯示。
+
+### result item 渲染(renderItem 新分支)
+
+| 狀態 | 條件 | 顯示 |
+|---|---|---|
+| 空 | 尚無對應回應 | `emptyText`(resolveLabel,缺省 'No result yet') |
+| loading | 綁定按鈕(或無綁定時任一 api 按鈕)`apiState.status === 'pending'` | 'Loading…' + spinner |
+| 錯誤 | 對應按鈕最近一次 `apiState.status === 'error'` 且無成功回應可示 | 內建錯誤文案(含 meta 已有的 apiError 訊息不重複 —— 顯示 'Request failed') |
+| 成功 | 有回應 | 依 mode 渲染(下) |
+
+- **取值**:`sourceId` 有填 → `byButtonId[sourceId]`;沒填 → `last.response`。再套 `dataPath`(dot path helper 與 responseMap 共用 `getPath`);取不到(undefined)→ 視為空狀態,不炸。
+- **card**:值為物件 → key-value 卡(key 左、值右;值非 scalar 時 `JSON.stringify` 單行截斷);值為陣列 → 逐筆 key-value 卡直式堆疊,`maxItems`(預設 10)截斷 + 「+N more」;值為 scalar → 單值卡。
+- **json**:`<pre>` pretty print(`JSON.stringify(v, null, 2)`),樣式比照工具 JSON 面板(`bg-muted/30` 等既有慣例)。
+- **table**:占位卡「Table view — pending table-builder」。
+- 佈局:與其他 item 相同走 grid placement/fieldSpanStyle;無 conditional(型別不含,與 ButtonItem 一致)。
+
+## 3. 工具(apps/web form-builder)
+
+- **model.ts**:`Kind` 加 `"result"`;`Card` 加 `mode?/sourceId?/dataPath?/maxItems?/resultTable?(對映 table)/emptyText?`(命名避開既有欄位);cardToItem/formConfigToCards 雙向;新 result 卡預設 `{ mode: 'json' }`。
+- **ui.tsx**:`KIND_META` 加 result 卡(icon `PanelBottom` 或類似、區別色);`PALETTE` 加 `"result"`。
+- **inspector**:新 `inspector/result.tsx` —— mode select(card/json/table;table 選項標示 "coming soon" 但可選存)、source 下拉(列出畫布上現有 api 按鈕的 id+label,含「Last api response (unbound)」)、dataPath 輸入框、maxItems number(僅 card 顯示)、emptyText 輸入框。掛進 settings-panel(`isResult` gate)。
+- **範例(sample.ts)**:加一顆 api 按鈕(`{ type: 'api', url: '/api/search', fields: [...] }`,打 preview 的 echo fetcher)+ 一個 result 區(`mode: 'card'`, `dataPath: 'received.data'`, 綁定該按鈕)—— preview 按查詢就看到 echo 內容渲染成卡片。placements 對齊現有 row 結構。
+- inspector/palette 文案沿用硬編英文慣例;範例 label 用 LocalizedLabel(en+zh-TW)。
+
+## 4. 測試策略
+
+- **engine**:zod 各變體(合法:三種 mode、選填齊全;非法:mode 缺、maxItems 0/負數);`makeItem('result')`。
+- **renderer**:空狀態 → 按綁定按鈕(mock fetcher)→ card 渲染物件;陣列 + maxItems 截斷 + '+N more';dataPath 取子節點;dataPath 取不到 → 空狀態;json 模式 pretty print;sourceId 綁定隔離(A 按鈕回應不進 B 的 result);無綁定顯示 last;錯誤狀態;loading 狀態;config 切換清空;table 模式占位卡。
+- **工具**:model 雙向 round-trip;inspector 面板(mode 切換、source 下拉列 api 按鈕、maxItems 僅 card 顯示);ui.spec palette。
+- **e2e 一條**:Preview → 按範例 api 按鈕 → result 卡出現 echo 內容。
+- 真渲染:`next build` + `next start` 截圖 light/dark。
+
+## 5. 慣例
+
+- Changesets:`@rfjs/form-builder` minor、`@rfjs/form-builder-ui` minor(政策:有異動的 package 一律寫,private version-only)。
+- Commit/PR 英文 conventional(subject 全小寫),`Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`;spec/plan 繁中;HOLD PR。
+- e2e 撞 port 3002 時用 `E2E_PORT=3013`(table-builder session 用 3012)。

--- a/docs/superpowers/specs/2026-07-08-form-result-item-design.md
+++ b/docs/superpowers/specs/2026-07-08-form-result-item-design.md
@@ -16,6 +16,7 @@ form-builder 系列新增 **`result` item kind**:表單內的 api 回應展示�
 
 - **table 模式不實作渲染** —— schema 預留 `{ mode: 'table', table?: unknown }` 透傳(另一個並行 session 正在做 `@rfjs/data-schema` + `@rfjs/table-builder`;其 `TableConfig` 落地後由後續 PR 接上)。v1 遇 `mode: 'table'` 渲染占位卡(「Table view — pending table-builder」)。
 - 不做 inline 編輯、不做分頁控制(屬 table-builder 範疇)。
+- **card 永遠保持零配置**(與 table-builder 的分工紀律,2026-07-08 與使用者確認):card 只有 `maxItems` 一個旋鈕 —— 資料有什麼 key 就畫什麼。任何「選欄位/改順序/格式化/欄寬」需求一律屬 `mode: 'table'`(TableConfig 的事),不得往 card 加。mockup:`docs/mockups/2026-07-08-form-result-item.html`,實作以它為驗收基準。
 - 不動 Submission 面板(它管 payload,result 管畫面)。
 - **並行紅線**:不碰 `packages/web-core/**`、`apps/web/src/tools/{index,messages}.ts`、`apps/web/src/tools/index.spec.ts`、`apps/web/next.config.js`、`apps/web/package.json`(歸 table-builder session);本 session 只動 `packages/form-builder*` + `apps/web/src/tools/form-builder/**` + `apps/web/e2e/form-builder.e2e.ts`。
 

--- a/packages/form-builder-ui/src/config-form.spec.tsx
+++ b/packages/form-builder-ui/src/config-form.spec.tsx
@@ -1160,3 +1160,93 @@ describe('button items', () => {
     });
   });
 });
+
+describe('result items', () => {
+  const resultCfg = (result: Partial<import('@rfjs/form-builder').ResultItem>, apiOver?: object): FormConfig => ({
+    version: 1,
+    sections: [{
+      id: 's1',
+      rows: [{
+        id: 'r1',
+        items: [
+          { id: 'f1', kind: 'field', key: 'name', label: 'Name', component: 'Input', dataType: 'string' },
+          { id: 'b1', kind: 'button', label: 'Query', action: { type: 'api', url: '/x', ...apiOver } },
+          { id: 'b2', kind: 'button', label: 'Other', action: { type: 'api', url: '/y' } },
+          { id: 'res1', kind: 'result', mode: 'json', ...result },
+        ],
+      }],
+    }],
+  });
+
+  it('starts empty, renders the bound response after the api button succeeds', async () => {
+    const fetcher = vi.fn().mockResolvedValue({ hello: 'world' });
+    render(<ConfigForm config={resultCfg({ sourceId: 'b1' })} onSubmit={vi.fn()} fetcher={fetcher} />);
+    expect(screen.getByText('No result yet')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'Query' }));
+    await waitFor(() => expect(screen.getByText(/"hello": "world"/)).toBeTruthy());
+  });
+
+  it('bound result ignores other buttons; unbound shows the last response', async () => {
+    const fetcher = vi.fn()
+      .mockResolvedValueOnce({ from: 'other' });
+    render(
+      <ConfigForm
+        config={{
+          ...resultCfg({ sourceId: 'b1' }),
+          sections: [{
+            id: 's1',
+            rows: [{
+              id: 'r1',
+              items: [
+                { id: 'b1', kind: 'button', label: 'Query', action: { type: 'api', url: '/x' } },
+                { id: 'b2', kind: 'button', label: 'Other', action: { type: 'api', url: '/y' } },
+                { id: 'res1', kind: 'result', mode: 'json', sourceId: 'b1' },
+                { id: 'res2', kind: 'result', mode: 'json' },
+              ],
+            }],
+          }],
+        }}
+        onSubmit={vi.fn()}
+        fetcher={fetcher}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Other' }));
+    // 綁定 b1 的 res1 不顯示 b2 的回應;未綁定的 res2 顯示
+    await waitFor(() => expect(screen.getByText(/"from": "other"/)).toBeTruthy());
+    expect(screen.getByText('No result yet')).toBeTruthy(); // res1 仍空
+  });
+
+  it('dataPath extracts a sub-node; missing path falls back to empty', async () => {
+    const fetcher = vi.fn().mockResolvedValue({ data: { items: [{ id: 1 }] } });
+    const { rerender } = render(
+      <ConfigForm config={resultCfg({ sourceId: 'b1', mode: 'card', dataPath: 'data.items' })} onSubmit={vi.fn()} fetcher={fetcher} />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Query' }));
+    await waitFor(() => expect(screen.getByText('id')).toBeTruthy());
+    // 換一個取不到的 path,重新查詢:hasResponse 為真但 getPath undefined → 空狀態,不炸
+    rerender(<ConfigForm config={resultCfg({ sourceId: 'b1', mode: 'card', dataPath: 'no.such' })} onSubmit={vi.fn()} fetcher={fetcher} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Query' }));
+    await waitFor(() => expect(fetcher).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(screen.getByText('No result yet')).toBeTruthy());
+  });
+
+  it('shows loading while the bound button is pending and error on failure', async () => {
+    let reject!: (e: Error) => void;
+    const fetcher = vi.fn().mockReturnValue(new Promise((_r, rej) => { reject = rej; }));
+    render(<ConfigForm config={resultCfg({ sourceId: 'b1' })} onSubmit={vi.fn()} fetcher={fetcher} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Query' }));
+    await waitFor(() => expect(screen.getByText(/loading/i)).toBeTruthy());
+    reject(new Error('boom'));
+    await waitFor(() => expect(screen.getByText(/request failed/i)).toBeTruthy());
+  });
+
+  it('config change clears stored responses', async () => {
+    const fetcher = vi.fn().mockResolvedValue({ a: 1 });
+    const cfg = resultCfg({ sourceId: 'b1' });
+    const { rerender } = render(<ConfigForm config={cfg} onSubmit={vi.fn()} fetcher={fetcher} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Query' }));
+    await waitFor(() => expect(screen.getByText(/"a": 1/)).toBeTruthy());
+    rerender(<ConfigForm config={{ ...cfg }} onSubmit={vi.fn()} fetcher={fetcher} />);
+    await waitFor(() => expect(screen.getByText('No result yet')).toBeTruthy());
+  });
+});

--- a/packages/form-builder-ui/src/config-form.spec.tsx
+++ b/packages/form-builder-ui/src/config-form.spec.tsx
@@ -1240,6 +1240,22 @@ describe('result items', () => {
     await waitFor(() => expect(screen.getByText(/request failed/i)).toBeTruthy());
   });
 
+  it('surfaces the bound button\'s own error after a prior success, without hiding the stale result', async () => {
+    const fetcher = vi.fn()
+      .mockResolvedValueOnce({ ok: 1 })
+      .mockRejectedValueOnce(new Error('boom'));
+    render(<ConfigForm config={resultCfg({ sourceId: 'b1' })} onSubmit={vi.fn()} fetcher={fetcher} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Query' }));
+    await waitFor(() => expect(screen.getByText(/"ok": 1/)).toBeTruthy());
+    expect(screen.queryByText(/request failed/i)).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Query' }));
+    await waitFor(() => expect(screen.getAllByText(/request failed/i)).toHaveLength(1));
+    // Result still shows the stale success data — not overwritten/cleared by the failure.
+    expect(screen.getByText(/"ok": 1/)).toBeTruthy();
+  });
+
   it('config change clears stored responses', async () => {
     const fetcher = vi.fn().mockResolvedValue({ a: 1 });
     const cfg = resultCfg({ sourceId: 'b1' });

--- a/packages/form-builder-ui/src/config-form.tsx
+++ b/packages/form-builder-ui/src/config-form.tsx
@@ -396,8 +396,8 @@ export function ConfigForm({ config, defaultValues, onSubmit, submitLabel = 'Sub
   }
 
   // Button ids that own a dedicated (sourceId-bound) result item — their inline success/error
-  // message is redundant with (and would visually/DOM-duplicate) the ResultView's own state text,
-  // so it's suppressed in favor of the result item.
+  // message would otherwise visually/DOM-duplicate the ResultView's own state text. See the
+  // `bound`/`hasStoredResponse` logic below for exactly when the inline message still shows.
   const resultBoundButtonIds = React.useMemo(() => {
     const ids = new Set<string>();
     for (const section of normalizeToSections(config)) {
@@ -448,10 +448,17 @@ export function ConfigForm({ config, defaultValues, onSubmit, submitLabel = 'Sub
       const pending = mine?.status === 'pending';
       const apiDisabled = isApi && (!fetcher || apiState?.status === 'pending');
       const apiMessages = item.action.type === 'api' ? item.action.messages : undefined;
+      // A result item bound to this button (resultBoundButtonIds) renders its own state text,
+      // so the inline message is redundant — but ONLY in the cases ResultView actually covers:
+      // success is always shown by the rendered data, but ResultView's error state only fires
+      // while there's no stored response yet (`!hasResponse`); once a success has been stored,
+      // ResultView falls through to 'ready' (stale data) on a later failure, so the button must
+      // surface its own error again or the failure would be silent.
+      const bound = resultBoundButtonIds.has(item.id);
+      const hasStoredResponse = item.id in apiResults.byButtonId;
       const msg =
-        resultBoundButtonIds.has(item.id) ? null
-        : mine?.status === 'success' ? resolveLabel(apiMessages?.success ?? 'Success', locale)
-        : mine?.status === 'error' ? resolveLabel(apiMessages?.error ?? 'Request failed', locale)
+        mine?.status === 'success' ? (bound ? null : resolveLabel(apiMessages?.success ?? 'Success', locale))
+        : mine?.status === 'error' ? (bound && !hasStoredResponse ? null : resolveLabel(apiMessages?.error ?? 'Request failed', locale))
         : null;
       return (
         <div key={item.id} data-item={item.id} className="flex min-w-0 items-center gap-2" style={place ? placementStyle(place) : fieldSpanStyle(undefined, flow, cols)}>

--- a/packages/form-builder-ui/src/config-form.tsx
+++ b/packages/form-builder-ui/src/config-form.tsx
@@ -19,12 +19,14 @@ import {
   type SignatureTransport,
   type ButtonActionType,
   type ButtonItem,
+  type ResultItem,
 } from '@rfjs/form-builder';
 import { useDataSource } from './use-data-source';
 import { useContainerBreakpoint } from './use-container-breakpoint';
 import { Label } from '@rfjs/web-ui/components/label';
 import { Button } from '@rfjs/web-ui/components/button';
 import { FieldControl } from './field-control';
+import { ResultView, type ResultViewState } from './result-view';
 import { Loader2 } from 'lucide-react';
 
 // ---------------------------------------------------------------------------
@@ -212,6 +214,12 @@ export function ConfigForm({ config, defaultValues, onSubmit, submitLabel = 'Sub
   // api 動作狀態:同表單同時只允許一顆 in-flight。
   const [apiState, setApiState] = React.useState<{ itemId: string; status: 'pending' | 'success' | 'error' } | null>(null);
 
+  // result item 的資料來源:各 api 按鈕的最新成功回應 + 全域最後一次。
+  const [apiResults, setApiResults] = React.useState<{
+    byButtonId: Record<string, unknown>;
+    last?: { buttonId: string; response: unknown };
+  }>({ byButtonId: {} });
+
   // Bumps whenever `config` changes or the component unmounts. `runAction`'s api branch
   // captures the epoch before its `await fetcher(...)` and bails out (no setState/onAction)
   // if the epoch has moved on by the time the promise settles — guards against a stale
@@ -242,6 +250,7 @@ export function ConfigForm({ config, defaultValues, onSubmit, submitLabel = 'Sub
     // state (otherwise the button stays disabled forever) and bump the epoch so a late
     // fetcher resolution can't resurrect it.
     setApiState(null);
+    setApiResults({ byButtonId: {} });
     runEpoch.current += 1;
   }, [config]); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -373,6 +382,10 @@ export function ConfigForm({ config, defaultValues, onSubmit, submitLabel = 'Sub
           if (v !== undefined) setValue(targetKey, v, { shouldDirty: true });
         }
         setApiState({ itemId: item.id, status: 'success' });
+        setApiResults((prev) => ({
+          byButtonId: { ...prev.byButtonId, [item.id]: response },
+          last: { buttonId: item.id, response },
+        }));
         onAction?.('api', { data: sent, meta, response });
       } catch (err) {
         if (epoch !== runEpoch.current) return;   // unmounted or config swapped mid-flight — drop the result
@@ -381,6 +394,21 @@ export function ConfigForm({ config, defaultValues, onSubmit, submitLabel = 'Sub
       }
     }
   }
+
+  // Button ids that own a dedicated (sourceId-bound) result item — their inline success/error
+  // message is redundant with (and would visually/DOM-duplicate) the ResultView's own state text,
+  // so it's suppressed in favor of the result item.
+  const resultBoundButtonIds = React.useMemo(() => {
+    const ids = new Set<string>();
+    for (const section of normalizeToSections(config)) {
+      for (const row of section.rows) {
+        for (const item of row.items) {
+          if (item.kind === 'result' && item.sourceId !== undefined) ids.add(item.sourceId);
+        }
+      }
+    }
+    return ids;
+  }, [config]);
 
   function renderItem(item: FormItem, flow: 'v1' | 'section', cols: number, place?: { colStart: number; colSpan: number; row: number; rowSpan?: number }) {
     const vals = values as Record<string, unknown>;
@@ -421,7 +449,8 @@ export function ConfigForm({ config, defaultValues, onSubmit, submitLabel = 'Sub
       const apiDisabled = isApi && (!fetcher || apiState?.status === 'pending');
       const apiMessages = item.action.type === 'api' ? item.action.messages : undefined;
       const msg =
-        mine?.status === 'success' ? resolveLabel(apiMessages?.success ?? 'Success', locale)
+        resultBoundButtonIds.has(item.id) ? null
+        : mine?.status === 'success' ? resolveLabel(apiMessages?.success ?? 'Success', locale)
         : mine?.status === 'error' ? resolveLabel(apiMessages?.error ?? 'Request failed', locale)
         : null;
       return (
@@ -437,6 +466,24 @@ export function ConfigForm({ config, defaultValues, onSubmit, submitLabel = 'Sub
             {resolveLabel(item.label, locale)}
           </Button>
           {msg && <span className={`text-xs ${mine?.status === 'error' ? 'text-destructive' : 'text-muted-foreground'}`}>{msg}</span>}
+        </div>
+      );
+    }
+
+    if (item.kind === 'result') {
+      const raw = item.sourceId !== undefined ? apiResults.byButtonId[item.sourceId] : apiResults.last?.response;
+      const hasResponse = item.sourceId !== undefined ? item.sourceId in apiResults.byButtonId : apiResults.last !== undefined;
+      const value = hasResponse && item.dataPath ? getPath(raw, item.dataPath) : raw;
+      // 綁定時只理會來源按鈕的進行中/失敗;未綁定時理會任一 api 按鈕。
+      const watching = item.sourceId === undefined || apiState?.itemId === item.sourceId;
+      const state: ResultViewState =
+        watching && apiState?.status === 'pending' ? 'loading'
+        : watching && apiState?.status === 'error' && !hasResponse ? 'error'
+        : !hasResponse || value === undefined ? 'empty'
+        : 'ready';
+      return (
+        <div key={item.id} data-item={item.id} style={place ? placementStyle(place) : fieldSpanStyle(undefined, flow, cols)}>
+          <ResultView mode={item.mode} state={state} value={value} maxItems={item.maxItems} emptyText={item.emptyText} locale={locale} />
         </div>
       );
     }

--- a/packages/form-builder-ui/src/config-form.tsx
+++ b/packages/form-builder-ui/src/config-form.tsx
@@ -19,7 +19,6 @@ import {
   type SignatureTransport,
   type ButtonActionType,
   type ButtonItem,
-  type ResultItem,
 } from '@rfjs/form-builder';
 import { useDataSource } from './use-data-source';
 import { useContainerBreakpoint } from './use-container-breakpoint';

--- a/packages/form-builder-ui/src/index.ts
+++ b/packages/form-builder-ui/src/index.ts
@@ -4,6 +4,7 @@ export * from './config-form-builder';
 export * from './field-control';
 export * from './field-row';
 export * from './item-editor';
+export * from './result-view';
 export * from './section-arranger';
 export * from './use-config-builder';
 export * from './use-container-breakpoint';

--- a/packages/form-builder-ui/src/item-editor.tsx
+++ b/packages/form-builder-ui/src/item-editor.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import * as React from 'react';
-import { Trash2, ChevronRight, Type, AlignLeft, Minus, MoveVertical, Sparkles, MousePointerClick } from 'lucide-react';
+import { Trash2, ChevronRight, Type, AlignLeft, Minus, MoveVertical, Sparkles, MousePointerClick, PanelBottom } from 'lucide-react';
 import type { FieldItem, ContentItem, DividerItem, SpacerItem, AiNoteItem, FormItem, ItemKind, SpacerSize } from '@rfjs/form-builder';
 import { Input } from '@rfjs/web-ui/components/input';
 import { Textarea } from '@rfjs/web-ui/components/textarea';
@@ -36,6 +36,7 @@ const KIND_META: Record<ItemKind, KindMeta> = {
   divider: { label: 'Divider', Icon: Minus, color: '#6b7280' },
   spacer: { label: 'Spacer', Icon: MoveVertical, color: '#6b7280' },
   button: { label: 'Button', Icon: MousePointerClick, color: '#10b981' },
+  result: { label: 'Result', Icon: PanelBottom, color: '#0ea5e9' },
 };
 
 const PILL_COLORS: Record<string, string> = {

--- a/packages/form-builder-ui/src/result-view.spec.tsx
+++ b/packages/form-builder-ui/src/result-view.spec.tsx
@@ -1,0 +1,63 @@
+import { render, screen } from '@testing-library/react';
+import * as React from 'react';
+import { describe, expect, it } from 'vitest';
+
+import { ResultView } from './result-view';
+
+describe('ResultView states', () => {
+  it('empty: shows default text or custom LocalizedLabel', () => {
+    const { rerender } = render(<ResultView mode="card" state="empty" />);
+    expect(screen.getByText('No result yet')).toBeTruthy();
+    rerender(<ResultView mode="card" state="empty" emptyText={{ en: 'Nothing', 'zh-TW': '沒有資料' }} locale="zh-TW" />);
+    expect(screen.getByText('沒有資料')).toBeTruthy();
+  });
+
+  it('loading: shows spinner text', () => {
+    render(<ResultView mode="card" state="loading" />);
+    expect(screen.getByText(/loading/i)).toBeTruthy();
+  });
+
+  it('error: shows failure text', () => {
+    render(<ResultView mode="card" state="error" />);
+    expect(screen.getByText(/request failed/i)).toBeTruthy();
+  });
+});
+
+describe('ResultView card mode', () => {
+  it('object → one key-value card; non-scalar values stringified', () => {
+    render(<ResultView mode="card" state="ready" value={{ name: 'Roy', days: 3, detail: { dept: 'HR' } }} />);
+    expect(screen.getByText('name')).toBeTruthy();
+    expect(screen.getByText('Roy')).toBeTruthy();
+    expect(screen.getByText('{"dept":"HR"}')).toBeTruthy();
+  });
+
+  it('array → stacked cards capped by maxItems with a "+N more" hint', () => {
+    const rows = Array.from({ length: 5 }, (_, i) => ({ id: i + 1 }));
+    render(<ResultView mode="card" state="ready" value={rows} maxItems={3} />);
+    expect(screen.getAllByText('id')).toHaveLength(3);
+    expect(screen.getByText('+ 2 more')).toBeTruthy();
+  });
+
+  it('array within default cap renders all items and no hint', () => {
+    render(<ResultView mode="card" state="ready" value={[{ a: 1 }, { a: 2 }]} />);
+    expect(screen.getAllByText('a')).toHaveLength(2);
+    expect(screen.queryByText(/more$/)).toBeNull();
+  });
+
+  it('scalar → single value card', () => {
+    render(<ResultView mode="card" state="ready" value={42} />);
+    expect(screen.getByText('42')).toBeTruthy();
+  });
+});
+
+describe('ResultView json / table modes', () => {
+  it('json: pretty prints', () => {
+    render(<ResultView mode="json" state="ready" value={{ a: 1 }} />);
+    expect(screen.getByText(/"a": 1/)).toBeTruthy();
+  });
+
+  it('table: renders the pending placeholder', () => {
+    render(<ResultView mode="table" state="ready" value={[]} />);
+    expect(screen.getByText(/pending .*table-builder/i)).toBeTruthy();
+  });
+});

--- a/packages/form-builder-ui/src/result-view.tsx
+++ b/packages/form-builder-ui/src/result-view.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import * as React from 'react';
+import { Loader2 } from 'lucide-react';
+import { resolveLabel, type LocalizedLabel } from '@rfjs/form-builder';
+
+export type ResultViewState = 'empty' | 'loading' | 'error' | 'ready';
+
+export interface ResultViewProps {
+  mode: 'card' | 'json' | 'table';
+  state: ResultViewState;
+  value?: unknown;
+  maxItems?: number;
+  emptyText?: LocalizedLabel;
+  locale?: string;
+}
+
+const isScalar = (v: unknown): v is string | number | boolean =>
+  v === null || ['string', 'number', 'boolean'].includes(typeof v);
+
+function KvCard({ value }: { value: unknown }) {
+  if (isScalar(value)) {
+    return <div className="rounded-md border border-input bg-muted/30 px-3 py-2 text-sm">{String(value)}</div>;
+  }
+  const entries = Object.entries((value ?? {}) as Record<string, unknown>);
+  return (
+    <div className="flex flex-col gap-1.5 rounded-md border border-input bg-muted/30 px-3 py-2.5">
+      {entries.map(([k, v]) => (
+        <div key={k} className="flex gap-3 text-sm">
+          <span className="w-24 shrink-0 pt-px font-mono text-xs text-muted-foreground">{k}</span>
+          {isScalar(v) ? (
+            <span className="min-w-0 break-words">{String(v)}</span>
+          ) : (
+            <span className="min-w-0 truncate font-mono text-xs text-muted-foreground">{JSON.stringify(v)}</span>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+const stateBox = 'flex min-h-24 items-center justify-center gap-2 rounded-md border border-dashed border-input bg-muted/20 text-sm text-muted-foreground';
+
+/** api 回應的純展示元件 —— card 刻意零配置(僅 maxItems);欄位級控制屬 table 模式(table-builder)。 */
+export function ResultView({ mode, state, value, maxItems, emptyText, locale = 'en' }: ResultViewProps) {
+  if (state === 'empty') {
+    return <div className={stateBox}>{emptyText ? resolveLabel(emptyText, locale) : 'No result yet'}</div>;
+  }
+  if (state === 'loading') {
+    return (
+      <div className={stateBox}>
+        <Loader2 className="size-4 animate-spin" /> Loading…
+      </div>
+    );
+  }
+  if (state === 'error') {
+    return <div className={`${stateBox} border-destructive/40 text-destructive`}>Request failed</div>;
+  }
+
+  if (mode === 'json') {
+    return (
+      <pre className="max-h-64 overflow-auto rounded-md border border-input bg-muted/30 p-3 font-mono text-xs leading-relaxed">
+        {JSON.stringify(value, null, 2)}
+      </pre>
+    );
+  }
+
+  if (mode === 'table') {
+    return (
+      <div className={`${stateBox} flex-col gap-1`}>
+        <span className="font-medium text-foreground/70">Table view</span>
+        <span className="text-xs">pending @rfjs/table-builder</span>
+      </div>
+    );
+  }
+
+  // mode === 'card'
+  if (Array.isArray(value)) {
+    const cap = maxItems ?? 10;
+    const shown = value.slice(0, cap);
+    const rest = value.length - shown.length;
+    return (
+      <div className="flex flex-col gap-2">
+        {shown.map((row, i) => (
+          <KvCard key={i} value={row} />
+        ))}
+        {rest > 0 && (
+          <div className="rounded-md border border-dashed border-input py-1.5 text-center text-xs text-muted-foreground">{`+ ${rest} more`}</div>
+        )}
+      </div>
+    );
+  }
+  return <KvCard value={value} />;
+}

--- a/packages/form-builder/src/config-schema.spec.ts
+++ b/packages/form-builder/src/config-schema.spec.ts
@@ -540,3 +540,35 @@ describe('button items', () => {
     expect(r.success).toBe(true);
   });
 });
+
+describe('result items', () => {
+  const withItem = (item: unknown) => ({
+    version: 1,
+    sections: [{ id: 's1', rows: [{ id: 'r1', items: [item] }] }],
+  });
+
+  it('accepts minimal and full result items', () => {
+    const minimal = { id: 'res1', kind: 'result', mode: 'json' };
+    const full = {
+      id: 'res2', kind: 'result', mode: 'card',
+      sourceId: 'btn1', dataPath: 'data.items', maxItems: 5,
+      table: { anything: true }, emptyText: { en: 'Nothing', 'zh-TW': '沒有資料' },
+    };
+    for (const item of [minimal, full]) {
+      const r = formConfigSchema.safeParse(withItem(item));
+      expect(r.success, JSON.stringify(item)).toBe(true);
+    }
+  });
+
+  it('rejects invalid result items: missing mode, unknown mode, non-positive maxItems', () => {
+    const bad = [
+      { id: 'x', kind: 'result' },
+      { id: 'x', kind: 'result', mode: 'grid' },
+      { id: 'x', kind: 'result', mode: 'card', maxItems: 0 },
+    ];
+    for (const item of bad) {
+      const r = formConfigSchema.safeParse(withItem(item));
+      expect(r.success, JSON.stringify(item)).toBe(false);
+    }
+  });
+});

--- a/packages/form-builder/src/config-schema.ts
+++ b/packages/form-builder/src/config-schema.ts
@@ -164,6 +164,17 @@ const buttonItemSchema = z.object({
   validate: z.boolean().optional(),
 });
 
+const resultItemSchema = z.object({
+  id: z.string().min(1),
+  kind: z.literal('result'),
+  mode: z.enum(['card', 'json', 'table']),
+  sourceId: z.string().min(1).optional(),
+  dataPath: z.string().min(1).optional(),
+  maxItems: z.number().int().positive().optional(),
+  table: z.unknown().optional(),
+  emptyText: localizedLabelSchema.optional(),
+});
+
 const formItemSchema = z.discriminatedUnion('kind', [
   fieldItemSchema,
   contentItemSchema,
@@ -171,6 +182,7 @@ const formItemSchema = z.discriminatedUnion('kind', [
   spacerItemSchema,
   aiNoteItemSchema,
   buttonItemSchema,
+  resultItemSchema,
 ]);
 const gridPlacementSchema = z.object({
   itemId: z.string().min(1),

--- a/packages/form-builder/src/tree-ops.spec.ts
+++ b/packages/form-builder/src/tree-ops.spec.ts
@@ -92,6 +92,11 @@ describe('makeItem', () => {
     const item = makeItem('button');
     expect(item).toMatchObject({ kind: 'button', label: 'Button', action: { type: 'custom', name: 'action-1' } });
   });
+
+  it("makeItem('result') gives a json-mode result item", () => {
+    const item = makeItem('result');
+    expect(item).toMatchObject({ id: item.id, kind: 'result', mode: 'json' });
+  });
 });
 
 // --- addItem ---

--- a/packages/form-builder/src/tree-ops.ts
+++ b/packages/form-builder/src/tree-ops.ts
@@ -48,6 +48,8 @@ export function makeItem(kind: ItemKind, seed?: Omit<Partial<FieldItem>, 'id' | 
       return { id, kind: 'ai-note', text: '' };
     case 'button':
       return { id, kind: 'button', label: 'Button', action: { type: 'custom', name: 'action-1' } };
+    case 'result':
+      return { id, kind: 'result', mode: 'json' };
   }
 }
 

--- a/packages/form-builder/src/types.ts
+++ b/packages/form-builder/src/types.ts
@@ -81,7 +81,7 @@ export interface FieldConfig {
   fileUpload?: { accept?: string; multiple?: boolean; maxSize?: number };
 }
 
-export type ItemKind = 'field' | 'content' | 'divider' | 'spacer' | 'ai-note' | 'button';
+export type ItemKind = 'field' | 'content' | 'divider' | 'spacer' | 'ai-note' | 'button' | 'result';
 export type SpacerSize = 'sm' | 'md' | 'lg';
 
 export interface FieldItem extends FieldConfig {
@@ -126,7 +126,23 @@ export interface ButtonItem {
   validate?: boolean;   // default: submit→true, api/custom→false; ignored for reset/clear
 }
 
-export type FormItem = FieldItem | ContentItem | DividerItem | SpacerItem | AiNoteItem | ButtonItem;
+export interface ResultItem {
+  id: string;
+  kind: 'result';
+  mode: 'card' | 'json' | 'table';
+  /** 綁定的 api 按鈕 item id;缺省 = 顯示全域最後一次 api 成功回應。 */
+  sourceId?: string;
+  /** dot path 先取子節點再渲染(同 responseMap 語法);缺省渲染整包回應。 */
+  dataPath?: string;
+  /** card 模式陣列上限,預設 10。 */
+  maxItems?: number;
+  /** mode:'table' 預留:未來放 @rfjs/table-builder 的 TableConfig;v1 透傳不解讀。 */
+  table?: unknown;
+  /** 空狀態文案;缺省內建 'No result yet'。 */
+  emptyText?: LocalizedLabel;
+}
+
+export type FormItem = FieldItem | ContentItem | DividerItem | SpacerItem | AiNoteItem | ButtonItem | ResultItem;
 
 /** Explicit 12-column-grid placement of a single item (positioned by its `id`). */
 export interface GridPlacement {


### PR DESCRIPTION
## Summary

Adds a **`result` item kind** to form-builder — an api-response display area that completes the query-style form story: condition fields + api button (#232) + result area.

- **Engine (`@rfjs/form-builder`, minor)** — `ResultItem` (`kind: 'result'`): `mode: 'card' | 'json' | 'table'`, optional `sourceId` (bind to a specific api button; unbound = last api response), `dataPath` (dot-path extraction, same syntax as `responseMap`), `maxItems` (card list cap, default 10), `emptyText`, and a reserved `table?: unknown` passthrough for the upcoming `@rfjs/table-builder` TableConfig.
- **Renderer (`@rfjs/form-builder-ui`, minor)** — ConfigForm stores api successes (`byButtonId` + `last`, cleared on config change, epoch-guarded) and renders through a new pure `ResultView` component with four states: empty (custom/default text) / loading (bound-button pending) / error / ready. Card mode: object → key-value card, array → stacked cards capped with a "+ N more" hint, scalar → single value; json → pretty print; table → placeholder pending table-builder. Bound buttons hand their feedback to the result area (inline success message suppressed; inline error suppressed only before the first success so a failure-after-success is never silent).
- **Tool (apps/web)** — palette "Result" card, inspector Result panel (mode / source dropdown incl. a visible `missing: <id>` state for dangling bindings / data path / max items / empty text), sample gains a Query api button + bound result card so Preview demos the full loop against the echo fetcher.

**Design discipline (agreed with the parallel table-builder work):** card stays zero-config — the only knob is `maxItems`. Anything column-aware (pick/order/format fields) belongs to `mode: 'table'` and the parallel `@rfjs/table-builder`; its `TableConfig` will slot into the reserved `table` field in a follow-up PR.

## Review notes (accepted)

- Card edge renders are plain-but-safe: `null` shows the literal "null", `{}` shows an empty card, `undefined` entry values show a blank row.
- Localized (record) `emptyText` survives the engine but the canvas tool edits strings only — a record round-tripped through the tool is dropped (known v1 tool-layer limit).
- `resultTable ↔ table` round-trip is code-traced correct but not test-pinned.

## Test plan

- Unit: 729 specs pass — engine 172 (schema variants, makeItem), renderer 266 (ResultView state/mode matrix, binding isolation, dataPath, config-change clearing, failure-after-success regression), web 291 (model round-trip, inspector incl. dangling-source + fractional-maxItems regressions, preview echo loop).
- E2E: 14/14 incl. new "query api button renders the echoed response in the result card".
- Real render (next build + start, light/dark) verified against the committed mockup `docs/mockups/2026-07-08-form-result-item.html`: empty state text, kv card after query, inspector panel.
- Changesets: `@rfjs/form-builder` minor (publishable), `@rfjs/form-builder-ui` minor (private, version-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)