### PR TITLE
feat(form-builder): render result mode:'table' with ConfigTable (A render + B snapshot)

### DIFF
--- a/.changeset/form-result-table-render.md
+++ b/.changeset/form-result-table-render.md
@@ -1,0 +1,5 @@
+---
+"@rfjs/form-builder": minor
+---
+
+Type and validate the result item `table` field as `TableConfig` (was `unknown`), backing the form result `mode:'table'` renderer.

--- a/.changeset/form-result-table-ui.md
+++ b/.changeset/form-result-table-ui.md
@@ -1,0 +1,5 @@
+---
+"@rfjs/form-builder-ui": minor
+---
+
+Render result items with `mode:'table'` using `@rfjs/table-builder-ui`'s `ConfigTable`, deriving columns from the response when no `table` config is carried.

--- a/apps/web/src/tools/form-builder/inspector/result-table-snapshot.spec.ts
+++ b/apps/web/src/tools/form-builder/inspector/result-table-snapshot.spec.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { snapshotTableConfig } from "./result-table-snapshot";
+
+describe("snapshotTableConfig", () => {
+  it("derives a TableConfig from a sample array", () => {
+    const { config, error } = snapshotTableConfig('[{"id":1,"name":"Ada"}]');
+    expect(error).toBeUndefined();
+    expect(config?.columns.map((c) => c.key)).toEqual(["id", "name"]);
+    expect(config?.pagination.pageSize).toBeGreaterThan(0);
+  });
+
+  it("wraps a single object into a one-row inference", () => {
+    const { config } = snapshotTableConfig('{"a":1,"b":"x"}');
+    expect(config?.columns.map((c) => c.key)).toEqual(["a", "b"]);
+  });
+
+  it("returns an error for invalid JSON", () => {
+    const { config, error } = snapshotTableConfig("{not json");
+    expect(config).toBeUndefined();
+    expect(error).toMatch(/json/i);
+  });
+
+  it("returns an error for an empty array", () => {
+    const { error } = snapshotTableConfig("[]");
+    expect(error).toBeTruthy();
+  });
+});

--- a/apps/web/src/tools/form-builder/inspector/result-table-snapshot.ts
+++ b/apps/web/src/tools/form-builder/inspector/result-table-snapshot.ts
@@ -1,0 +1,24 @@
+import { deriveTableConfig, type TableConfig } from "@rfjs/table-builder";
+import { inferFieldsFromRows } from "@rfjs/data-schema";
+
+/**
+ * Turn a pasted sample response into a TableConfig via infer→derive.
+ * Accepts an array of row objects or a single object (wrapped to one row).
+ * Pure and self-contained so it unit-tests without rendering.
+ */
+export function snapshotTableConfig(text: string): { config?: TableConfig; error?: string } {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return { error: "Invalid JSON" };
+  }
+  const rows = Array.isArray(parsed) ? parsed : [parsed];
+  try {
+    const fields = inferFieldsFromRows(rows);
+    if (fields.length === 0) return { error: "No columns found in the sample" };
+    return { config: deriveTableConfig({ fields }) };
+  } catch (e) {
+    return { error: e instanceof Error ? e.message : "Could not read the sample" };
+  }
+}

--- a/apps/web/src/tools/form-builder/inspector/result.spec.tsx
+++ b/apps/web/src/tools/form-builder/inspector/result.spec.tsx
@@ -58,3 +58,37 @@ describe("ResultSection", () => {
     expect(onChange).toHaveBeenCalledWith({ maxItems: undefined });
   });
 });
+
+describe("ResultSection table snapshot", () => {
+  it("snapshots pasted rows into resultTable", () => {
+    const onChange = vi.fn();
+    render(<ResultSection card={resCard({ mode: "table" })} onChange={onChange} apiButtons={apiButtons} />);
+    fireEvent.change(screen.getByPlaceholderText(/paste a sample/i), {
+      target: { value: '[{"id":1,"name":"Ada"}]' },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /snapshot/i }));
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ resultTable: expect.objectContaining({ columns: expect.any(Array) }) }),
+    );
+  });
+
+  it("shows an error and does not write on invalid JSON", () => {
+    const onChange = vi.fn();
+    render(<ResultSection card={resCard({ mode: "table" })} onChange={onChange} apiButtons={apiButtons} />);
+    fireEvent.change(screen.getByPlaceholderText(/paste a sample/i), { target: { value: "{bad" } });
+    fireEvent.click(screen.getByRole("button", { name: /snapshot/i }));
+    expect(screen.getByText(/invalid json/i)).toBeTruthy();
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("clears resultTable", () => {
+    const onChange = vi.fn();
+    const withTable = resCard({
+      mode: "table",
+      resultTable: { columns: [{ key: "x", label: "X", dataType: "string" }], pagination: { pageSize: 10 } },
+    });
+    render(<ResultSection card={withTable} onChange={onChange} apiButtons={apiButtons} />);
+    fireEvent.click(screen.getByRole("button", { name: /clear/i }));
+    expect(onChange).toHaveBeenCalledWith({ resultTable: undefined });
+  });
+});

--- a/apps/web/src/tools/form-builder/inspector/result.tsx
+++ b/apps/web/src/tools/form-builder/inspector/result.tsx
@@ -3,6 +3,7 @@ import * as React from "react";
 
 import { INPUT_CLS } from "./constants";
 import type { Card } from "../model";
+import { snapshotTableConfig } from "./result-table-snapshot";
 
 const MODES = ["card", "json", "table"] as const;
 
@@ -16,7 +17,7 @@ export function ResultSection({
         Mode
         <select className={INPUT_CLS} value={mode} onChange={(e) => onChange({ mode: e.target.value as Card["mode"] })}>
           {MODES.map((m) => (
-            <option key={m} value={m}>{m === "table" ? "table (coming soon)" : m}</option>
+            <option key={m} value={m}>{m}</option>
           ))}
         </select>
       </label>
@@ -54,10 +55,54 @@ export function ResultSection({
         </label>
       )}
 
+      {mode === "table" && <TableSnapshot card={card} onChange={onChange} />}
+
       <label className="flex flex-col gap-1 text-xs text-muted-foreground">
         Empty text
         <input className={INPUT_CLS} value={card.emptyText ?? ""} placeholder="No result yet" onChange={(e) => onChange({ emptyText: e.target.value || undefined })} />
       </label>
+    </div>
+  );
+}
+
+function TableSnapshot({ card, onChange }: { card: Card; onChange: (p: Partial<Card>) => void }) {
+  const [text, setText] = React.useState("");
+  const [error, setError] = React.useState<string | null>(null);
+  const columnCount = card.resultTable?.columns.length ?? 0;
+
+  function doSnapshot() {
+    const { config, error: err } = snapshotTableConfig(text);
+    if (err || !config) {
+      setError(err ?? "Could not read the sample");
+      return;
+    }
+    setError(null);
+    onChange({ resultTable: config });
+  }
+
+  return (
+    <div className="flex flex-col gap-1.5 rounded-md border border-input bg-muted/20 p-2">
+      <span className="text-xs text-muted-foreground">
+        {columnCount > 0 ? `${columnCount} columns captured — edit in the JSON tab` : "No columns yet — auto-derived from the response, or snapshot a sample:"}
+      </span>
+      <textarea
+        className={`${INPUT_CLS} font-mono`}
+        rows={3}
+        value={text}
+        placeholder='Paste a sample response, e.g. [{"id":1,"name":"Ada"}]'
+        onChange={(e) => setText(e.target.value)}
+      />
+      {error && <span className="text-xs text-destructive">{error}</span>}
+      <div className="flex gap-2">
+        <button type="button" className="rounded-md border border-input px-2 py-1 text-xs hover:bg-muted" onClick={doSnapshot}>
+          Snapshot columns
+        </button>
+        {columnCount > 0 && (
+          <button type="button" className="rounded-md border border-input px-2 py-1 text-xs hover:bg-muted" onClick={() => onChange({ resultTable: undefined })}>
+            Clear
+          </button>
+        )}
+      </div>
     </div>
   );
 }

--- a/apps/web/src/tools/form-builder/model.spec.ts
+++ b/apps/web/src/tools/form-builder/model.spec.ts
@@ -212,4 +212,21 @@ describe('result cards', () => {
     const item = cardsToFormConfig(groups, cards).sections![0]!.rows[0]!.items[0]!;
     expect(item).toMatchObject({ kind: 'result', mode: 'json' });
   });
+
+  it('round-trips a table-mode result item with a TableConfig', () => {
+    const table = {
+      columns: [{ key: 'name', label: 'Name', dataType: 'string' as const }],
+      pagination: { pageSize: 10 },
+    };
+    const groups = [{ id: 'g1', title: 'G', collapsed: false }];
+    const cards = [
+      { id: 'res', groupId: 'g1', kind: 'result' as const, label: 'Result', mode: 'table' as const,
+        resultTable: table, col: 1, span: 6, row: 1 },
+    ];
+    const config = cardsToFormConfig(groups, cards);
+    const back = formConfigToCards(config);
+    const res = back.cards.find((c) => c.id === 'res');
+    expect(res?.mode).toBe('table');
+    expect(res?.resultTable).toEqual(table);
+  });
 });

--- a/apps/web/src/tools/form-builder/model.ts
+++ b/apps/web/src/tools/form-builder/model.ts
@@ -6,6 +6,7 @@ import {
   type LocalizedLabel, type FieldOption, type FieldValidation, type ConditionalRule, type DataSource,
   type ButtonAction,
 } from "@rfjs/form-builder";
+import type { TableConfig } from "@rfjs/table-builder";
 
 export type Kind = "field" | "content" | "divider" | "spacer" | "ai-note" | "button" | "result";
 // Canvas Component = full engine FieldComponent union.
@@ -40,7 +41,7 @@ export interface Card {
   sourceId?: string; // result
   dataPath?: string; // result
   maxItems?: number; // result
-  resultTable?: unknown; // result
+  resultTable?: TableConfig; // result
   emptyText?: string; // result
   col: number;
   span: number;

--- a/apps/web/src/tools/form-builder/sample.ts
+++ b/apps/web/src/tools/form-builder/sample.ts
@@ -182,7 +182,7 @@ export const SAMPLE_CONFIG: FormConfig = {
         {
           id: "r_result",
           items: [
-            { id: "res_query", kind: "result", mode: "card", sourceId: "btn_query", dataPath: "received.data", emptyText: "Run a query to see results" },
+            { id: "res_query", kind: "result", mode: "table", sourceId: "btn_query", dataPath: "data", emptyText: "Run a query to see results" },
           ],
         },
       ],

--- a/apps/web/src/tools/form-builder/ui.spec.tsx
+++ b/apps/web/src/tools/form-builder/ui.spec.tsx
@@ -192,13 +192,14 @@ describe("FormBuilderTool preview tab integration", () => {
     await waitFor(() => expect(screen.getAllByText(/save-draft/).length).toBeGreaterThan(0));
   });
 
-  it("preview: query api button renders its echoed response into the result card", async () => {
+  it("preview: query api button renders its rows as a ConfigTable in the result", async () => {
     renderTool();
     fireEvent.click(screen.getByRole("button", { name: /^preview$/i }));
     fireEvent.click(await screen.findByRole("button", { name: /^query$/i }));
-    // echo fetcher 回 { echoedAt, received: { data, meta } };result dataPath received.data → kv 卡出現欄位 key
+    // query fetcher returns SAMPLE_QUERY_ROWS under `data`; result mode:'table' → ConfigTable headers + rows
     const resultContainer = document.querySelector('[data-item="res_query"]') as HTMLElement;
-    await waitFor(() => expect(resultContainer.textContent).toMatch(/name/i));
+    await waitFor(() => expect(resultContainer.textContent).toMatch(/email/i));
+    expect(resultContainer.textContent).toMatch(/Ada Lovelace/);
   });
 });
 

--- a/apps/web/src/tools/form-builder/ui.tsx
+++ b/apps/web/src/tools/form-builder/ui.tsx
@@ -53,6 +53,14 @@ const GAP = 8;
 const DRAG_THRESHOLD = 4; // px the pointer must travel before a press becomes a drag (a click just selects)
 const clamp = (v: number, lo: number, hi: number) => Math.max(lo, Math.min(hi, v));
 
+// Demo rows for query-shaped api-action URLs (e.g. /api/actions/query) — lets the
+// result mode:'table' snapshot/preview show a ConfigTable instead of a bare echo.
+const SAMPLE_QUERY_ROWS = [
+  { id: 1001, name: "Ada Lovelace", email: "ada@example.com", amount: 1240, status: "paid" },
+  { id: 1002, name: "Alan Turing", email: "alan@example.com", amount: 980, status: "pending" },
+  { id: 1003, name: "Grace Hopper", email: "grace@example.com", amount: 3010, status: "paid" },
+];
+
 // Merged preview fetcher: echoes api-action requests (body shaped { data, meta }),
 // otherwise delegates to sampleFetcher for dataSource requests (e.g. /api/countries).
 // Detects api-action by checking if req.body has both 'data' and 'meta' properties.
@@ -63,8 +71,9 @@ export async function createPreviewFetcher(req: { url: string; body?: unknown })
     "data" in req.body &&
     "meta" in req.body
   ) {
-    // api-action request: echo it back with a timestamp
-    return { echoedAt: new Date().toISOString(), received: req.body };
+    // api-action request: echo it back with a timestamp; query-shaped URLs also get demo rows.
+    const echo = { echoedAt: new Date().toISOString(), received: req.body };
+    return /search|query|list/i.test(req.url) ? { ...echo, data: SAMPLE_QUERY_ROWS } : echo;
   }
   // dataSource request: delegate to sampleFetcher
   return sampleFetcher(req);

--- a/docs/superpowers/plans/2026-07-10-form-result-table.md
+++ b/docs/superpowers/plans/2026-07-10-form-result-table.md
@@ -1,0 +1,852 @@
+# form result `mode:'table'` (A render + B snapshot) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Render the form-builder result item's `mode:'table'` by embedding `@rfjs/table-builder-ui`'s `<ConfigTable>` (zero-config derive fallback, A), plus an optional inspector snapshot that freezes columns into `item.table` for JSON editing (B).
+
+**Architecture:** The engine (`@rfjs/form-builder`) types `ResultItem.table` as `TableConfig` and validates it with table-builder's zod schema. The renderer (`@rfjs/form-builder-ui`) fills `ResultView`'s existing `mode:'table'` placeholder with a `<ConfigTable>`, deriving a config from the response rows when `item.table` is absent. The form tool (`apps/web`) types the mirror field and adds a paste-a-sample snapshot control; column customization is done via the existing JSON tab, not a visual editor.
+
+**Tech Stack:** TypeScript, React 19, Zod 4, Vitest + @testing-library/react, pnpm workspaces, Next.js `transpilePackages`.
+
+## Global Constraints
+
+- **Red line:** do NOT modify `packages/table-builder` or `packages/table-builder-ui`. Consume only: types, `deriveTableConfig`, `inferFieldsFromRows`, `ConfigTable`, `tableConfigSchema`.
+- **No `@dnd-kit`** added anywhere (no visual reorder this round).
+- **No visual per-column editor** (C is out of scope).
+- Inspector strings are inline English, matching the existing `ResultSection` (`Mode`/`Source`/`Data path`) — do NOT route them through `messages.ts`.
+- Commits: English Conventional Commits + `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>` trailer.
+- Changesets: `@rfjs/form-builder` and `@rfjs/form-builder-ui` each get one (minor). Apps get none.
+- Run all commands from the worktree root: `/home/royfw/_/code/royfw/rfjs/.claude/worktrees/feat-form-result-table`.
+
+---
+
+## File Structure
+
+- `packages/form-builder/src/types.ts` — type `ResultItem.table` as `TableConfig`.
+- `packages/form-builder/src/config-schema.ts` — validate `table` with `tableConfigSchema`.
+- `packages/form-builder/package.json` — add `@rfjs/table-builder` dep.
+- `packages/form-builder-ui/src/result-view.tsx` — `mode:'table'` → `<ConfigTable>` (+ `table` prop, derive fallback, non-array fallback).
+- `packages/form-builder-ui/src/config-form.tsx` — thread `item.table` into `<ResultView>`.
+- `packages/form-builder-ui/package.json` — add table-builder(-ui) + data-schema deps.
+- `apps/web/src/tools/form-builder/model.ts` — type `Card.resultTable` as `TableConfig` (mapping already carries it).
+- `apps/web/src/tools/form-builder/inspector/result-table-snapshot.ts` — pure sample→TableConfig helper (new).
+- `apps/web/src/tools/form-builder/inspector/result.tsx` — snapshot UI for `mode:'table'`; drop "coming soon".
+- `apps/web/src/tools/form-builder/ui.tsx` — demo fetcher returns rows for query-shaped URLs.
+- `apps/web/src/tools/form-builder/sample.ts` — flip the query result item to `mode:'table'`.
+
+---
+
+## Task 1: Engine — type & validate `ResultItem.table`
+
+**Files:**
+- Modify: `packages/form-builder/src/types.ts` (import + `table` field)
+- Modify: `packages/form-builder/src/config-schema.ts:167-176` (result item schema)
+- Modify: `packages/form-builder/package.json` (dependencies)
+- Test: `packages/form-builder/src/config-schema.spec.ts`
+
+**Interfaces:**
+- Consumes: `TableConfig`, `tableConfigSchema` from `@rfjs/table-builder`.
+- Produces: `ResultItem.table?: TableConfig`; `FormConfigSchema` now rejects a malformed `table`.
+
+- [ ] **Step 1: Add the workspace dependency and install**
+
+Edit `packages/form-builder/package.json` `dependencies` (keep alphabetical-ish with the other `@rfjs/*`):
+
+```json
+    "@rfjs/data-expr": "workspace:*",
+    "@rfjs/data-filter": "workspace:*",
+    "@rfjs/object-utils": "workspace:*",
+    "@rfjs/table-builder": "workspace:*",
+    "zod": "^4.0.0"
+```
+
+Run: `pnpm install`
+Expected: lockfile links `@rfjs/form-builder` → `@rfjs/table-builder`, no errors.
+
+- [ ] **Step 2: Write the failing test**
+
+Add to `packages/form-builder/src/config-schema.spec.ts`:
+
+```ts
+describe('result item table (mode:table)', () => {
+  const withTable = {
+    version: 1,
+    sections: [
+      {
+        id: 's1',
+        title: 'S',
+        rows: [
+          {
+            id: 'r1',
+            items: [
+              {
+                id: 'res',
+                kind: 'result',
+                mode: 'table',
+                table: {
+                  columns: [{ key: 'name', label: 'Name', dataType: 'string' }],
+                  pagination: { pageSize: 10 },
+                },
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+
+  it('accepts a result item carrying a valid TableConfig', () => {
+    expect(parseFormConfig(withTable)).toEqual(withTable);
+  });
+
+  it('rejects a result item whose table has no columns', () => {
+    const bad = JSON.parse(JSON.stringify(withTable));
+    bad.sections[0].rows[0].items[0].table.columns = [];
+    expect(FormConfigSchema.safeParse(bad).success).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `pnpm -F @rfjs/form-builder vitest:run config-schema`
+Expected: FAIL — the "no columns" case currently passes because `table` is `z.unknown()` (test expects `success: false`). (If the section shape is rejected, adjust the section keys to whatever the schema reports as required, then re-run.)
+
+- [ ] **Step 4: Type the field in `types.ts`**
+
+Add the import under the existing one at the top of `packages/form-builder/src/types.ts`:
+
+```ts
+import type { ConditionalRule } from './conditional';
+import type { TableConfig } from '@rfjs/table-builder';
+```
+
+Change the `ResultItem.table` field (currently `table?: unknown;`):
+
+```ts
+  /** mode:'table' 的欄位設定;缺省時 renderer 從回應 rows derive。 */
+  table?: TableConfig;
+```
+
+- [ ] **Step 5: Validate the field in `config-schema.ts`**
+
+Add the import near the top (after the zod imports):
+
+```ts
+import { tableConfigSchema } from '@rfjs/table-builder';
+```
+
+In `resultItemSchema`, change `table: z.unknown().optional(),` to:
+
+```ts
+  table: tableConfigSchema.optional(),
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `pnpm -F @rfjs/form-builder vitest:run config-schema`
+Expected: PASS (both new cases + existing).
+
+Run: `pnpm -F @rfjs/form-builder typecheck`
+Expected: no type errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/form-builder/src/types.ts packages/form-builder/src/config-schema.ts packages/form-builder/src/config-schema.spec.ts packages/form-builder/package.json pnpm-lock.yaml
+git commit -m "$(cat <<'EOF'
+feat(form-builder): type and validate result item table as TableConfig
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Renderer — `ResultView` table branch → `<ConfigTable>`
+
+**Files:**
+- Modify: `packages/form-builder-ui/src/result-view.tsx`
+- Modify: `packages/form-builder-ui/package.json` (dependencies)
+- Test: `packages/form-builder-ui/src/result-view.spec.tsx`
+
+**Interfaces:**
+- Consumes: `TableConfig`, `deriveTableConfig` (`@rfjs/table-builder`); `inferFieldsFromRows` (`@rfjs/data-schema`); `ConfigTable` (`@rfjs/table-builder-ui`).
+- Produces: `ResultViewProps.table?: TableConfig`. `ResultView` renders a `<table>` for `mode:'table'` when `value` is a non-empty object array; otherwise the empty-state box.
+
+- [ ] **Step 1: Add workspace dependencies and install**
+
+Edit `packages/form-builder-ui/package.json` `dependencies`, adding:
+
+```json
+    "@rfjs/data-schema": "workspace:*",
+    "@rfjs/table-builder": "workspace:*",
+    "@rfjs/table-builder-ui": "workspace:*",
+```
+
+Run: `pnpm install`
+Expected: links resolve, no errors.
+
+- [ ] **Step 2: Write the failing tests**
+
+Add to `packages/form-builder-ui/src/result-view.spec.tsx`:
+
+```ts
+describe('ResultView table mode', () => {
+  const rows = [
+    { id: 1, name: 'Ada' },
+    { id: 2, name: 'Alan' },
+  ];
+
+  it('derives columns from rows when no table config is given', () => {
+    render(<ResultView mode="table" state="ready" value={rows} />);
+    expect(screen.getByText('id')).toBeTruthy();
+    expect(screen.getByText('name')).toBeTruthy();
+    expect(screen.getByText('Ada')).toBeTruthy();
+  });
+
+  it('honors a carried TableConfig (column label overrides the key)', () => {
+    render(
+      <ResultView
+        mode="table"
+        state="ready"
+        value={rows}
+        table={{
+          columns: [{ key: 'name', label: 'Full Name', dataType: 'string' }],
+          pagination: { pageSize: 10 },
+        }}
+      />,
+    );
+    expect(screen.getByText('Full Name')).toBeTruthy();
+    expect(screen.queryByText('id')).toBeNull();
+  });
+
+  it('falls back to the empty box when the value is not an object array', () => {
+    render(<ResultView mode="table" state="ready" value={{ notAnArray: true }} emptyText={{ en: 'No rows' }} />);
+    expect(screen.getByText('No rows')).toBeTruthy();
+  });
+});
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `pnpm -F @rfjs/form-builder-ui vitest:run result-view`
+Expected: FAIL — current table branch renders the "pending @rfjs/table-builder" placeholder, so `id`/`Full Name` are absent.
+
+- [ ] **Step 4: Implement the table branch**
+
+In `packages/form-builder-ui/src/result-view.tsx`, add imports at the top:
+
+```ts
+import { deriveTableConfig, type TableConfig } from '@rfjs/table-builder';
+import { inferFieldsFromRows } from '@rfjs/data-schema';
+import { ConfigTable } from '@rfjs/table-builder-ui';
+```
+
+Add `table` to the props interface:
+
+```ts
+export interface ResultViewProps {
+  mode: 'card' | 'json' | 'table';
+  state: ResultViewState;
+  value?: unknown;
+  maxItems?: number;
+  table?: TableConfig;
+  emptyText?: LocalizedLabel;
+  locale?: string;
+}
+```
+
+Add a small internal component that isolates the memoized derive/source (hooks must not be conditional, so keep them in their own component mounted only for the ready+rows path):
+
+```tsx
+function ResultTable({ rows, table, locale }: { rows: Record<string, unknown>[]; table?: TableConfig; locale: string }) {
+  const config = React.useMemo(
+    () => table ?? deriveTableConfig({ fields: inferFieldsFromRows(rows) }),
+    [table, rows],
+  );
+  const source = React.useMemo(() => ({ kind: 'rows' as const, rows }), [rows]);
+  return <ConfigTable config={config} source={source} locale={locale} />;
+}
+```
+
+Replace the existing `mode === 'table'` placeholder block (currently the "Table view / pending" box) with:
+
+```tsx
+  if (mode === 'table') {
+    const rows = Array.isArray(value) ? (value as Record<string, unknown>[]) : null;
+    if (!rows || rows.length === 0 || !rows.every((r) => r !== null && typeof r === 'object' && !Array.isArray(r))) {
+      return <div className={stateBox}>{emptyText ? resolveLabel(emptyText, locale) : 'No result yet'}</div>;
+    }
+    return <ResultTable rows={rows} table={table} locale={locale} />;
+  }
+```
+
+Update the `ResultView` signature to destructure `table`:
+
+```tsx
+export function ResultView({ mode, state, value, maxItems, table, emptyText, locale = 'en' }: ResultViewProps) {
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pnpm -F @rfjs/form-builder-ui vitest:run result-view`
+Expected: PASS (3 new + existing states/card/json).
+(If `ConfigTable` throws for a missing `ResizeObserver` in jsdom, install the mock used elsewhere in this package — see `config-form.spec.tsx`'s `installResizeObserverMock` — inside a `beforeEach` for this describe block.)
+
+Run: `pnpm -F @rfjs/form-builder-ui typecheck`
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/form-builder-ui/src/result-view.tsx packages/form-builder-ui/src/result-view.spec.tsx packages/form-builder-ui/package.json pnpm-lock.yaml
+git commit -m "$(cat <<'EOF'
+feat(form-builder-ui): render result mode:'table' with ConfigTable + derive fallback
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Renderer — thread `item.table` through `config-form`
+
+**Files:**
+- Modify: `packages/form-builder-ui/src/config-form.tsx:492`
+- Test: `packages/form-builder-ui/src/config-form.spec.tsx`
+
+**Interfaces:**
+- Consumes: `ResultView` `table` prop (Task 2); `ConfigForm`'s existing `fetcher` prop + api-button flow.
+- Produces: nothing new; ensures a result item's `table` reaches the renderer.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `packages/form-builder-ui/src/config-form.spec.tsx`:
+
+```ts
+describe('ConfigForm result mode:table', () => {
+  const tableConfig: FormConfig = {
+    version: 1,
+    sections: [
+      {
+        id: 's1',
+        title: 'S',
+        rows: [
+          {
+            id: 'r1',
+            items: [
+              { id: 'btn', kind: 'button', label: 'Query', action: { type: 'api', url: '/api/search' } },
+              {
+                id: 'res',
+                kind: 'result',
+                mode: 'table',
+                sourceId: 'btn',
+                table: {
+                  columns: [{ key: 'name', label: 'Full Name', dataType: 'string' }],
+                  pagination: { pageSize: 10 },
+                },
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+
+  it('passes item.table to the rendered table (label override shows)', async () => {
+    const rows = [{ id: 1, name: 'Ada' }, { id: 2, name: 'Alan' }];
+    const fetcher = vi.fn().mockResolvedValue(rows);
+    render(<ConfigForm config={tableConfig} onSubmit={() => {}} fetcher={fetcher} />);
+    fireEvent.click(screen.getByRole('button', { name: /query/i }));
+    await waitFor(() => expect(screen.getByText('Full Name')).toBeTruthy());
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm -F @rfjs/form-builder-ui vitest:run config-form`
+Expected: FAIL — `Full Name` never appears because `<ResultView>` isn't yet passed `table`, so it derives `name` instead. (If it instead fails on `installResizeObserverMock`, add that mock to this describe block as the surrounding tests do.)
+
+- [ ] **Step 3: Thread the prop**
+
+In `packages/form-builder-ui/src/config-form.tsx`, the result render at line ~492 currently reads:
+
+```tsx
+          <ResultView mode={item.mode} state={state} value={value} maxItems={item.maxItems} emptyText={item.emptyText} locale={locale} />
+```
+
+Change it to include `table`:
+
+```tsx
+          <ResultView mode={item.mode} state={state} value={value} maxItems={item.maxItems} table={item.table} emptyText={item.emptyText} locale={locale} />
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm -F @rfjs/form-builder-ui vitest:run config-form`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/form-builder-ui/src/config-form.tsx packages/form-builder-ui/src/config-form.spec.tsx
+git commit -m "$(cat <<'EOF'
+feat(form-builder-ui): thread result item table config into ResultView
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Form tool — type `Card.resultTable`
+
+**Files:**
+- Modify: `apps/web/src/tools/form-builder/model.ts` (import + `resultTable` field type)
+- Test: `apps/web/src/tools/form-builder/model.spec.ts`
+
+**Interfaces:**
+- Consumes: `TableConfig` (`@rfjs/table-builder`). The `cardToItem`/`formConfigToCards` mapping already carries `table`↔`resultTable` (added in #235) — this task only types it.
+- Produces: `Card.resultTable?: TableConfig`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `apps/web/src/tools/form-builder/model.spec.ts`:
+
+```ts
+it('round-trips a table-mode result item with a TableConfig', () => {
+  const table = {
+    columns: [{ key: 'name', label: 'Name', dataType: 'string' as const }],
+    pagination: { pageSize: 10 },
+  };
+  const groups = [{ id: 'g1', title: 'G', collapsed: false }];
+  const cards = [
+    { id: 'res', groupId: 'g1', kind: 'result' as const, label: 'Result', mode: 'table' as const,
+      resultTable: table, col: 1, span: 6, row: 1 },
+  ];
+  const config = cardsToFormConfig(groups, cards);
+  const back = formConfigToCards(config);
+  const res = back.cards.find((c) => c.id === 'res');
+  expect(res?.mode).toBe('table');
+  expect(res?.resultTable).toEqual(table);
+});
+```
+
+(Imports: ensure `cardsToFormConfig` and `formConfigToCards` are imported at the top of the spec — mirror the existing import line.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm -F web vitest run model`
+Expected: initially this may PASS at runtime (mapping already carries the value) but FAIL `typecheck` because `resultTable` is `unknown` and `dataType`/`res?.resultTable` typing is loose. If runtime passes, proceed — Step 3 locks the type; the value is the guardrail.
+
+- [ ] **Step 3: Type the field**
+
+In `apps/web/src/tools/form-builder/model.ts`, add the import near the other type imports at the top:
+
+```ts
+import type { TableConfig } from "@rfjs/table-builder";
+```
+
+Change the `Card` interface field (currently `resultTable?: unknown; // result`):
+
+```ts
+  resultTable?: TableConfig; // result
+```
+
+- [ ] **Step 4: Run test + typecheck**
+
+Run: `pnpm -F web vitest run model`
+Expected: PASS.
+
+Run: `pnpm -F web typecheck`
+Expected: no errors from `model.ts`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/tools/form-builder/model.ts apps/web/src/tools/form-builder/model.spec.ts
+git commit -m "$(cat <<'EOF'
+feat(web): type form-builder Card.resultTable as TableConfig
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Form tool — snapshot helper + inspector UI + demo data
+
+**Files:**
+- Create: `apps/web/src/tools/form-builder/inspector/result-table-snapshot.ts`
+- Test: `apps/web/src/tools/form-builder/inspector/result-table-snapshot.spec.ts`
+- Modify: `apps/web/src/tools/form-builder/inspector/result.tsx`
+- Modify: `apps/web/src/tools/form-builder/ui.tsx` (`createPreviewFetcher`)
+- Modify: `apps/web/src/tools/form-builder/sample.ts`
+- Modify: `apps/web/src/tools/form-builder/ui.spec.tsx:195-202` (update the stale card-mode integration test to guard the table path)
+
+**Interfaces:**
+- Consumes: `inferFieldsFromRows` (`@rfjs/data-schema`), `deriveTableConfig`, `TableConfig` (`@rfjs/table-builder`); `Card`/`onChange` from `../model`.
+- Produces: `snapshotTableConfig(text: string): { config?: TableConfig; error?: string }`; `ResultSection` renders a snapshot control for `mode:'table'`.
+
+- [ ] **Step 1: Write the failing helper test**
+
+Create `apps/web/src/tools/form-builder/inspector/result-table-snapshot.spec.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { snapshotTableConfig } from "./result-table-snapshot";
+
+describe("snapshotTableConfig", () => {
+  it("derives a TableConfig from a sample array", () => {
+    const { config, error } = snapshotTableConfig('[{"id":1,"name":"Ada"}]');
+    expect(error).toBeUndefined();
+    expect(config?.columns.map((c) => c.key)).toEqual(["id", "name"]);
+    expect(config?.pagination.pageSize).toBeGreaterThan(0);
+  });
+
+  it("wraps a single object into a one-row inference", () => {
+    const { config } = snapshotTableConfig('{"a":1,"b":"x"}');
+    expect(config?.columns.map((c) => c.key)).toEqual(["a", "b"]);
+  });
+
+  it("returns an error for invalid JSON", () => {
+    const { config, error } = snapshotTableConfig("{not json");
+    expect(config).toBeUndefined();
+    expect(error).toMatch(/json/i);
+  });
+
+  it("returns an error for an empty array", () => {
+    const { error } = snapshotTableConfig("[]");
+    expect(error).toBeTruthy();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm -F web vitest run result-table-snapshot`
+Expected: FAIL — module does not exist.
+
+- [ ] **Step 3: Implement the helper**
+
+Create `apps/web/src/tools/form-builder/inspector/result-table-snapshot.ts`:
+
+```ts
+import { deriveTableConfig, type TableConfig } from "@rfjs/table-builder";
+import { inferFieldsFromRows } from "@rfjs/data-schema";
+
+/**
+ * Turn a pasted sample response into a TableConfig via infer→derive.
+ * Accepts an array of row objects or a single object (wrapped to one row).
+ * Pure and self-contained so it unit-tests without rendering.
+ */
+export function snapshotTableConfig(text: string): { config?: TableConfig; error?: string } {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return { error: "Invalid JSON" };
+  }
+  const rows = Array.isArray(parsed) ? parsed : [parsed];
+  try {
+    const fields = inferFieldsFromRows(rows);
+    if (fields.length === 0) return { error: "No columns found in the sample" };
+    return { config: deriveTableConfig({ fields }) };
+  } catch (e) {
+    return { error: e instanceof Error ? e.message : "Could not read the sample" };
+  }
+}
+```
+
+- [ ] **Step 4: Run helper test to verify it passes**
+
+Run: `pnpm -F web vitest run result-table-snapshot`
+Expected: PASS.
+
+- [ ] **Step 5: Write the failing inspector test**
+
+Add to `apps/web/src/tools/form-builder/inspector/result.spec.tsx` (create the file if it does not exist, mirroring a sibling inspector spec's imports):
+
+```tsx
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import * as React from "react";
+import { ResultSection } from "./result";
+import type { Card } from "../model";
+
+const baseCard = { id: "res", groupId: "g1", kind: "result", label: "Result", mode: "table", col: 1, span: 6, row: 1 } as Card;
+
+describe("ResultSection table snapshot", () => {
+  it("snapshots pasted rows into resultTable", () => {
+    const onChange = vi.fn();
+    render(<ResultSection card={baseCard} onChange={onChange} />);
+    fireEvent.change(screen.getByPlaceholderText(/paste a sample/i), {
+      target: { value: '[{"id":1,"name":"Ada"}]' },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /snapshot/i }));
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ resultTable: expect.objectContaining({ columns: expect.any(Array) }) }),
+    );
+  });
+
+  it("shows an error and does not write on invalid JSON", () => {
+    const onChange = vi.fn();
+    render(<ResultSection card={baseCard} onChange={onChange} />);
+    fireEvent.change(screen.getByPlaceholderText(/paste a sample/i), { target: { value: "{bad" } });
+    fireEvent.click(screen.getByRole("button", { name: /snapshot/i }));
+    expect(screen.getByText(/invalid json/i)).toBeTruthy();
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("clears resultTable", () => {
+    const onChange = vi.fn();
+    const withTable = { ...baseCard, resultTable: { columns: [{ key: "x", label: "X", dataType: "string" }], pagination: { pageSize: 10 } } } as Card;
+    render(<ResultSection card={withTable} onChange={onChange} />);
+    fireEvent.click(screen.getByRole("button", { name: /clear/i }));
+    expect(onChange).toHaveBeenCalledWith({ resultTable: undefined });
+  });
+});
+```
+
+- [ ] **Step 6: Run inspector test to verify it fails**
+
+Run: `pnpm -F web vitest run result.spec`
+Expected: FAIL — no snapshot textarea/button yet.
+
+- [ ] **Step 7: Implement the inspector snapshot UI**
+
+In `apps/web/src/tools/form-builder/inspector/result.tsx`:
+
+Add imports at the top:
+
+```tsx
+import { snapshotTableConfig } from "./result-table-snapshot";
+```
+
+Change the mode `<option>` line (drop "coming soon"):
+
+```tsx
+          {MODES.map((m) => (
+            <option key={m} value={m}>{m}</option>
+          ))}
+```
+
+Add a snapshot sub-panel. After the "Max items" block (which is `mode === "card"`), add a `mode === "table"` block:
+
+```tsx
+      {mode === "table" && <TableSnapshot card={card} onChange={onChange} />}
+```
+
+And define `TableSnapshot` below the `ResultSection` function in the same file:
+
+```tsx
+function TableSnapshot({ card, onChange }: { card: Card; onChange: (p: Partial<Card>) => void }) {
+  const [text, setText] = React.useState("");
+  const [error, setError] = React.useState<string | null>(null);
+  const columnCount = card.resultTable?.columns.length ?? 0;
+
+  function doSnapshot() {
+    const { config, error: err } = snapshotTableConfig(text);
+    if (err || !config) {
+      setError(err ?? "Could not read the sample");
+      return;
+    }
+    setError(null);
+    onChange({ resultTable: config });
+  }
+
+  return (
+    <div className="flex flex-col gap-1.5 rounded-md border border-input bg-muted/20 p-2">
+      <span className="text-xs text-muted-foreground">
+        {columnCount > 0 ? `${columnCount} columns captured — edit in the JSON tab` : "No columns yet — auto-derived from the response, or snapshot a sample:"}
+      </span>
+      <textarea
+        className={`${INPUT_CLS} font-mono`}
+        rows={3}
+        value={text}
+        placeholder='Paste a sample response, e.g. [{"id":1,"name":"Ada"}]'
+        onChange={(e) => setText(e.target.value)}
+      />
+      {error && <span className="text-xs text-destructive">{error}</span>}
+      <div className="flex gap-2">
+        <button type="button" className="rounded-md border border-input px-2 py-1 text-xs hover:bg-muted" onClick={doSnapshot}>
+          Snapshot columns
+        </button>
+        {columnCount > 0 && (
+          <button type="button" className="rounded-md border border-input px-2 py-1 text-xs hover:bg-muted" onClick={() => onChange({ resultTable: undefined })}>
+            Clear
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 8: Run inspector tests to verify they pass**
+
+Run: `pnpm -F web vitest run result.spec result-table-snapshot`
+Expected: PASS.
+
+- [ ] **Step 9: Make the demo fetcher return rows for query URLs**
+
+In `apps/web/src/tools/form-builder/ui.tsx`, add a sample-rows constant above `createPreviewFetcher`:
+
+```ts
+const SAMPLE_QUERY_ROWS = [
+  { id: 1001, name: "Ada Lovelace", email: "ada@example.com", amount: 1240, status: "paid" },
+  { id: 1002, name: "Alan Turing", email: "alan@example.com", amount: 980, status: "pending" },
+  { id: 1003, name: "Grace Hopper", email: "grace@example.com", amount: 3010, status: "paid" },
+];
+```
+
+Change the api-action branch of `createPreviewFetcher` to attach rows for query-shaped URLs:
+
+```ts
+  if (
+    req.body &&
+    typeof req.body === "object" &&
+    "data" in req.body &&
+    "meta" in req.body
+  ) {
+    // api-action request: echo it back with a timestamp; query-shaped URLs also get demo rows.
+    const echo = { echoedAt: new Date().toISOString(), received: req.body };
+    return /search|query|list/i.test(req.url) ? { ...echo, data: SAMPLE_QUERY_ROWS } : echo;
+  }
+```
+
+(Note: `createPreviewFetcher` currently takes `{ url, body }`; the `url` field is already present in callers. If the local signature omits `url`, add it: `req: { url: string; body?: unknown }`.)
+
+- [ ] **Step 10: Point the sample result item at the rows and use table mode**
+
+In `apps/web/src/tools/form-builder/sample.ts`, change the `res_query` item:
+
+```ts
+            { id: "res_query", kind: "result", mode: "table", sourceId: "btn_query", dataPath: "data", emptyText: "Run a query to see results" },
+```
+
+- [ ] **Step 10b: Update the stale `res_query` integration test**
+
+`ui.spec.tsx:195-202` was written for card mode (`received.data` → KV card). After Step 9/10 it silently exercises the table path and its name/comment are wrong. Replace the whole `it(...)` block with one that reflects table mode and asserts on table-specific content from `SAMPLE_QUERY_ROWS` (a header key + a cell value the card demo never had):
+
+```tsx
+  it("preview: query api button renders its rows as a ConfigTable in the result", async () => {
+    renderTool();
+    fireEvent.click(screen.getByRole("button", { name: /^preview$/i }));
+    fireEvent.click(await screen.findByRole("button", { name: /^query$/i }));
+    // query fetcher returns SAMPLE_QUERY_ROWS under `data`; result mode:'table' → ConfigTable headers + rows
+    const resultContainer = document.querySelector('[data-item="res_query"]') as HTMLElement;
+    await waitFor(() => expect(resultContainer.textContent).toMatch(/email/i));
+    expect(resultContainer.textContent).toMatch(/Ada Lovelace/);
+  });
+```
+
+(`ui.spec.tsx` already installs a top-of-file `ResizeObserver` mock, so `<ConfigTable>` renders in jsdom without crashing.)
+
+- [ ] **Step 11: Run the tool's full test + typecheck**
+
+Run: `pnpm -F web vitest run form-builder`
+Expected: PASS (including the existing `ui.spec.tsx` `createPreviewFetcher` test — `received` still equals the body for non-query URLs).
+
+Run: `pnpm -F web typecheck`
+Expected: no errors.
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add apps/web/src/tools/form-builder/inspector/result-table-snapshot.ts apps/web/src/tools/form-builder/inspector/result-table-snapshot.spec.ts apps/web/src/tools/form-builder/inspector/result.tsx apps/web/src/tools/form-builder/inspector/result.spec.tsx apps/web/src/tools/form-builder/ui.tsx apps/web/src/tools/form-builder/ui.spec.tsx apps/web/src/tools/form-builder/sample.ts
+git commit -m "$(cat <<'EOF'
+feat(web): add result table snapshot control and table-mode sample
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: Changesets, full verification, screenshot
+
+**Files:**
+- Create: `.changeset/form-result-table-render.md`
+- Create: `.changeset/form-result-table-ui.md`
+
+- [ ] **Step 1: Add changesets**
+
+Create `.changeset/form-result-table-render.md`:
+
+```md
+---
+"@rfjs/form-builder": minor
+---
+
+Type and validate the result item `table` field as `TableConfig` (was `unknown`), backing the form result `mode:'table'` renderer.
+```
+
+Create `.changeset/form-result-table-ui.md`:
+
+```md
+---
+"@rfjs/form-builder-ui": minor
+---
+
+Render result items with `mode:'table'` using `@rfjs/table-builder-ui`'s `ConfigTable`, deriving columns from the response when no `table` config is carried.
+```
+
+- [ ] **Step 2: Full affected verification**
+
+Run: `pnpm -F @rfjs/form-builder -F @rfjs/form-builder-ui -F web test`
+Expected: all PASS.
+
+Run: `pnpm -F @rfjs/form-builder -F @rfjs/form-builder-ui -F web typecheck`
+Expected: no errors.
+
+Run: `pnpm -F @rfjs/form-builder -F @rfjs/form-builder-ui -F web lint`
+Expected: no errors.
+
+- [ ] **Step 3: Screenshot the real app (verify skill)**
+
+Start the web dev server and drive the form-builder tool: switch the result item to table mode / run the sample query, confirm a real `ConfigTable` renders (headers, sortable, paginated) in the preview, and capture a screenshot. Also open the inspector for the result item and confirm the snapshot control appears with `mode:'table'`.
+
+Run: `pnpm dev -F web` (port 3000), navigate to the form-builder tool.
+Expected: table renders from `SAMPLE_QUERY_ROWS`; inspector shows the snapshot panel.
+
+- [ ] **Step 4: Commit changesets**
+
+```bash
+git add .changeset/form-result-table-render.md .changeset/form-result-table-ui.md
+git commit -m "$(cat <<'EOF'
+chore: changesets for form result table mode
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+- [ ] **Step 5: HOLD** — do not push or open a PR. Report the branch state and screenshots; wait for the go-ahead.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §1 A render → Task 2 + Task 3. ✅
+- §1 B snapshot → Task 5. ✅
+- §4.2 engine type + zod → Task 1. ✅
+- §5 file table → Tasks 1–5 cover every row (model mapping already existed; typed in Task 4). ✅
+- §6 snapshot UX (paste-sample, status, clear, JSON note) → Task 5 Step 7. ✅
+- §8 tests: render (Task 2), snapshot (Task 5), model round-trip (Task 4), config-schema (Task 1). ✅ config-form integration (Task 3) is an extra guardrail.
+- §9 changesets → Task 6. ✅
+- §2 non-goals honored: no `@dnd-kit`, no per-column editor, no messages.ts routing. ✅
+
+**Placeholder scan:** no TBD/TODO; every code step shows code. ✅
+
+**Type consistency:** `snapshotTableConfig` (helper) matches between Task 5 helper + test + inspector. `ResultViewProps.table` matches Task 2 def, Task 3 usage. `Card.resultTable: TableConfig` matches Task 4 + Task 5 usage. `deriveTableConfig({ fields })` / `inferFieldsFromRows(rows)` signatures consistent across Tasks 2 and 5. ✅
+
+**Known runtime caveat:** if `ConfigTable` requires a `ResizeObserver` in jsdom, reuse this package's existing `installResizeObserverMock` pattern in the affected describe blocks (flagged in Tasks 2 and 3).

--- a/docs/superpowers/specs/2026-07-10-form-result-table-design.md
+++ b/docs/superpowers/specs/2026-07-10-form-result-table-design.md
@@ -1,0 +1,151 @@
+# form result `mode:'table'` 接線 — 設計 spec
+
+- 日期:2026-07-10
+- 分支 / worktree:`feat-form-result-table` @ `.claude/worktrees/feat-form-result-table`
+- 背景 memory:`rfjs-form-tool-consolidation`(#235 留下 `{ mode:'table', table: TableConfig }` 縫)、`rfjs-table-builder-line`(`ConfigTable` 已成熟)
+- 範圍決策:**A(render)+ B(snapshot,optional 便利);C(視覺化欄位編輯器)本輪不做**
+- 狀態:設計已與使用者確認,待 spec review → plan
+
+---
+
+## 1. 背景與目標
+
+`form-builder` 工具的 result item 在 #235 已凍結一道縫:`ResultItem` 有 `mode: 'card' | 'json' | 'table'` 與 `table?: unknown`(engine `packages/form-builder/src/types.ts:132,139`),`TableConfig` 之名亦為此凍結。目前 `table` 分支在 renderer(`packages/form-builder-ui/src/result-view.tsx:68-75`)只是一個「pending @rfjs/table-builder」佔位。
+
+**目標**:把 result 的 `mode:'table'` 真正接上,內嵌成熟的 `<ConfigTable>`(`@rfjs/table-builder-ui`)渲染回應資料。
+
+- **A(render)**:切到 `mode:'table'`、有 rows 時,零配置即渲染出可排序/篩選/分頁的表格(欄位自回應 derive)。這是這條線的核心價值——讓 form engine「能」渲染表格結果、順帶 dogfood `@rfjs/table-builder`。
+- **B(snapshot,optional)**:inspector 提供把欄位擷取進 `item.table` 的動作,讓欄位集**穩定**且**可於 JSON tab 手改**。
+
+**這條線的定位**:table 結果的真實用途是「搜尋/查詢表單」這類組裝場景,A 是讓 form + table 兩個 engine 組起來的膠水。作者端的重度客製非本輪目標。
+
+**成功判準**:
+- 切到 `mode:'table'` 且回應為物件陣列時,result 區塊渲染出 `<ConfigTable>`(排序/篩選/分頁可用)。
+- 沒有手帶 `table` 時,零配置也能從回應 rows 自動 derive 出表。
+- 有 `table`(手帶或 snapshot)時,依該 config 渲染。
+- inspector 提供 snapshot 擷取欄位進 `item.table`,之後可經 JSON tab 手改。
+- 全程只**消費** `@rfjs/table-builder*`,不修改。
+
+---
+
+## 2. 非目標(out of scope)
+
+- **C — 視覺化欄位編輯器**(inspector 內拖曳/pin/隱藏/改 label/align/format 的逐欄 UI)。理由:authoring 的正確歸屬是 table-builder-ui(feat-api-filter 正在該處建 metadata-authoring 面板),不應在 form 工具內自刻第二份;且屬 STOP-adding-builders 的範圍。等一個「非工程使用者要在表單內排版欄位」的真實場景再議。
+- **不改** `packages/table-builder`、`packages/table-builder-ui`(紅線)。
+- 欄位 `options`(值→標籤 enum 映射)。
+- 遠端資料源表格(`TableSource.kind:'remote'`)——result item 資料是 in-memory 回應,一律 `kind:'rows'`。
+- 視覺/UX 大改。
+- Group 3 欄位型別 / DatePicker / dataSource(姊妹線 A,獨立 worktree)。
+
+---
+
+## 3. 架構分層(A ⊂ B)
+
+1. **A — Render 基線(零配置)**:`mode:'table'` + 有 rows → 立即出表。`config = item.table ?? deriveTableConfig({ fields: inferFieldsFromRows(rows) })`。這是「沒手帶 config 也能用」的保底。
+2. **B — Snapshot(擷取欄位)**:inspector 一顆動作把 derive 結果凍進 `item.table`,之後欄位集穩定且可 JSON 手改。
+
+執行時 A 與 B 渲染出的表格相同;B 只改變作者端(欄位穩定性 + JSON 可編輯把手)。
+
+---
+
+## 4. 資料流與型別
+
+### 4.1 Render 資料流(在 `form-builder-ui`)
+
+```
+result item 的回應 value
+  └─(dataPath 取子節點,沿用既有邏輯)
+      └─ rows: 需為 Record<string,unknown>[]
+           ├─ 是陣列物件 → config = item.table ?? deriveTableConfig({ fields: inferFieldsFromRows(rows) })
+           │                 source = { kind:'rows', rows }(memoize,referential stable)
+           │                 <ConfigTable config source locale />
+           └─ 非陣列 / 空 → 優雅 fallback(空狀態文案,沿用 emptyText)
+```
+
+- `inferFieldsFromRows`(`@rfjs/data-schema`)、`deriveTableConfig`(`@rfjs/table-builder`)、`ConfigTable`(`@rfjs/table-builder-ui`)全是消費。
+- `source` 必須 referential stable(`ConfigTableProps.source` 註明:remote fetch effect 依賴其 identity)——用 `React.useMemo` 綁 rows。
+
+### 4.2 型別(engine `@rfjs/form-builder`)
+
+- `ResultItem.table?: unknown` → `table?: TableConfig`(type-only import from `@rfjs/table-builder`)。
+- `config-schema.ts`:`table` 欄位改用 `@rfjs/table-builder` 的 `tableConfigSchema`(現成 zod,`packages/table-builder/src/schema.ts:43`)驗證,不自行重寫。
+- 決策:engine typed(而非留 `unknown` 只在 UI cast),因為 B 的 snapshot 會寫入真正的 TableConfig、JSON tab 也會編輯它,型別安全與 config 驗證都需要。
+
+---
+
+## 5. 檔案範圍與改動
+
+| 層 | 檔案 | 改動 |
+|---|---|---|
+| Engine `@rfjs/form-builder` | `src/types.ts` | `ResultItem.table` 由 `unknown` → `TableConfig`(type-only dep) |
+| | `src/config-schema.ts` | 以 `tableConfigSchema` 驗證 `table` |
+| | `package.json` | + `@rfjs/table-builder`(workspace,型別/schema) |
+| Renderer `@rfjs/form-builder-ui` | `src/result-view.tsx` | 換掉 pending 佔位分支 → `<ConfigTable>` + derive fallback + 非陣列 fallback;新增 `table` prop |
+| | `src/config-form.tsx` | `:492` 把 `item.table` thread 進 `<ResultView>` |
+| | `package.json` | + `@rfjs/table-builder`、`@rfjs/table-builder-ui`、`@rfjs/data-schema`(workspace) |
+| Form 工具 `apps/web/src/tools/form-builder` | `model.ts` | `Card.resultTable?: unknown` → `TableConfig`;`cardsToFormConfig`/`formConfigToCards` 帶上 `table`↔`resultTable` |
+| | `inspector/result.tsx` | mode=table 時顯示 snapshot 區(見 §6);mode option 拿掉 "coming soon" |
+| | `messages.ts` | 新字串(snapshot / clear / 說明) |
+| | `sample.ts` | 加一個 `mode:'table'` 的 result 範例卡 |
+
+> 註:apps/web 已依賴 `@rfjs/table-builder`、`@rfjs/table-builder-ui`、`@rfjs/data-schema`、`@rfjs/form-builder(-ui)`。**本輪不加 `@dnd-kit`(無視覺化 reorder)。**
+
+---
+
+## 6. Inspector · Snapshot 區(B)
+
+`mode:'table'` 時,`ResultSection` 於既有欄位下方加一小區:
+
+- **Snapshot columns from a sample**:一個 textarea 貼入一段 sample 回應(陣列或單物件)→ `inferFieldsFromRows` → `deriveTableConfig` → 寫入 `resultTable`(`onChange({ resultTable })`)。採 paste-sample 而非讀 preview 執行結果:保持 inspector 自包含、可單元測試。
+- **狀態列**:已擷取 N 欄的提示 + 一行「要客製欄位請到 JSON 分頁」。
+- **Clear**:清掉 `resultTable`(回到 A 的自動 derive)。
+
+寫入前以 `tableConfigSchema` 保證結構有效;貼入非法 JSON → 顯示錯誤,不寫入。
+
+> C 的逐欄視覺編輯不在本輪;客製一律走 JSON tab(config 已是型別化的可編輯資料)。
+
+---
+
+## 7. 紅線與相依
+
+- **紅線**:不修改 `packages/table-builder`、`packages/table-builder-ui`。只 import 型別、`deriveTableConfig`、`inferFieldsFromRows`、`ConfigTable`。
+- **新相依**:
+  - `@rfjs/form-builder` → `@rfjs/table-builder`(type + zod)。
+  - `@rfjs/form-builder-ui` → `@rfjs/table-builder`、`@rfjs/table-builder-ui`、`@rfjs/data-schema`。
+- form-builder-ui 為 `private`、走 transpilePackages,無 build/publish 負擔;`ConfigTable` 會連帶把 `filter-builder-ui` 拉進 renderer,但只在 table 模式渲染時掛載。
+
+---
+
+## 8. 測試策略(vitest + @testing-library)
+
+- **Render(`result-view.spec.tsx`)**:
+  - config-carried:給 `table` → 依該 config 渲染欄位/順序。
+  - derive fallback:無 `table` + 陣列 rows → 自動生欄位。
+  - 非陣列 / 空 rows → fallback 空狀態,不丟例外。
+- **Snapshot(`result.spec.tsx` 或就近)**:
+  - 貼合法 sample → 寫入正確的 `resultTable`(欄位數/型別)。
+  - 貼非法 JSON → 不寫入、顯示錯誤。
+  - Clear → `resultTable` 清空。
+- **model round-trip(`model.spec.ts`)**:`mode:'table'` + `resultTable` 的 card ↔ FormConfig 雙向不失真。
+- **config-schema(`config-schema.spec.ts`)**:合法 / 非法 `table` 的驗證。
+
+---
+
+## 9. Changeset
+
+依 changeset policy(packages/* 一律給 changeset):
+- `@rfjs/form-builder`:minor(型別 + schema:`table` 由 unknown → TableConfig)。
+- `@rfjs/form-builder-ui`:minor(table 模式真正渲染;private 但仍記版本)。
+- apps 不給 changeset。
+
+commits:英文 conventional + `Co-Authored-By` trailer;spec/plan 繁中。
+
+---
+
+## 10. 風險與待決
+
+1. **Seed 來源**:採 paste-sample(§6)。若日後偏好讀 preview 執行結果,需額外 plumbing(非本輪)。
+2. **LocalizedLabel**:snapshot/JSON 編輯以當前 locale 字串處理;多語 label 留日後。
+3. **B 的實用性**:B 是 optional 作者便利;若實測顯示很少人 snapshot,可再收成純 A。render(A)是不動搖的核心。
+4. **filter-builder-ui 重量**:`ConfigTable` 帶入 FilterTreeEditor,僅 table 模式掛載,可接受。
+5. **C 的未來歸屬**:若真需視覺化欄位編輯,做進 table-builder-ui 讓 form 消費,不在 form 內自刻。

--- a/packages/form-builder-ui/package.json
+++ b/packages/form-builder-ui/package.json
@@ -12,7 +12,10 @@
     "vitest:run": "vitest --passWithNoTests --run"
   },
   "dependencies": {
+    "@rfjs/data-schema": "workspace:*",
     "@rfjs/form-builder": "workspace:*",
+    "@rfjs/table-builder": "workspace:*",
+    "@rfjs/table-builder-ui": "workspace:*",
     "@rfjs/web-ui": "workspace:*",
     "@dnd-kit/core": "^6.3.1",
     "lucide-react": "^1.17.0",

--- a/packages/form-builder-ui/src/config-form.spec.tsx
+++ b/packages/form-builder-ui/src/config-form.spec.tsx
@@ -1266,3 +1266,43 @@ describe('result items', () => {
     await waitFor(() => expect(screen.getByText('No result yet')).toBeTruthy());
   });
 });
+
+describe('ConfigForm result mode:table', () => {
+  installResizeObserverMock();
+
+  const tableConfig: FormConfig = {
+    version: 1,
+    sections: [
+      {
+        id: 's1',
+        title: 'S',
+        rows: [
+          {
+            id: 'r1',
+            items: [
+              { id: 'btn', kind: 'button', label: 'Query', action: { type: 'api', url: '/api/search' } },
+              {
+                id: 'res',
+                kind: 'result',
+                mode: 'table',
+                sourceId: 'btn',
+                table: {
+                  columns: [{ key: 'name', label: 'Full Name', dataType: 'string' }],
+                  pagination: { pageSize: 10 },
+                },
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+
+  it('passes item.table to the rendered table (label override shows)', async () => {
+    const rows = [{ id: 1, name: 'Ada' }, { id: 2, name: 'Alan' }];
+    const fetcher = vi.fn().mockResolvedValue(rows);
+    render(<ConfigForm config={tableConfig} onSubmit={() => {}} fetcher={fetcher} />);
+    fireEvent.click(screen.getByRole('button', { name: /query/i }));
+    await waitFor(() => expect(screen.getByText('Full Name')).toBeTruthy());
+  });
+});

--- a/packages/form-builder-ui/src/config-form.tsx
+++ b/packages/form-builder-ui/src/config-form.tsx
@@ -489,7 +489,7 @@ export function ConfigForm({ config, defaultValues, onSubmit, submitLabel = 'Sub
         : 'ready';
       return (
         <div key={item.id} data-item={item.id} style={place ? placementStyle(place) : fieldSpanStyle(undefined, flow, cols)}>
-          <ResultView mode={item.mode} state={state} value={value} maxItems={item.maxItems} emptyText={item.emptyText} locale={locale} />
+          <ResultView mode={item.mode} state={state} value={value} maxItems={item.maxItems} table={item.table} emptyText={item.emptyText} locale={locale} />
         </div>
       );
     }

--- a/packages/form-builder-ui/src/result-view.spec.tsx
+++ b/packages/form-builder-ui/src/result-view.spec.tsx
@@ -56,8 +56,43 @@ describe('ResultView json / table modes', () => {
     expect(screen.getByText(/"a": 1/)).toBeTruthy();
   });
 
-  it('table: renders the pending placeholder', () => {
+  it('table: empty array falls back to the empty box', () => {
     render(<ResultView mode="table" state="ready" value={[]} />);
-    expect(screen.getByText(/pending .*table-builder/i)).toBeTruthy();
+    expect(screen.getByText('No result yet')).toBeTruthy();
+  });
+});
+
+describe('ResultView table mode', () => {
+  const rows = [
+    { id: 1, name: 'Ada' },
+    { id: 2, name: 'Alan' },
+  ];
+
+  it('derives columns from rows when no table config is given', () => {
+    render(<ResultView mode="table" state="ready" value={rows} />);
+    expect(screen.getByText('id')).toBeTruthy();
+    expect(screen.getByText('name')).toBeTruthy();
+    expect(screen.getByText('Ada')).toBeTruthy();
+  });
+
+  it('honors a carried TableConfig (column label overrides the key)', () => {
+    render(
+      <ResultView
+        mode="table"
+        state="ready"
+        value={rows}
+        table={{
+          columns: [{ key: 'name', label: 'Full Name', dataType: 'string' }],
+          pagination: { pageSize: 10 },
+        }}
+      />,
+    );
+    expect(screen.getByText('Full Name')).toBeTruthy();
+    expect(screen.queryByText('id')).toBeNull();
+  });
+
+  it('falls back to the empty box when the value is not an object array', () => {
+    render(<ResultView mode="table" state="ready" value={{ notAnArray: true }} emptyText={{ en: 'No rows' }} />);
+    expect(screen.getByText('No rows')).toBeTruthy();
   });
 });

--- a/packages/form-builder-ui/src/result-view.tsx
+++ b/packages/form-builder-ui/src/result-view.tsx
@@ -3,6 +3,9 @@
 import * as React from 'react';
 import { Loader2 } from 'lucide-react';
 import { resolveLabel, type LocalizedLabel } from '@rfjs/form-builder';
+import { deriveTableConfig, type TableConfig } from '@rfjs/table-builder';
+import { inferFieldsFromRows } from '@rfjs/data-schema';
+import { ConfigTable } from '@rfjs/table-builder-ui';
 
 export type ResultViewState = 'empty' | 'loading' | 'error' | 'ready';
 
@@ -11,6 +14,7 @@ export interface ResultViewProps {
   state: ResultViewState;
   value?: unknown;
   maxItems?: number;
+  table?: TableConfig;
   emptyText?: LocalizedLabel;
   locale?: string;
 }
@@ -41,8 +45,17 @@ function KvCard({ value }: { value: unknown }) {
 
 const stateBox = 'flex min-h-24 items-center justify-center gap-2 rounded-md border border-dashed border-input bg-muted/20 text-sm text-muted-foreground';
 
+function ResultTable({ rows, table, locale }: { rows: Record<string, unknown>[]; table?: TableConfig; locale: string }) {
+  const config = React.useMemo(
+    () => table ?? deriveTableConfig({ fields: inferFieldsFromRows(rows) }),
+    [table, rows],
+  );
+  const source = React.useMemo(() => ({ kind: 'rows' as const, rows }), [rows]);
+  return <ConfigTable config={config} source={source} locale={locale} />;
+}
+
 /** api 回應的純展示元件 —— card 刻意零配置(僅 maxItems);欄位級控制屬 table 模式(table-builder)。 */
-export function ResultView({ mode, state, value, maxItems, emptyText, locale = 'en' }: ResultViewProps) {
+export function ResultView({ mode, state, value, maxItems, table, emptyText, locale = 'en' }: ResultViewProps) {
   if (state === 'empty') {
     return <div className={stateBox}>{emptyText ? resolveLabel(emptyText, locale) : 'No result yet'}</div>;
   }
@@ -66,12 +79,11 @@ export function ResultView({ mode, state, value, maxItems, emptyText, locale = '
   }
 
   if (mode === 'table') {
-    return (
-      <div className={`${stateBox} flex-col gap-1`}>
-        <span className="font-medium text-foreground/70">Table view</span>
-        <span className="text-xs">pending @rfjs/table-builder</span>
-      </div>
-    );
+    const rows = Array.isArray(value) ? (value as Record<string, unknown>[]) : null;
+    if (!rows || rows.length === 0 || !rows.every((r) => r !== null && typeof r === 'object' && !Array.isArray(r))) {
+      return <div className={stateBox}>{emptyText ? resolveLabel(emptyText, locale) : 'No result yet'}</div>;
+    }
+    return <ResultTable rows={rows} table={table} locale={locale} />;
   }
 
   // mode === 'card'

--- a/packages/form-builder/package.json
+++ b/packages/form-builder/package.json
@@ -31,6 +31,7 @@
     "@rfjs/data-expr": "workspace:*",
     "@rfjs/data-filter": "workspace:*",
     "@rfjs/object-utils": "workspace:*",
+    "@rfjs/table-builder": "workspace:*",
     "zod": "^4.0.0"
   },
   "devDependencies": {

--- a/packages/form-builder/src/config-schema.spec.ts
+++ b/packages/form-builder/src/config-schema.spec.ts
@@ -552,7 +552,8 @@ describe('result items', () => {
     const full = {
       id: 'res2', kind: 'result', mode: 'card',
       sourceId: 'btn1', dataPath: 'data.items', maxItems: 5,
-      table: { anything: true }, emptyText: { en: 'Nothing', 'zh-TW': '沒有資料' },
+      table: { columns: [{ key: 'name', label: 'Name', dataType: 'string' }], pagination: { pageSize: 10 } },
+      emptyText: { en: 'Nothing', 'zh-TW': '沒有資料' },
     };
     for (const item of [minimal, full]) {
       const r = formConfigSchema.safeParse(withItem(item));
@@ -570,5 +571,43 @@ describe('result items', () => {
       const r = formConfigSchema.safeParse(withItem(item));
       expect(r.success, JSON.stringify(item)).toBe(false);
     }
+  });
+});
+
+describe('result item table (mode:table)', () => {
+  const withTable = {
+    version: 1,
+    sections: [
+      {
+        id: 's1',
+        title: 'S',
+        rows: [
+          {
+            id: 'r1',
+            items: [
+              {
+                id: 'res',
+                kind: 'result',
+                mode: 'table',
+                table: {
+                  columns: [{ key: 'name', label: 'Name', dataType: 'string' }],
+                  pagination: { pageSize: 10 },
+                },
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+
+  it('accepts a result item carrying a valid TableConfig', () => {
+    expect(parseFormConfig(withTable)).toEqual(withTable);
+  });
+
+  it('rejects a result item whose table has no columns', () => {
+    const bad = JSON.parse(JSON.stringify(withTable));
+    bad.sections[0].rows[0].items[0].table.columns = [];
+    expect(FormConfigSchema.safeParse(bad).success).toBe(false);
   });
 });

--- a/packages/form-builder/src/config-schema.ts
+++ b/packages/form-builder/src/config-schema.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import type { ZodType, ZodTypeAny } from 'zod';
+import { tableConfigSchema } from '@rfjs/table-builder';
 
 import type { FormConfig } from './types';
 
@@ -171,7 +172,7 @@ const resultItemSchema = z.object({
   sourceId: z.string().min(1).optional(),
   dataPath: z.string().min(1).optional(),
   maxItems: z.number().int().positive().optional(),
-  table: z.unknown().optional(),
+  table: tableConfigSchema.optional(),
   emptyText: localizedLabelSchema.optional(),
 });
 

--- a/packages/form-builder/src/types.ts
+++ b/packages/form-builder/src/types.ts
@@ -1,4 +1,5 @@
 import type { ConditionalRule } from './conditional';
+import type { TableConfig } from '@rfjs/table-builder';
 
 // Data-type vocabulary — identical to @rfjs/filter-builder's FieldType.
 export type ScalarType = 'string' | 'numeric' | 'date' | 'boolean';
@@ -136,8 +137,8 @@ export interface ResultItem {
   dataPath?: string;
   /** card 模式陣列上限,預設 10。 */
   maxItems?: number;
-  /** mode:'table' 預留:未來放 @rfjs/table-builder 的 TableConfig;v1 透傳不解讀。 */
-  table?: unknown;
+  /** mode:'table' 的欄位設定;缺省時 renderer 從回應 rows derive。 */
+  table?: TableConfig;
   /** 空狀態文案;缺省內建 'No result yet'。 */
   emptyText?: LocalizedLabel;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1114,9 +1114,18 @@ importers:
       '@hookform/resolvers':
         specifier: ^5.0.0
         version: 5.4.0(react-hook-form@7.80.0(react@19.2.7))
+      '@rfjs/data-schema':
+        specifier: workspace:*
+        version: link:../data-schema
       '@rfjs/form-builder':
         specifier: workspace:*
         version: link:../form-builder
+      '@rfjs/table-builder':
+        specifier: workspace:*
+        version: link:../table-builder
+      '@rfjs/table-builder-ui':
+        specifier: workspace:*
+        version: link:../table-builder-ui
       '@rfjs/web-ui':
         specifier: workspace:*
         version: link:../web-ui

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1068,6 +1068,9 @@ importers:
       '@rfjs/object-utils':
         specifier: workspace:*
         version: link:../object-utils
+      '@rfjs/table-builder':
+        specifier: workspace:*
+        version: link:../table-builder
       zod:
         specifier: ^4.0.0
         version: 4.4.3


### PR DESCRIPTION
## Summary

Wires the form-builder result item's `mode:'table'` to render `@rfjs/table-builder-ui`'s `<ConfigTable>`, filling the seam reserved in #235. Scoped to **A (render) + B (snapshot)**; a visual per-column editor (**C**) is intentionally **out of scope** — column authoring belongs in `@rfjs/table-builder-ui`, not the form tool.

- **A — render (zero-config):** a `mode:'table'` result renders a real `ConfigTable`. Columns derive from the response rows when no `table` config is carried (`item.table ?? deriveTableConfig({ fields: inferFieldsFromRows(rows) })`); a non-array / empty / non-object-array response degrades to the empty box.
- **B — snapshot (optional authoring):** the inspector offers a paste-a-sample control that freezes a `TableConfig` into `item.table` (stable columns, editable in the JSON tab). `Clear` returns to auto-derive.

## Changes by layer

| Layer | Change |
|---|---|
| `@rfjs/form-builder` (engine) | `ResultItem.table` typed `unknown` → `TableConfig`; validated with `tableConfigSchema` |
| `@rfjs/form-builder-ui` (renderer) | `ResultView` table branch → `<ConfigTable>` (derive fallback + non-array guard); `config-form` threads `item.table` |
| `apps/web` form-builder tool | `Card.resultTable` typed; inspector `TableSnapshot` panel + pure `snapshotTableConfig` helper; demo fetcher returns rows for query URLs; sample `res_query` → `mode:'table'` |

## Constraints held

- **Red line:** `packages/table-builder` and `packages/table-builder-ui` are **unchanged** — consumed only.
- No `@dnd-kit`; no visual per-column editor (C deferred).
- Changesets: `@rfjs/form-builder` minor + `@rfjs/form-builder-ui` minor.

## Testing

- 6 TDD tasks (subagent-driven); each task passed spec + quality review.
- **841 tests pass** (form-builder 174, form-builder-ui 270, web 397). `web` check-types + lint clean; `form-builder-ui` check-types clean.
- Plan was adversarially verified before execution; final whole-branch review (Opus): **no Critical/Important**, ready to merge.
- Manually verified in the running app (screenshots captured locally): the result renders a real sortable/filterable/paginated table from the query response, and the inspector snapshot captures columns ("N columns captured — edit in the JSON tab").

## Known pre-existing (not introduced by this PR)

- `@rfjs/form-builder` `typecheck` has ~3 errors present at the branch base (config-schema conditional typing; `types.ts` File/AbortSignal globals) — unrelated to this change.
- `@rfjs/form-builder` and `@rfjs/form-builder-ui` have no `eslint.config.js` on `main`, so `lint` cannot run for them (pre-existing repo gap).

## Docs

Spec + plan under `docs/superpowers/{specs,plans}/2026-07-10-form-result-table*` (zh-TW).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
