### PR TITLE
feat(web): filter→API dogfood — fake Next route + HTTP transport for table-builder

### DIFF
--- a/apps/web/src/app/api/query/[resource]/route.spec.ts
+++ b/apps/web/src/app/api/query/[resource]/route.spec.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { POST } from "./route";
+
+function post(resource: string, body: unknown, search = ""): Promise<Response> {
+  const req = new Request(`http://t/api/query/${resource}${search}`, {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "content-type": "application/json" },
+  });
+  return POST(req, { params: Promise.resolve({ resource }) });
+}
+
+describe("POST /api/query/[resource]", () => {
+  it("returns { data: { items, total } } for the sample resource", async () => {
+    const res = await post("sample", { params: {} });
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { data: { items: unknown[]; total: number } };
+    expect(Array.isArray(json.data.items)).toBe(true);
+    expect(json.data.total).toBeGreaterThan(0);
+  });
+
+  it("404 for unknown resource", async () => {
+    const res = await post("nope", { params: {} });
+    expect(res.status).toBe(404);
+  });
+
+  it("?error=500 → 500", async () => {
+    const res = await post("sample", { params: {} }, "?error=500");
+    expect(res.status).toBe(500);
+  });
+
+  it("?empty=1 → 0 items", async () => {
+    const res = await post("sample", { params: {} }, "?empty=1");
+    const json = (await res.json()) as { data: { items: unknown[]; total: number } };
+    expect(json.data.items).toHaveLength(0);
+    expect(json.data.total).toBe(0);
+  });
+});

--- a/apps/web/src/app/api/query/[resource]/route.ts
+++ b/apps/web/src/app/api/query/[resource]/route.ts
@@ -1,0 +1,31 @@
+import { getResource } from "@/lib/query-resources";
+import { runQuery } from "@/lib/fake-query";
+
+// runQuery 拉入 @rfjs/filter-builder + crypto.randomUUID → Node runtime。
+export const runtime = "nodejs";
+
+interface Built { params?: Record<string, string>; filter?: unknown }
+
+export async function POST(req: Request, ctx: { params: Promise<{ resource: string }> }): Promise<Response> {
+  const { resource } = await ctx.params;
+  const url = new URL(req.url);
+  const knob = url.searchParams;
+
+  // 場景旋鈕(spec §5):強制 error / delay / empty 以驅動 UI 狀態。
+  const errorCode = Number(knob.get("error"));
+  if (errorCode >= 400) return Response.json({ error: "forced" }, { status: errorCode });
+  const delay = Number(knob.get("delay"));
+  if (delay > 0) await new Promise((r) => setTimeout(r, delay));
+
+  const found = getResource(resource);
+  if (!found) return Response.json({ error: `unknown resource ${resource}` }, { status: 404 });
+
+  const body = (await req.json().catch(() => ({}))) as Built;
+  const built = { params: body.params ?? {}, filter: body.filter };
+  const rows = knob.get("empty") ? [] : found.rows;
+
+  const { items, total, nextCursor } = runQuery(rows, found.columns, found.fields, built);
+  const data: Record<string, unknown> = { items, total };
+  if (nextCursor !== undefined) data.nextCursor = nextCursor;
+  return Response.json({ data });
+}

--- a/apps/web/src/lib/fake-query.spec.ts
+++ b/apps/web/src/lib/fake-query.spec.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { runQuery } from "./fake-query";
+import type { TableColumnConfig } from "@rfjs/table-builder";
+import type { DataFieldMeta } from "@rfjs/data-schema";
+
+const fields: DataFieldMeta[] = [
+  { key: "id", label: "ID", dataType: "numeric", filterable: true, kind: "column" },
+  { key: "name", label: "Name", dataType: "string", filterable: true, kind: "column" },
+];
+const columns: TableColumnConfig[] = [
+  { key: "id", label: "ID", dataType: "numeric" },
+  { key: "name", label: "Name", dataType: "string" },
+];
+const rows = [
+  { id: 1, name: "Ada" },
+  { id: 2, name: "Alan" },
+  { id: 3, name: "Grace" },
+];
+
+describe("runQuery", () => {
+  it("no filter → all rows, total = length", () => {
+    const r = runQuery(rows, columns, fields, { params: {} });
+    expect(r.total).toBe(3);
+    expect(r.items).toHaveLength(3);
+  });
+
+  it("applies a column filter (eq)", () => {
+    const filter = { logic: "and", filters: [{ target: "column", column: "name", operator: "eq", value: "Ada" }] };
+    const r = runQuery(rows, columns, fields, { params: {}, filter });
+    expect(r.items).toEqual([{ id: 1, name: "Ada" }]);
+    expect(r.total).toBe(1);
+  });
+
+  it("sorts + paginates (page strategy)", () => {
+    const r = runQuery(rows, columns, fields, { params: { page: "1", pageSize: "2", sort: "-id" } });
+    expect(r.items.map((x) => x.id)).toEqual([3, 2]);
+    expect(r.total).toBe(3);
+  });
+});

--- a/apps/web/src/lib/fake-query.ts
+++ b/apps/web/src/lib/fake-query.ts
@@ -1,0 +1,111 @@
+import { sortRows } from "@rfjs/table-builder";
+import type { TableColumnConfig } from "@rfjs/table-builder";
+import { filterGroupToTree, runLiveMatch } from "@rfjs/filter-builder";
+import type { FilterConditionLike, FilterGroupLike } from "@rfjs/filter-builder";
+import type { PgFilterGroup, PgLeaf } from "@rfjs/pg-filter";
+import type { DataFieldMeta } from "@rfjs/data-schema";
+
+interface ParsedSort {
+  key: string;
+  direction: "asc" | "desc";
+}
+
+// Decodes both `sort` encodings `buildRequestParams` can produce (colon `key:dir` / signed
+// `-key`|`key`) under the single `sort` param name, plus the split `sortBy`+`order` pair.
+function parseSort(params: Record<string, string>): ParsedSort | undefined {
+  const single = params.sort;
+  if (single !== undefined) {
+    if (single.startsWith("-")) return { key: single.slice(1), direction: "desc" };
+    if (single.includes(":")) {
+      const [key, dir] = single.split(":");
+      return { key: key ?? "", direction: dir === "desc" ? "desc" : "asc" };
+    }
+    return { key: single, direction: "asc" };
+  }
+  if (params.sortBy !== undefined) {
+    return { key: params.sortBy, direction: params.order === "desc" ? "desc" : "asc" };
+  }
+  return undefined;
+}
+
+interface PagedResult {
+  items: Record<string, unknown>[];
+  total: number;
+  nextCursor?: string;
+}
+
+// Distinguishes the three `PaginationMeta` strategies purely from which params are present:
+// offset always sends both `offset`+`limit`; page always sends both `page`+`pageSize`; cursor
+// sends `limit` alone on the first page and adds `cursor` (the previous response's `nextCursor`,
+// itself a stringified row offset) on subsequent pages.
+function paginate(rows: Record<string, unknown>[], params: Record<string, string>): PagedResult {
+  if (params.offset !== undefined) {
+    const limit = Number(params.limit ?? rows.length);
+    const offset = Number(params.offset);
+    return { items: rows.slice(offset, offset + limit), total: rows.length };
+  }
+
+  if (params.page !== undefined && params.pageSize !== undefined) {
+    const pageSize = Number(params.pageSize);
+    const page = Number(params.page);
+    const start = (page - 1) * pageSize;
+    return { items: rows.slice(start, start + pageSize), total: rows.length };
+  }
+
+  const limit = Number(params.limit ?? rows.length);
+  const offset = params.cursor !== undefined ? Number(params.cursor) : 0;
+  const items = rows.slice(offset, offset + limit);
+  const nextOffset = offset + items.length;
+  const nextCursor = nextOffset < rows.length ? String(nextOffset) : undefined;
+  return { items, total: rows.length, nextCursor };
+}
+
+// pg 群組 → filter-builder 的 FilterGroupLike:column 葉不帶 dataType,從 fields 反查(spec §3)。
+function pgLeafToCondition(leaf: PgLeaf, fields: DataFieldMeta[]): FilterConditionLike {
+  if (leaf.target === "column") {
+    const meta = fields.find((f) => f.key === leaf.column);
+    return { field: leaf.column, dataType: meta?.dataType ?? "string", operator: leaf.operator, value: leaf.value };
+  }
+  return {
+    field: leaf.field,
+    dataType: leaf.dataType as FilterConditionLike["dataType"],
+    operator: leaf.operator,
+    value: leaf.value,
+  };
+}
+
+function pgGroupToFilterGroup(group: PgFilterGroup, fields: DataFieldMeta[]): FilterGroupLike {
+  return {
+    logic: group.logic,
+    filters: group.filters.map((node) =>
+      "logic" in node ? pgGroupToFilterGroup(node as PgFilterGroup, fields) : pgLeafToCondition(node as PgLeaf, fields),
+    ),
+  };
+}
+
+/** built.filter(PgFilterGroup)→ reverse 成 builder 樹 → runLiveMatch 在記憶體執行(dogfood reverse 鏈)。 */
+function applyPgFilter(
+  rows: Record<string, unknown>[],
+  filter: unknown,
+  fields: DataFieldMeta[],
+): Record<string, unknown>[] {
+  if (filter === undefined) return rows;
+  const tree = filterGroupToTree(pgGroupToFilterGroup(filter as PgFilterGroup, fields), () => crypto.randomUUID());
+  const match = runLiveMatch(rows, tree);
+  // 不可覆蓋的運算子:示範資料不該發生;寧可回全量也不要誤報 0 筆
+  return match.uncoverable ? rows : (match.matched as Record<string, unknown>[]);
+}
+
+/** 純記憶體查詢:filter(pg reverse → runLiveMatch)→ sort → paginate。in-process fake fetcher
+ * 與 HTTP route 共用,兩者 dogfood 完全相同的引擎。 */
+export function runQuery(
+  rows: Record<string, unknown>[],
+  columns: TableColumnConfig[],
+  fields: DataFieldMeta[],
+  built: { params: Record<string, string>; filter?: unknown },
+): PagedResult {
+  const filtered = applyPgFilter(rows, built.filter, fields);
+  const sort = parseSort(built.params);
+  const sorted = sort ? sortRows(filtered, sort, columns) : filtered;
+  return paginate(sorted, built.params);
+}

--- a/apps/web/src/lib/query-resources.spec.ts
+++ b/apps/web/src/lib/query-resources.spec.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from "vitest";
+import { getResource } from "./query-resources";
+
+describe("getResource", () => {
+  it("returns the sample resource with rows/columns/fields", () => {
+    const r = getResource("sample");
+    expect(r).toBeDefined();
+    expect(r!.rows.length).toBeGreaterThan(0);
+    expect(r!.columns.length).toBeGreaterThan(0);
+    expect(r!.fields.length).toBeGreaterThan(0);
+  });
+  it("returns undefined for an unknown resource", () => {
+    expect(getResource("nope")).toBeUndefined();
+  });
+});

--- a/apps/web/src/lib/query-resources.ts
+++ b/apps/web/src/lib/query-resources.ts
@@ -1,0 +1,19 @@
+import { SAMPLE_ROWS, SAMPLE_META, SAMPLE_CONFIG } from "@/tools/table-builder/sample";
+import type { TableColumnConfig } from "@rfjs/table-builder";
+import type { DataFieldMeta } from "@rfjs/data-schema";
+
+export interface QueryResource {
+  rows: Record<string, unknown>[];
+  columns: TableColumnConfig[];
+  fields: DataFieldMeta[];
+}
+
+// 服務與 table-builder 工具相同的 rows，所以工具把 transport 從 in-memory 切成 HTTP 時，
+// 回傳的資料一模一樣（證明變的只有 transport）。
+const RESOURCES: Record<string, QueryResource> = {
+  sample: { rows: SAMPLE_ROWS, columns: SAMPLE_CONFIG.columns, fields: SAMPLE_META.fields },
+};
+
+export function getResource(id: string): QueryResource | undefined {
+  return RESOURCES[id];
+}

--- a/apps/web/src/tools/table-builder/fake-fetcher.ts
+++ b/apps/web/src/tools/table-builder/fake-fetcher.ts
@@ -1,115 +1,22 @@
-import { sortRows } from "@rfjs/table-builder";
 import type { TableColumnConfig } from "@rfjs/table-builder";
-import { filterGroupToTree, runLiveMatch } from "@rfjs/filter-builder";
-import type { FilterConditionLike, FilterGroupLike } from "@rfjs/filter-builder";
-import type { PgFilterGroup, PgLeaf } from "@rfjs/pg-filter";
 import type { BuiltRequest, DataFieldMeta } from "@rfjs/data-schema";
+import { runQuery } from "@/lib/fake-query";
 
 // A live example of the `DataResourceMeta` request/response contract (design spec §6.2): the
 // same in-memory rows are served under all three pagination strategies (offset/page/cursor) plus
 // server-side sort, purely by reading the param names `buildRequestParams` produces for each
 // strategy -- so the fetcher never needs to be told which strategy is in play, only the rows/
 // columns to serve. Response shape is always `{ data: { items, total, nextCursor? } }`, matching
-// `SAMPLE_META.response` (`data.items` / `data.total` / `data.nextCursor`).
+// `SAMPLE_META.response` (`data.items` / `data.total` / `data.nextCursor`). The actual filter →
+// sort → paginate logic lives in `@/lib/fake-query` (`runQuery`), shared with the HTTP route.
 
 const FAKE_FETCH_DELAY_MS = 120;
-
-interface ParsedSort {
-  key: string;
-  direction: "asc" | "desc";
-}
-
-// Decodes both `sort` encodings `buildRequestParams` can produce (colon `key:dir` / signed
-// `-key`|`key`) under the single `sort` param name, plus the split `sortBy`+`order` pair.
-function parseSort(params: Record<string, string>): ParsedSort | undefined {
-  const single = params.sort;
-  if (single !== undefined) {
-    if (single.startsWith("-")) return { key: single.slice(1), direction: "desc" };
-    if (single.includes(":")) {
-      const [key, dir] = single.split(":");
-      return { key: key ?? "", direction: dir === "desc" ? "desc" : "asc" };
-    }
-    return { key: single, direction: "asc" };
-  }
-  if (params.sortBy !== undefined) {
-    return { key: params.sortBy, direction: params.order === "desc" ? "desc" : "asc" };
-  }
-  return undefined;
-}
-
-interface PagedResult {
-  items: Record<string, unknown>[];
-  total: number;
-  nextCursor?: string;
-}
-
-// Distinguishes the three `PaginationMeta` strategies purely from which params are present:
-// offset always sends both `offset`+`limit`; page always sends both `page`+`pageSize`; cursor
-// sends `limit` alone on the first page and adds `cursor` (the previous response's `nextCursor`,
-// itself a stringified row offset) on subsequent pages.
-function paginate(rows: Record<string, unknown>[], params: Record<string, string>): PagedResult {
-  if (params.offset !== undefined) {
-    const limit = Number(params.limit ?? rows.length);
-    const offset = Number(params.offset);
-    return { items: rows.slice(offset, offset + limit), total: rows.length };
-  }
-
-  if (params.page !== undefined && params.pageSize !== undefined) {
-    const pageSize = Number(params.pageSize);
-    const page = Number(params.page);
-    const start = (page - 1) * pageSize;
-    return { items: rows.slice(start, start + pageSize), total: rows.length };
-  }
-
-  const limit = Number(params.limit ?? rows.length);
-  const offset = params.cursor !== undefined ? Number(params.cursor) : 0;
-  const items = rows.slice(offset, offset + limit);
-  const nextOffset = offset + items.length;
-  const nextCursor = nextOffset < rows.length ? String(nextOffset) : undefined;
-  return { items, total: rows.length, nextCursor };
-}
-
-// pg 群組 → filter-builder 的 FilterGroupLike:column 葉不帶 dataType,從 fields 反查(spec §3)。
-function pgLeafToCondition(leaf: PgLeaf, fields: DataFieldMeta[]): FilterConditionLike {
-  if (leaf.target === "column") {
-    const meta = fields.find((f) => f.key === leaf.column);
-    return { field: leaf.column, dataType: meta?.dataType ?? "string", operator: leaf.operator, value: leaf.value };
-  }
-  return {
-    field: leaf.field,
-    dataType: leaf.dataType as FilterConditionLike["dataType"],
-    operator: leaf.operator,
-    value: leaf.value,
-  };
-}
-
-function pgGroupToFilterGroup(group: PgFilterGroup, fields: DataFieldMeta[]): FilterGroupLike {
-  return {
-    logic: group.logic,
-    filters: group.filters.map((node) =>
-      "logic" in node ? pgGroupToFilterGroup(node as PgFilterGroup, fields) : pgLeafToCondition(node as PgLeaf, fields),
-    ),
-  };
-}
-
-/** built.filter(PgFilterGroup)→ reverse 成 builder 樹 → runLiveMatch 在記憶體執行(dogfood reverse 鏈)。 */
-function applyPgFilter(
-  rows: Record<string, unknown>[],
-  filter: unknown,
-  fields: DataFieldMeta[],
-): Record<string, unknown>[] {
-  if (filter === undefined) return rows;
-  const tree = filterGroupToTree(pgGroupToFilterGroup(filter as PgFilterGroup, fields), () => crypto.randomUUID());
-  const match = runLiveMatch(rows, tree);
-  // 不可覆蓋的運算子:示範資料不該發生;寧可回全量也不要誤報 0 筆
-  return match.uncoverable ? rows : (match.matched as Record<string, unknown>[]);
-}
 
 /**
  * Builds a fake `TableSource['fetch']` implementation over static `rows`. `columns` is needed
  * only to pick the right comparator per `sortRows` (dataType-aware); pagination/sort strategy is
- * inferred entirely from `built.params` (see `paginate`/`parseSort`). Resolves after a fixed
- * delay so the tool page's loading state is actually visible.
+ * inferred entirely from `built.params` (see `runQuery`). Resolves after a fixed delay so the
+ * tool page's loading state is actually visible.
  */
 export function makeFakeFetcher(
   rows: Record<string, unknown>[],
@@ -117,10 +24,7 @@ export function makeFakeFetcher(
   fields: DataFieldMeta[] = [],
 ): (built: BuiltRequest) => Promise<unknown> {
   return (built: BuiltRequest): Promise<unknown> => {
-    const filtered = applyPgFilter(rows, built.filter, fields);
-    const sort = parseSort(built.params);
-    const sorted = sort ? sortRows(filtered, sort, columns) : filtered;
-    const { items, total, nextCursor } = paginate(sorted, built.params);
+    const { items, total, nextCursor } = runQuery(rows, columns, fields, built);
 
     const data: Record<string, unknown> = { items, total };
     if (nextCursor !== undefined) data.nextCursor = nextCursor;

--- a/apps/web/src/tools/table-builder/http-fetcher.spec.ts
+++ b/apps/web/src/tools/table-builder/http-fetcher.spec.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect, vi } from "vitest";
+import { makeHttpFetcher } from "./http-fetcher";
+
+describe("makeHttpFetcher", () => {
+  it("POSTs the built request as JSON and returns parsed json", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({ data: { items: [], total: 0 } }) });
+    vi.stubGlobal("fetch", fetchMock);
+    const fetcher = makeHttpFetcher("/api/query/sample");
+    const built = { endpoint: "/api/query/sample", method: "POST", params: { page: "1" }, filter: undefined };
+    const out = await fetcher(built as never);
+    expect(fetchMock).toHaveBeenCalledWith("/api/query/sample", expect.objectContaining({ method: "POST" }));
+    const sentBody = JSON.parse(fetchMock.mock.calls[0]![1].body);
+    expect(sentBody.params).toEqual({ page: "1" });
+    expect(out).toEqual({ data: { items: [], total: 0 } });
+    vi.unstubAllGlobals();
+  });
+
+  it("throws on a non-ok response", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 500 }));
+    const fetcher = makeHttpFetcher("/api/query/sample");
+    await expect(fetcher({ params: {} } as never)).rejects.toThrow();
+    vi.unstubAllGlobals();
+  });
+});

--- a/apps/web/src/tools/table-builder/http-fetcher.ts
+++ b/apps/web/src/tools/table-builder/http-fetcher.ts
@@ -1,0 +1,19 @@
+import type { BuiltRequest } from "@rfjs/data-schema";
+
+/**
+ * App-level minimal HTTP transport for a remote `TableSource.fetch`: POSTs the tool's
+ * `BuiltRequest` to `endpoint` and returns the parsed JSON. Deliberately a thin, replaceable
+ * adapter -- a package-level http-fetcher (#14) can supersede it; both share the same
+ * `(built) => Promise<unknown>` signature and BuiltRequest/`{data}` contract.
+ */
+export function makeHttpFetcher(endpoint: string): (built: BuiltRequest) => Promise<unknown> {
+  return async (built: BuiltRequest): Promise<unknown> => {
+    const res = await fetch(endpoint, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(built),
+    });
+    if (!res.ok) throw new Error(`query failed: ${res.status}`);
+    return res.json();
+  };
+}

--- a/apps/web/src/tools/table-builder/source-panel.spec.tsx
+++ b/apps/web/src/tools/table-builder/source-panel.spec.tsx
@@ -129,3 +129,20 @@ describe("SourcePanel", () => {
     expect(onImport).toHaveBeenCalledWith([{ a: 1, b: "x" }]);
   });
 });
+
+const baseLabels = {} as never; // labels 有預設值;見 SourcePanel props
+
+describe("SourcePanel transport toggle", () => {
+  it("shows a transport toggle only when remote, and reports changes", () => {
+    const onTransportChange = vi.fn();
+    const { rerender } = render(
+      <SourcePanel mode="rows" onModeChange={() => {}} labels={baseLabels} transport="memory" onTransportChange={onTransportChange} />,
+    );
+    expect(screen.queryByRole("button", { name: /http/i })).toBeNull();
+    rerender(
+      <SourcePanel mode="offset" onModeChange={() => {}} labels={baseLabels} transport="memory" onTransportChange={onTransportChange} />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /http/i }));
+    expect(onTransportChange).toHaveBeenCalledWith("http");
+  });
+});

--- a/apps/web/src/tools/table-builder/source-panel.tsx
+++ b/apps/web/src/tools/table-builder/source-panel.tsx
@@ -31,6 +31,8 @@ export interface SourcePanelProps {
   importLabels?: SourcePanelImportLabels;
   /** Initial paste-box contents (e.g. the sample rows as JSON) so the box is a usable, editable example. */
   defaultText?: string;
+  transport?: "memory" | "http";
+  onTransportChange?: (t: "memory" | "http") => void;
 }
 
 // Fetcher strategies shown once 'rows' is switched off (design spec §6.1: "靜態 rows ↔ 假
@@ -45,7 +47,16 @@ function segmentClass(active: boolean): string {
   ].join(" ");
 }
 
-export function SourcePanel({ mode, onModeChange, labels, onImport, importLabels, defaultText }: SourcePanelProps) {
+export function SourcePanel({
+  mode,
+  onModeChange,
+  labels,
+  onImport,
+  importLabels,
+  defaultText,
+  transport,
+  onTransportChange,
+}: SourcePanelProps) {
   const isRemote = mode !== "rows";
   const [format, setFormat] = React.useState<ImportFormat>("json");
   const [text, setText] = React.useState(defaultText ?? "");
@@ -108,6 +119,21 @@ export function SourcePanel({ mode, onModeChange, labels, onImport, importLabels
             ))}
           </div>
         ) : null}
+        {isRemote && onTransportChange && (
+          <div className="flex items-center gap-2">
+            <span className="text-xs text-muted-foreground">Transport</span>
+            <button
+              type="button"
+              className={segmentClass(transport === "memory")}
+              onClick={() => onTransportChange("memory")}
+            >
+              in-memory
+            </button>
+            <button type="button" className={segmentClass(transport === "http")} onClick={() => onTransportChange("http")}>
+              HTTP
+            </button>
+          </div>
+        )}
         {!isRemote && importLabels ? (
           <div className="flex flex-col gap-2 border-t pt-2">
             <div className="flex gap-1">

--- a/apps/web/src/tools/table-builder/ui.tsx
+++ b/apps/web/src/tools/table-builder/ui.tsx
@@ -25,6 +25,7 @@ import {
 } from "./sample";
 import type { SourceMode } from "./sample";
 import { makeFakeFetcher } from "./fake-fetcher";
+import { makeHttpFetcher } from "./http-fetcher";
 import { SourcePanel } from "./source-panel";
 import { ColumnsPanel } from "./columns-panel";
 import { PaginationPanel } from "./pagination-panel";
@@ -53,6 +54,7 @@ export function TableBuilderTool() {
 
   const [config, setConfig] = React.useState<TableConfig>(SAMPLE_CONFIG);
   const [sourceMode, setSourceMode] = React.useState<SourceMode>("rows");
+  const [transport, setTransport] = React.useState<"memory" | "http">("memory");
   const [rows, setRows] =
     React.useState<Record<string, unknown>[]>(SAMPLE_ROWS);
   const [dataVersion, setDataVersion] = React.useState(0);
@@ -178,9 +180,12 @@ export function TableBuilderTool() {
       request,
       response: SAMPLE_META.response!,
       fields: SAMPLE_META.fields,
-      fetch: makeFakeFetcher(SAMPLE_ROWS, config.columns, SAMPLE_META.fields),
+      fetch:
+        transport === "http"
+          ? makeHttpFetcher("/api/query/sample")
+          : makeFakeFetcher(SAMPLE_ROWS, config.columns, SAMPLE_META.fields),
     };
-  }, [sourceMode, config.columns, rows]);
+  }, [sourceMode, transport, config.columns, rows]);
 
   // Metadata tab inputs (design spec §2.2): rows mode is a pure fields description; fetcher
   // mode carries the currently selected strategy's request protocol + the sample response map.
@@ -319,6 +324,8 @@ export function TableBuilderTool() {
           onImport={handleImport}
           importLabels={importLabels}
           defaultText={SAMPLE_JSON}
+          transport={transport}
+          onTransportChange={setTransport}
         />
       ) : null}
       {tab === "columns" ? (

--- a/docs/superpowers/plans/2026-07-11-filter-api-dogfood.md
+++ b/docs/superpowers/plans/2026-07-11-filter-api-dogfood.md
@@ -1,0 +1,685 @@
+# filter → API dogfood 實作計畫
+
+> **給執行者:** 必用子技能:superpowers:subagent-driven-development(建議)或 superpowers:executing-plans,逐任務執行本計畫。步驟用 checkbox(`- [ ]`)追蹤。
+
+**目標:** 為 table-builder 工具點亮一條真實的 filter→HTTP→rows 往返——透過一個自包含的 Next.js 假 route(免 Postgres),含場景旋鈕與最小客端接線。
+
+**架構:** 把現有 `fake-fetcher.ts` 的記憶體查詢引擎抽成共享純模組;Next.js `POST /api/query/[resource]` route 複用它在伺服端 filter/sort/paginate;`makeHttpFetcher` transport 把工具的 `BuiltRequest` POST 到該 route;table-builder 新增 in-memory↔HTTP 的 transport 切換。契約走**工具原生慣例**(`BuiltRequest` + `{data:{items,total,nextCursor?}}`),**非** apps/api 的結構化 body。
+
+**技術棧:** Next.js 16 App Router(Node runtime)、TypeScript、React 19、Vitest + @testing-library、消費 `@rfjs/filter-builder`/`@rfjs/pg-filter`/`@rfjs/table-builder(-ui)`/`@rfjs/data-schema`。
+
+## 全域約束
+
+- **紅線:** 不改 `packages/*` 底下任何東西。所有改動都在 `apps/web`,只消費。
+- **無 changeset**(只動 apps/web;app 不記版本)。
+- 契約 = 工具原生 `BuiltRequest`(`{params, filter}`)請求 + `{data:{items,total,nextCursor?}}` 回應。**不要**改成 apps/api 的 `{filter,sort,page,pageSize}`。
+- Transport(`makeHttpFetcher`)是 app 級、可替換的 adapter——**不要**放進 package(避免撞 #14)。
+- 複用既有樣本資料(`SAMPLE_ROWS`/`SAMPLE_META`/`SAMPLE_CONFIG`,來自 `@/tools/table-builder/sample`),讓 HTTP 路徑回傳與 in-memory 路徑相同的 rows。
+- Commit:英文 Conventional Commits,結尾加 `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`。
+- 一切從 worktree 根目錄執行:`/home/royfw/_/code/royfw/rfjs/.claude/worktrees/feat-filter-api-dogfood`。web 測試 = `pnpm -F web exec vitest run <pattern>`;型別檢查 = `pnpm -F web check-types`;lint = `pnpm -F web lint`。
+
+---
+
+## 檔案結構
+
+- `apps/web/src/lib/fake-query.ts`(新)— 純 `runQuery(rows, columns, fields, built)`;由 `fake-fetcher.ts` 原封搬出的記憶體 filter/sort/paginate 引擎。
+- `apps/web/src/tools/table-builder/fake-fetcher.ts`(改)— 變成 `runQuery` 的薄殼(行為不變)。
+- `apps/web/src/lib/query-resources.ts`(新)— 資源 registry(`sample` → rows/columns/fields)。
+- `apps/web/src/app/api/query/[resource]/route.ts`(新)— POST route + 場景旋鈕。
+- `apps/web/src/tools/table-builder/http-fetcher.ts`(新)— `makeHttpFetcher(endpoint)`。
+- `apps/web/src/tools/table-builder/ui.tsx`(改)— transport 狀態 + source `fetch` 選擇。
+- `apps/web/src/tools/table-builder/source-panel.tsx`(改)— transport 切換(memory / HTTP)。
+
+---
+
+## Task 1 · 抽出純查詢引擎
+
+**檔案:**
+- 新增:`apps/web/src/lib/fake-query.ts`
+- 修改:`apps/web/src/tools/table-builder/fake-fetcher.ts`
+- 測試:`apps/web/src/lib/fake-query.spec.ts`
+
+**介面:**
+- 產出:`runQuery(rows: Record<string,unknown>[], columns: TableColumnConfig[], fields: DataFieldMeta[], built: { params: Record<string,string>; filter?: unknown }): { items: Record<string,unknown>[]; total: number; nextCursor?: string }`。
+
+- [ ] **步驟 1:寫失敗測試**
+
+新增 `apps/web/src/lib/fake-query.spec.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { runQuery } from "./fake-query";
+import type { TableColumnConfig } from "@rfjs/table-builder";
+import type { DataFieldMeta } from "@rfjs/data-schema";
+
+const fields: DataFieldMeta[] = [
+  { key: "id", label: "ID", dataType: "numeric", filterable: true, kind: "column" },
+  { key: "name", label: "Name", dataType: "string", filterable: true, kind: "column" },
+];
+const columns: TableColumnConfig[] = [
+  { key: "id", label: "ID", dataType: "numeric" },
+  { key: "name", label: "Name", dataType: "string" },
+];
+const rows = [
+  { id: 1, name: "Ada" },
+  { id: 2, name: "Alan" },
+  { id: 3, name: "Grace" },
+];
+
+describe("runQuery", () => {
+  it("no filter → all rows, total = length", () => {
+    const r = runQuery(rows, columns, fields, { params: {} });
+    expect(r.total).toBe(3);
+    expect(r.items).toHaveLength(3);
+  });
+
+  it("applies a column filter (eq)", () => {
+    const filter = { logic: "and", filters: [{ target: "column", column: "name", operator: "eq", value: "Ada" }] };
+    const r = runQuery(rows, columns, fields, { params: {}, filter });
+    expect(r.items).toEqual([{ id: 1, name: "Ada" }]);
+    expect(r.total).toBe(1);
+  });
+
+  it("sorts + paginates (page strategy)", () => {
+    const r = runQuery(rows, columns, fields, { params: { page: "1", pageSize: "2", sort: "-id" } });
+    expect(r.items.map((x) => x.id)).toEqual([3, 2]);
+    expect(r.total).toBe(3);
+  });
+});
+```
+
+- [ ] **步驟 2:跑測試確認 FAIL**
+
+執行:`pnpm -F web exec vitest run fake-query`
+預期:FAIL —— `./fake-query` 不存在。
+
+- [ ] **步驟 3:建立純模組**
+
+把 `fake-fetcher.ts` 的純邏輯搬到 `apps/web/src/lib/fake-query.ts`(helpers 原封複製,export `runQuery`):
+
+```ts
+import { sortRows } from "@rfjs/table-builder";
+import type { TableColumnConfig } from "@rfjs/table-builder";
+import { filterGroupToTree, runLiveMatch } from "@rfjs/filter-builder";
+import type { FilterConditionLike, FilterGroupLike } from "@rfjs/filter-builder";
+import type { PgFilterGroup, PgLeaf } from "@rfjs/pg-filter";
+import type { DataFieldMeta } from "@rfjs/data-schema";
+
+interface ParsedSort { key: string; direction: "asc" | "desc"; }
+
+function parseSort(params: Record<string, string>): ParsedSort | undefined {
+  const single = params.sort;
+  if (single !== undefined) {
+    if (single.startsWith("-")) return { key: single.slice(1), direction: "desc" };
+    if (single.includes(":")) {
+      const [key, dir] = single.split(":");
+      return { key: key ?? "", direction: dir === "desc" ? "desc" : "asc" };
+    }
+    return { key: single, direction: "asc" };
+  }
+  if (params.sortBy !== undefined) {
+    return { key: params.sortBy, direction: params.order === "desc" ? "desc" : "asc" };
+  }
+  return undefined;
+}
+
+interface PagedResult { items: Record<string, unknown>[]; total: number; nextCursor?: string; }
+
+function paginate(rows: Record<string, unknown>[], params: Record<string, string>): PagedResult {
+  if (params.offset !== undefined) {
+    const limit = Number(params.limit ?? rows.length);
+    const offset = Number(params.offset);
+    return { items: rows.slice(offset, offset + limit), total: rows.length };
+  }
+  if (params.page !== undefined && params.pageSize !== undefined) {
+    const pageSize = Number(params.pageSize);
+    const page = Number(params.page);
+    const start = (page - 1) * pageSize;
+    return { items: rows.slice(start, start + pageSize), total: rows.length };
+  }
+  const limit = Number(params.limit ?? rows.length);
+  const offset = params.cursor !== undefined ? Number(params.cursor) : 0;
+  const items = rows.slice(offset, offset + limit);
+  const nextOffset = offset + items.length;
+  const nextCursor = nextOffset < rows.length ? String(nextOffset) : undefined;
+  return { items, total: rows.length, nextCursor };
+}
+
+function pgLeafToCondition(leaf: PgLeaf, fields: DataFieldMeta[]): FilterConditionLike {
+  if (leaf.target === "column") {
+    const meta = fields.find((f) => f.key === leaf.column);
+    return { field: leaf.column, dataType: meta?.dataType ?? "string", operator: leaf.operator, value: leaf.value };
+  }
+  return { field: leaf.field, dataType: leaf.dataType as FilterConditionLike["dataType"], operator: leaf.operator, value: leaf.value };
+}
+
+function pgGroupToFilterGroup(group: PgFilterGroup, fields: DataFieldMeta[]): FilterGroupLike {
+  return {
+    logic: group.logic,
+    filters: group.filters.map((node) =>
+      "logic" in node ? pgGroupToFilterGroup(node as PgFilterGroup, fields) : pgLeafToCondition(node as PgLeaf, fields),
+    ),
+  };
+}
+
+function applyPgFilter(rows: Record<string, unknown>[], filter: unknown, fields: DataFieldMeta[]): Record<string, unknown>[] {
+  if (filter === undefined) return rows;
+  const tree = filterGroupToTree(pgGroupToFilterGroup(filter as PgFilterGroup, fields), () => crypto.randomUUID());
+  const match = runLiveMatch(rows, tree);
+  return match.uncoverable ? rows : (match.matched as Record<string, unknown>[]);
+}
+
+/** 純記憶體查詢:filter(pg reverse → runLiveMatch)→ sort → paginate。in-process fake fetcher
+ * 與 HTTP route 共用,兩者 dogfood 完全相同的引擎。 */
+export function runQuery(
+  rows: Record<string, unknown>[],
+  columns: TableColumnConfig[],
+  fields: DataFieldMeta[],
+  built: { params: Record<string, string>; filter?: unknown },
+): PagedResult {
+  const filtered = applyPgFilter(rows, built.filter, fields);
+  const sort = parseSort(built.params);
+  const sorted = sort ? sortRows(filtered, sort, columns) : filtered;
+  return paginate(sorted, built.params);
+}
+```
+
+再把 `fake-fetcher.ts` 改成委派(保留 `FAKE_FETCH_DELAY_MS` 與 `{data}` 外殼):
+
+```ts
+import type { TableColumnConfig } from "@rfjs/table-builder";
+import type { BuiltRequest, DataFieldMeta } from "@rfjs/data-schema";
+import { runQuery } from "@/lib/fake-query";
+
+const FAKE_FETCH_DELAY_MS = 120;
+
+export function makeFakeFetcher(
+  rows: Record<string, unknown>[],
+  columns: TableColumnConfig[],
+  fields: DataFieldMeta[] = [],
+): (built: BuiltRequest) => Promise<unknown> {
+  return (built: BuiltRequest): Promise<unknown> => {
+    const { items, total, nextCursor } = runQuery(rows, columns, fields, built);
+    const data: Record<string, unknown> = { items, total };
+    if (nextCursor !== undefined) data.nextCursor = nextCursor;
+    return new Promise((resolve) => setTimeout(() => resolve({ data }), FAKE_FETCH_DELAY_MS));
+  };
+}
+```
+
+- [ ] **步驟 4:跑測試確認 PASS**
+
+執行:`pnpm -F web exec vitest run fake-query fake-fetcher table-builder`
+預期:PASS —— 新 `fake-query` 測試 + 既有 `fake-fetcher`/table-builder 測試續綠(行為不變)。
+
+執行:`pnpm -F web check-types`
+預期:無錯誤(apps/web 已設 `@/` 路徑別名)。
+
+- [ ] **步驟 5:Commit**
+
+```bash
+git add apps/web/src/lib/fake-query.ts apps/web/src/lib/fake-query.spec.ts apps/web/src/tools/table-builder/fake-fetcher.ts
+git commit -m "$(cat <<'EOF'
+refactor(web): extract shared in-memory runQuery engine from fake-fetcher
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2 · 資源 registry
+
+**檔案:**
+- 新增:`apps/web/src/lib/query-resources.ts`
+- 測試:`apps/web/src/lib/query-resources.spec.ts`
+
+**介面:**
+- 消費:`SAMPLE_ROWS`、`SAMPLE_META`、`SAMPLE_CONFIG`(來自 `@/tools/table-builder/sample`)。
+- 產出:`getResource(id: string): { rows; columns; fields } | undefined`。
+
+- [ ] **步驟 1:寫失敗測試**
+
+新增 `apps/web/src/lib/query-resources.spec.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { getResource } from "./query-resources";
+
+describe("getResource", () => {
+  it("returns the sample resource with rows/columns/fields", () => {
+    const r = getResource("sample");
+    expect(r).toBeDefined();
+    expect(r!.rows.length).toBeGreaterThan(0);
+    expect(r!.columns.length).toBeGreaterThan(0);
+    expect(r!.fields.length).toBeGreaterThan(0);
+  });
+  it("returns undefined for an unknown resource", () => {
+    expect(getResource("nope")).toBeUndefined();
+  });
+});
+```
+
+- [ ] **步驟 2:跑測試確認 FAIL**
+
+執行:`pnpm -F web exec vitest run query-resources`
+預期:FAIL —— 模組不存在。
+
+- [ ] **步驟 3:實作 registry**
+
+新增 `apps/web/src/lib/query-resources.ts`:
+
+```ts
+import { SAMPLE_ROWS, SAMPLE_META, SAMPLE_CONFIG } from "@/tools/table-builder/sample";
+import type { TableColumnConfig } from "@rfjs/table-builder";
+import type { DataFieldMeta } from "@rfjs/data-schema";
+
+export interface QueryResource {
+  rows: Record<string, unknown>[];
+  columns: TableColumnConfig[];
+  fields: DataFieldMeta[];
+}
+
+// 服務與 table-builder 工具相同的 rows,所以工具把 transport 從 in-memory 切成 HTTP 時,
+// 回傳的資料一模一樣(證明變的只有 transport)。
+const RESOURCES: Record<string, QueryResource> = {
+  sample: { rows: SAMPLE_ROWS, columns: SAMPLE_CONFIG.columns, fields: SAMPLE_META.fields },
+};
+
+export function getResource(id: string): QueryResource | undefined {
+  return RESOURCES[id];
+}
+```
+
+- [ ] **步驟 4:跑測試確認 PASS**
+
+執行:`pnpm -F web exec vitest run query-resources`
+預期:PASS。
+
+- [ ] **步驟 5:Commit**
+
+```bash
+git add apps/web/src/lib/query-resources.ts apps/web/src/lib/query-resources.spec.ts
+git commit -m "$(cat <<'EOF'
+feat(web): add fake query resource registry (sample)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3 · Next.js 假 route + 場景旋鈕
+
+**檔案:**
+- 新增:`apps/web/src/app/api/query/[resource]/route.ts`
+- 測試:`apps/web/src/app/api/query/[resource]/route.spec.ts`
+
+**介面:**
+- 消費:`getResource`(任務 2)、`runQuery`(任務 1)。
+- 產出:`POST /api/query/[resource]` → `{ data: { items, total, nextCursor? } }`;未知資源 404;旋鈕 `?delay/?error/?empty`。
+
+- [ ] **步驟 1:寫失敗測試**
+
+新增 `apps/web/src/app/api/query/[resource]/route.spec.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { POST } from "./route";
+
+function post(resource: string, body: unknown, search = ""): Promise<Response> {
+  const req = new Request(`http://t/api/query/${resource}${search}`, {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "content-type": "application/json" },
+  });
+  return POST(req, { params: Promise.resolve({ resource }) });
+}
+
+describe("POST /api/query/[resource]", () => {
+  it("returns { data: { items, total } } for the sample resource", async () => {
+    const res = await post("sample", { params: {} });
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { data: { items: unknown[]; total: number } };
+    expect(Array.isArray(json.data.items)).toBe(true);
+    expect(json.data.total).toBeGreaterThan(0);
+  });
+
+  it("404 for unknown resource", async () => {
+    const res = await post("nope", { params: {} });
+    expect(res.status).toBe(404);
+  });
+
+  it("?error=500 → 500", async () => {
+    const res = await post("sample", { params: {} }, "?error=500");
+    expect(res.status).toBe(500);
+  });
+
+  it("?empty=1 → 0 items", async () => {
+    const res = await post("sample", { params: {} }, "?empty=1");
+    const json = (await res.json()) as { data: { items: unknown[]; total: number } };
+    expect(json.data.items).toHaveLength(0);
+    expect(json.data.total).toBe(0);
+  });
+});
+```
+
+- [ ] **步驟 2:跑測試確認 FAIL**
+
+執行:`pnpm -F web exec vitest run "api/query"`
+預期:FAIL —— `./route` 不存在。
+
+- [ ] **步驟 3:實作 route**
+
+新增 `apps/web/src/app/api/query/[resource]/route.ts`:
+
+```ts
+import { getResource } from "@/lib/query-resources";
+import { runQuery } from "@/lib/fake-query";
+
+// runQuery 拉入 @rfjs/filter-builder + crypto.randomUUID → Node runtime。
+export const runtime = "nodejs";
+
+interface Built { params?: Record<string, string>; filter?: unknown }
+
+export async function POST(req: Request, ctx: { params: Promise<{ resource: string }> }): Promise<Response> {
+  const { resource } = await ctx.params;
+  const url = new URL(req.url);
+  const knob = url.searchParams;
+
+  // 場景旋鈕(spec §5):強制 error / delay / empty 以驅動 UI 狀態。
+  const errorCode = Number(knob.get("error"));
+  if (errorCode >= 400) return Response.json({ error: "forced" }, { status: errorCode });
+  const delay = Number(knob.get("delay"));
+  if (delay > 0) await new Promise((r) => setTimeout(r, delay));
+
+  const found = getResource(resource);
+  if (!found) return Response.json({ error: `unknown resource ${resource}` }, { status: 404 });
+
+  const body = (await req.json().catch(() => ({}))) as Built;
+  const built = { params: body.params ?? {}, filter: body.filter };
+  const rows = knob.get("empty") ? [] : found.rows;
+
+  const { items, total, nextCursor } = runQuery(rows, found.columns, found.fields, built);
+  const data: Record<string, unknown> = { items, total };
+  if (nextCursor !== undefined) data.nextCursor = nextCursor;
+  return Response.json({ data });
+}
+```
+
+- [ ] **步驟 4:跑測試確認 PASS**
+
+執行:`pnpm -F web exec vitest run "api/query"`
+預期:PASS(4 個 case)。
+
+執行:`pnpm -F web check-types`
+預期:無錯誤。
+
+- [ ] **步驟 5:Commit**
+
+```bash
+git add "apps/web/src/app/api/query/[resource]/route.ts" "apps/web/src/app/api/query/[resource]/route.spec.ts"
+git commit -m "$(cat <<'EOF'
+feat(web): add fake /api/query/[resource] route with scenario knobs
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4 · HTTP transport
+
+**檔案:**
+- 新增:`apps/web/src/tools/table-builder/http-fetcher.ts`
+- 測試:`apps/web/src/tools/table-builder/http-fetcher.spec.ts`
+
+**介面:**
+- 產出:`makeHttpFetcher(endpoint: string): (built: BuiltRequest) => Promise<unknown>`。
+
+- [ ] **步驟 1:寫失敗測試**
+
+新增 `apps/web/src/tools/table-builder/http-fetcher.spec.ts`:
+
+```ts
+import { describe, it, expect, vi } from "vitest";
+import { makeHttpFetcher } from "./http-fetcher";
+
+describe("makeHttpFetcher", () => {
+  it("POSTs the built request as JSON and returns parsed json", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({ data: { items: [], total: 0 } }) });
+    vi.stubGlobal("fetch", fetchMock);
+    const fetcher = makeHttpFetcher("/api/query/sample");
+    const built = { endpoint: "/api/query/sample", method: "POST", params: { page: "1" }, filter: undefined };
+    const out = await fetcher(built as never);
+    expect(fetchMock).toHaveBeenCalledWith("/api/query/sample", expect.objectContaining({ method: "POST" }));
+    const sentBody = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(sentBody.params).toEqual({ page: "1" });
+    expect(out).toEqual({ data: { items: [], total: 0 } });
+    vi.unstubAllGlobals();
+  });
+
+  it("throws on a non-ok response", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 500 }));
+    const fetcher = makeHttpFetcher("/api/query/sample");
+    await expect(fetcher({ params: {} } as never)).rejects.toThrow();
+    vi.unstubAllGlobals();
+  });
+});
+```
+
+- [ ] **步驟 2:跑測試確認 FAIL**
+
+執行:`pnpm -F web exec vitest run http-fetcher`
+預期:FAIL —— 模組不存在。
+
+- [ ] **步驟 3:實作**
+
+新增 `apps/web/src/tools/table-builder/http-fetcher.ts`:
+
+```ts
+import type { BuiltRequest } from "@rfjs/data-schema";
+
+/**
+ * 給 remote `TableSource.fetch` 用的 app 級最小 HTTP transport:把工具的 `BuiltRequest`
+ * POST 到 `endpoint`、回傳解析後的 JSON。刻意是薄、可替換的 adapter —— package 級的
+ * http-fetcher(#14)可取代它;兩者共用同一 `(built)=>Promise<unknown>` 簽名與
+ * BuiltRequest/`{data}` 契約。
+ */
+export function makeHttpFetcher(endpoint: string): (built: BuiltRequest) => Promise<unknown> {
+  return async (built: BuiltRequest): Promise<unknown> => {
+    const res = await fetch(endpoint, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(built),
+    });
+    if (!res.ok) throw new Error(`query failed: ${res.status}`);
+    return res.json();
+  };
+}
+```
+
+- [ ] **步驟 4:跑測試確認 PASS**
+
+執行:`pnpm -F web exec vitest run http-fetcher`
+預期:PASS。
+
+- [ ] **步驟 5:Commit**
+
+```bash
+git add apps/web/src/tools/table-builder/http-fetcher.ts apps/web/src/tools/table-builder/http-fetcher.spec.ts
+git commit -m "$(cat <<'EOF'
+feat(web): add app-level HTTP fetcher transport for table-builder remote source
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5 · 把 transport 切換接進 table-builder
+
+**檔案:**
+- 修改:`apps/web/src/tools/table-builder/ui.tsx`
+- 修改:`apps/web/src/tools/table-builder/source-panel.tsx`
+- 測試:`apps/web/src/tools/table-builder/source-panel.spec.tsx`(沒有就新建,有就擴充)
+
+**介面:**
+- 消費:`makeHttpFetcher`(任務 4)。endpoint = `/api/query/sample`。
+- 產出:一個 `transport: "memory" | "http"` 控制,只在 remote 來源時顯示;當 `http` 時,remote source 的 `fetch` = `makeHttpFetcher("/api/query/sample")`。
+
+- [ ] **步驟 1:寫失敗測試**
+
+既有的 `apps/web/src/tools/table-builder/source-panel.spec.tsx` 開頭已 import 了 `describe/expect/it/vi`(vitest)、`render/screen/fireEvent`(@testing-library/react)、`SourcePanel`——**不要重複 import,也不要加 `import * as React`(automatic JSX runtime 不需要,會觸發 lint)**。只在檔尾**追加**這個新 `describe` 區塊:
+
+```tsx
+const baseLabels = {} as never; // labels 有預設值;見 SourcePanel props
+
+describe("SourcePanel transport toggle", () => {
+  it("shows a transport toggle only when remote, and reports changes", () => {
+    const onTransportChange = vi.fn();
+    const { rerender } = render(
+      <SourcePanel mode="rows" onModeChange={() => {}} labels={baseLabels} transport="memory" onTransportChange={onTransportChange} />,
+    );
+    expect(screen.queryByRole("button", { name: /http/i })).toBeNull();
+    rerender(
+      <SourcePanel mode="offset" onModeChange={() => {}} labels={baseLabels} transport="memory" onTransportChange={onTransportChange} />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /http/i }));
+    expect(onTransportChange).toHaveBeenCalledWith("http");
+  });
+});
+```
+
+- [ ] **步驟 2:跑測試確認 FAIL**
+
+執行:`pnpm -F web exec vitest run source-panel`
+預期:FAIL —— `transport`/`onTransportChange` props 與 HTTP 切換鈕尚不存在。
+
+- [ ] **步驟 3:在 `source-panel.tsx` 加切換**
+
+在 `SourcePanelProps` 加:
+
+```ts
+  transport?: "memory" | "http";
+  onTransportChange?: (t: "memory" | "http") => void;
+```
+
+更新 `SourcePanel` 簽名解構它們,並在 `isRemote` 分支(策略列附近)用 `segmentClass` 渲染切換:
+
+```tsx
+{isRemote && onTransportChange && (
+  <div className="flex items-center gap-2">
+    <span className="text-xs text-muted-foreground">Transport</span>
+    <button type="button" className={segmentClass(transport === "memory")} onClick={() => onTransportChange("memory")}>in-memory</button>
+    <button type="button" className={segmentClass(transport === "http")} onClick={() => onTransportChange("http")}>HTTP</button>
+  </div>
+)}
+```
+
+- [ ] **步驟 4:接 `ui.tsx`**
+
+在既有 `sourceMode` 狀態附近(`ui.tsx:55`)加 import + 狀態:
+
+```tsx
+import { makeHttpFetcher } from "./http-fetcher";
+// ...
+const [transport, setTransport] = React.useState<"memory" | "http">("memory");
+```
+
+在 `source` useMemo(`ui.tsx:170-181`)依 transport 選 fetch,並把 `transport` 加進 deps:
+
+```tsx
+  const source: TableSource = React.useMemo(() => {
+    if (sourceMode === "rows") return { kind: "rows", rows };
+    const request: RequestMeta = { ...SAMPLE_META.request!, pagination: samplePaginationMeta(sourceMode) };
+    return {
+      kind: "remote",
+      request,
+      response: SAMPLE_META.response!,
+      fields: SAMPLE_META.fields,
+      fetch: transport === "http" ? makeHttpFetcher("/api/query/sample") : makeFakeFetcher(SAMPLE_ROWS, config.columns, SAMPLE_META.fields),
+    };
+  }, [sourceMode, transport, config.columns, rows]);
+```
+
+在渲染 `<SourcePanel>` 的地方(`ui.tsx` 約 317 行,`onModeChange={setSourceMode}` 旁)傳新 props:
+
+```tsx
+          transport={transport}
+          onTransportChange={setTransport}
+```
+
+- [ ] **步驟 5:跑測試確認 PASS**
+
+執行:`pnpm -F web exec vitest run source-panel table-builder`
+預期:PASS。
+
+執行:`pnpm -F web check-types`
+預期:無錯誤。
+
+- [ ] **步驟 6:Commit**
+
+```bash
+git add apps/web/src/tools/table-builder/ui.tsx apps/web/src/tools/table-builder/source-panel.tsx apps/web/src/tools/table-builder/source-panel.spec.tsx
+git commit -m "$(cat <<'EOF'
+feat(web): add in-memory/HTTP transport toggle to table-builder remote source
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6 · 全量驗證 + 截圖
+
+**檔案:** 無(只驗證)。
+
+- [ ] **步驟 1:全量 affected 驗證**
+
+執行:`pnpm -F web exec vitest run fake-query query-resources http-fetcher source-panel table-builder "api/query"`
+預期:全 PASS。
+
+執行:`pnpm -F web check-types`
+預期:無錯誤(若有 PRE-EXISTING 無關錯誤,記錄但不修)。
+
+執行:`pnpm -F web lint`
+預期:無錯誤。
+
+- [ ] **步驟 2:截圖真實 HTTP 往返(verify skill)**
+
+從 worktree 起 dev server 在**非 3000** 埠(3000 常被別的 session 佔):
+`pnpm --dir "<worktree>/apps/web" exec next dev --port 3120`
+用 playwright 驅動(bundled chromium `~/.cache/ms-playwright/chromium-1228/chrome-linux64/chrome`,同 #243 那次):
+1. 開 `/en/tools/table-builder`,把 Source 從 "rows" 切開(→ offset),Transport 設 HTTP。
+2. 打開 filter、加條件、Apply → 確認表格從一發真 network POST `/api/query/sample` 更新(看 Network 分頁 / rows 有被篩)。
+3. 截:happy(篩後 rows)。loading / error / 空 可用旋鈕 URL(`?delay=1500` / `?error=500` / `?empty=1`)驅動;若 UI 驅動旋鈕不便,happy path 截 UI,loading/error/空 由已寫的 route.spec 斷言涵蓋。
+
+截圖存 session scratchpad;回報路徑。
+
+- [ ] **步驟 3:HOLD** —— 不 push、不開 PR。回報分支狀態 + 截圖;等放行。
+
+---
+
+## 自我檢查
+
+**Spec 覆蓋:**
+- §3 契約(BuiltRequest + `{data}`)→ 任務 1/3/4。✅
+- §4 共享引擎 → 任務 1。✅
+- §5 route + 旋鈕 + registry → 任務 2/3。✅
+- §6 客端接線 → 任務 4/5。✅
+- §8 測試:純引擎(T1)、registry(T2)、route 含旋鈕(T3)、transport(T4)、切換(T5)。✅
+- §9 截圖 → 任務 6。✅
+- §10 無 changeset → 遵守(只動 apps/web)。✅
+- §2/§7 紅線(不改 `packages/*`)、transport 留 app 級 → 各任務遵守。✅
+
+**Placeholder 掃描:** 無 TBD/TODO;每個 code 步驟都給 code。✅
+
+**型別一致:** `runQuery(rows, columns, fields, {params, filter})` 在 T1 定義、T3 route、T1 fake-fetcher 一致。`makeHttpFetcher(endpoint): (built)=>Promise<unknown>` 在 T4 定義 + T5 使用一致。route `POST(req, { params: Promise<{resource}> })` 對上 T3 測試的 `Promise.resolve(...)` 與 Next 16 async params。回應 `{data:{items,total,nextCursor?}}` 在 T1 fake-fetcher、T3 route、T4 測試一致。✅
+
+**已知注意:** Next 16 App Router 的 `params` 是 Promise —— route `await ctx.params`、測試傳 `Promise.resolve({resource})`;若安裝的 Next 型別預期同步 params 物件,handler 與測試要一起改。

--- a/docs/superpowers/specs/2026-07-11-filter-api-dogfood-design.md
+++ b/docs/superpowers/specs/2026-07-11-filter-api-dogfood-design.md
@@ -1,0 +1,138 @@
+# filter → API dogfood(Next.js 假 route + 共享契約 + 場景旋鈕 + 最小接線)— 設計 spec
+
+- 日期:2026-07-11
+- 分支 / worktree:`feat-filter-api-dogfood` @ `.claude/worktrees/feat-filter-api-dogfood`(off main `d776c79`)
+- 背景 memory:`rfjs-table-builder-line`(#240 remote filter contract + apply-driven ConfigTable;fetch seam 目前是 in-process 函式,非 Next route)、`rfjs-form-tool-consolidation`(dogfood = 唯一缺 transport)
+- 狀態:設計已與使用者逐叉路確認,待 spec review → plan
+
+---
+
+## 1. 背景與目標
+
+table-builder-ui 的 remote filter 管線(#240)已建好且測過:`applyFilter → treeToPgFilterGroup → buildRequestParams → source.fetch(built)`。**唯一是假的是 `source.fetch` 本身**——目前只有 in-process `makeFakeFetcher`(一個 JS 函式,沒有網路)。`apps/web/src/app/api/` 底下**沒有任何 filter-query route**。
+
+**目標**:補上那根 transport,讓 table 的 filter 走**真 HTTP 往返**——不必起 Postgres / apps-api:
+
+- **假 route**:一個 Next.js route,收工具送出的請求、伺服端執行 filter、回結構化 rows。
+- **場景旋鈕**:能故意觸發 loading / error / 空 三種 UI 態。
+- **最小客端接線**:把 table-builder 工具的 remote 來源接到 route,瀏覽器 UI 當場端到端點亮。
+- **共享契約**:request/response 型別,route 與(未來)transport 共用。
+
+**成功判準**:table-builder 切到「remote (HTTP)」來源 → 打 filter → Apply → 一發真 HTTP POST 到 `/api/query/customers` → 伺服端篩 → 表格渲染篩後 rows;旋鈕能演示 loading/error/空。
+
+---
+
+## 2. 非目標(out of scope)
+
+- **不接真 apps/api / Postgres**(見 §7 的誠實修正:apps/api 是不同契約,需 adapter,屬 #13/workbench 那條線)。
+- **不改 `packages/*`**——contract、route、transport、wiring 全在 `apps/web`;filter 執行**消費**既有 `@rfjs/filter-builder` / `@rfjs/pg-filter` / `@rfjs/table-builder-ui`。
+- 不做 cursor 策略的旋鈕演示(pagination 先只 offset/page;route 仍原生支援 cursor 因邏輯複用 fake-fetcher)。
+- 不碰 #14 的 package 級 http-fetcher(見 §7 協調)。
+- 不做 form-builder 端接線(這輪接 table-builder)。
+
+---
+
+## 3. 契約(誠實修正:採「工具原生慣例」,非 apps/api 結構化 body)
+
+> **修正說明**:brainstorm 早期口頭說「body 鏡像 apps/api、零改動對換」。讀 code 後修正:工具 remote 端天生產出的是 `BuiltRequest`(params 為字串化分頁/排序 + 不透明 filter),response 慣例是 `{ data: { items, total, nextCursor? } }`(見 `fake-fetcher.ts:12-13`、`SAMPLE_META.response`)。apps/api 收的是結構化 `{ filter, sort: SortSpec[], page, pageSize }` 且回 `{ items, total, page, pageSize }`——**兩種慣例不同(尤其 sort)**。最小且最真的 dogfood 是讓 route 講**工具原生慣例**、複用現有 fake-fetcher 邏輯;當 apps/api 的替身需一層 adapter,留給 #13。
+
+**Request(POST body)** = 工具送出的 `BuiltRequest`(`@rfjs/data-schema`):
+```ts
+type BuiltRequest = { endpoint: string; method: string; params: Record<string,string>; filter?: PgFilterGroup }
+```
+transport 直接把 `built` JSON 化當 body POST 出去(resource 由 URL path 帶,不進 body)。
+
+**Response** = `{ data: { items: Record<string,unknown>[]; total: number; nextCursor?: string } }`(對齊 `SAMPLE_META.response` 的 rowsPath `data.items` / totalPath `data.total`)。
+
+**共享契約型別**放 `apps/web/src/lib/query-contract.ts`(引用 `@rfjs/data-schema` 的 `BuiltRequest`、`@rfjs/pg-filter` 的 `PgFilterGroup`),route 與 transport 共用。
+
+---
+
+## 4. 伺服端查詢引擎(DRY:抽出 fake-fetcher 的純邏輯)
+
+`fake-fetcher.ts` 現有的純函式(`applyPgFilter` reverse+`runLiveMatch`、`parseSort`、`paginate`、`sortRows`)正是 route 要的伺服端執行。**抽成共享純模組** `apps/web/src/lib/fake-query.ts`:
+
+```ts
+// 純、無網路、無 React;in-process fake-fetcher 與 HTTP route 都消費它
+export function runQuery(
+  rows: Record<string, unknown>[],
+  columns: TableColumnConfig[],
+  fields: DataFieldMeta[],
+  built: { params: Record<string,string>; filter?: unknown },
+): { items: Record<string,unknown>[]; total: number; nextCursor?: string }
+```
+- 內部 = 現有 `applyPgFilter`(pg group → `pgGroupToFilterGroup` → `filterGroupToTree` → `runLiveMatch`)+ `parseSort` + `sortRows` + `paginate`,原封不動搬過來。
+- `makeFakeFetcher` 改成薄殼:`runQuery(...)` 再包 `{ data }` + delay(行為不變,既有 table-builder 測試應續綠)。
+
+---
+
+## 5. Next.js 假 route
+
+`apps/web/src/app/api/query/[resource]/route.ts`(POST):
+
+```
+1. 解析 resource(path)+ 讀 URL searchParams 的旋鈕(delay/error/empty)
+2. 旋鈕:error → 回對應 HTTP 錯誤碼;delay → await 指定 ms;empty → rows 視為 []
+3. body = BuiltRequest(zod 驗:params 物件、filter 選填)
+4. resource registry 查 { rows, columns, fields };未知 → 404
+5. result = runQuery(rows, columns, fields, built)   // §4 共享引擎
+6. 回 { data: result }
+```
+
+**場景旋鈕(query params)**:
+- `?delay=<ms>` → 伺服端延遲(看 loading)。
+- `?error=<code>` → 回 4xx/5xx(看 error 態)。
+- `?empty=1` → 回 0 筆(看空態)。
+
+**資源 registry**(`apps/web/src/lib/query-resources.ts`):至少 `customers`——`~50` 列、混 column 與 jsonb-ish 欄位(id/name/email/amount/status + 一個巢狀 profile),欄位帶 `filterable`+`kind`,供 filter 演示。可複用 / 擴充 table-builder 現有 `SAMPLE_ROWS`/`SAMPLE_META`。
+
+---
+
+## 6. 最小客端接線(table-builder)
+
+`apps/web/src/tools/table-builder/`:
+- 新增 `http-fetcher.ts`:`makeHttpFetcher(endpoint): (built) => Promise<unknown>` = `fetch(endpoint, { method:'POST', headers, body: JSON.stringify(built) }).then(r => { if(!r.ok) throw ...; return r.json() })`。
+- `ui.tsx:170-181` 的 `source` useMemo:`sourceMode` 增加一個 `"remote-http"`(或把既有 remote 分支的 `fetch` 依 toggle 換成 `makeHttpFetcher("/api/query/customers")`),**保留** in-process fake 分支不動。UI 加一個來源切換(rows / remote (in-memory) / remote (HTTP))。
+
+> 只動 apps/web tool 檔;消費 `@rfjs/table-builder-ui` 既有 `kind:'remote'` 支援,**不改 package**。
+
+---
+
+## 7. 紅線 / 與 #14、apps/api 的關係
+
+- **紅線**:不改 `packages/*`。全部在 `apps/web`(app route + lib + tool)。
+- **與 #14(http-fetcher,目前無 PR)**:我的 `makeHttpFetcher` 是 **app 級、最小、可升級**的 transport。若 #14 之後落地 package 級版本,把工具的 `fetch` 換成它即可;兩者共用同一 fetch 簽名(`(built)=>Promise<unknown>`)與契約,收斂點在契約。這輪**不進 package**,避免撞 #14/#245 地盤。
+- **與 apps/api**:apps/api `/datasets/query` 是**不同契約**(結構化 body + `{items,total,page,pageSize}` 回應)。要當它的真替身需 request/response adapter(BuiltRequest ↔ QueryDatasetsBody;params↔structured sort)——**屬 #13/workbench 那條線,非本輪**。本輪只證明「工具 remote 管線 → 真 HTTP → 伺服端篩 → rows 回表格」。
+
+---
+
+## 8. 測試策略
+
+- **`fake-query.spec.ts`(純)**:給 rows + PgFilterGroup(column & jsonb 葉)+ sort + offset/page params → 斷言篩/排/分頁正確;空 filter → 全量;uncoverable → 全量不誤 0。
+- **route 整合測試**:對 route handler 打 `BuiltRequest`(直接呼叫 handler 或 `fetch` 測試伺服器)→ 斷言 `{data:{items,total}}`;未知 resource 404;`?error=500` → 500;`?empty=1` → 0 筆。
+- **`http-fetcher.spec.ts`**:mock `fetch`,斷言 POST body = JSON 化 built、非 2xx → throw。
+- **table-builder 既有測試**:`makeFakeFetcher` 重構後行為不變,續綠。
+- **UI e2e / 截圖**:table-builder 切 remote(HTTP)→ filter → Apply → 表格更新;旋鈕演示 loading/error/空(見 §9)。
+
+---
+
+## 9. 驗證 / 截圖
+
+worktree 起 dev(非 3000 埠),playwright(bundled chromium)驅動 table-builder:切「remote (HTTP)」來源、開 filter、Apply → 截 happy(篩後 rows);再以旋鈕 URL 截 loading / error / 空。手法沿用 #243 那次(bundled chromium executablePath + 自寫腳本)。
+
+---
+
+## 10. Changeset
+
+- 全部在 `apps/web` → **無 changeset**(app 不記版本,依 changeset policy)。
+
+commits 英文 conventional + `Co-Authored-By` trailer;spec/plan 繁中。
+
+---
+
+## 11. 風險與待決
+
+1. **與 #14 收斂**:app 級 transport 是刻意的過渡;#14 落地後升級(§7)。若使用者希望這輪就做成 package 級,需重新界定紅線。
+2. **契約非 apps/api 對齊**(§3/§7 誠實修正):本輪證明工具↔假 route;apps/api 對接是 #13 的 adapter。若使用者要這輪就對齊 apps/api,範圍加大(要解 params↔structured sort 映射)。
+3. **route 執行環境**:`runQuery` 依賴 `@rfjs/filter-builder`/`data-filter`(純 JS)+ `crypto.randomUUID`——Next route 的 Node runtime 可用;必要時 `export const runtime = 'nodejs'`。
+4. **來源切換 UX**:table-builder 多一個來源模式,注意別破壞既有 rows/remote 切換與 e2e。


### PR DESCRIPTION
## Summary

Lights up a real **filter → HTTP → rows** round-trip for the `table-builder` tool via a self-contained Next.js fake route — no Postgres, no `apps/api` required. This closes the last gap in the table-builder-ui remote-filter pipeline (which was fully built and tested except the transport).

- **Fake backend:** `POST /api/query/[resource]` reuses the tool's existing in-memory query engine to filter/sort/paginate server-side, with scenario knobs (`?delay/?error/?empty`) for driving loading/error/empty states.
- **Transport:** an app-level `makeHttpFetcher` that POSTs the tool's `BuiltRequest` to the route.
- **Wiring:** a table-builder Data-source **Transport** toggle (in-memory / HTTP), shown only when the source is remote.

The contract is the **tool-native** convention (`BuiltRequest` request + `{ data: { items, total, nextCursor? } }` response), not apps/api's structured body — so this dogfoods the `filter-builder → table-builder → ConfigTable-remote` stack end to end without an adapter.

## Changes (all in `apps/web`)

| Layer | Change |
|---|---|
| `lib/fake-query.ts` (new) | Extracted the shared `runQuery(rows, columns, fields, built)` engine from `fake-fetcher.ts` (verbatim move; behaviour unchanged) |
| `tools/table-builder/fake-fetcher.ts` | Now a thin wrapper over `runQuery` |
| `lib/query-resources.ts` (new) | Resource registry (`sample` reuses the tool's existing sample data) |
| `app/api/query/[resource]/route.ts` (new) | POST route + scenario knobs, `runtime: 'nodejs'` |
| `tools/table-builder/http-fetcher.ts` (new) | App-level `makeHttpFetcher(endpoint)` |
| `tools/table-builder/{ui,source-panel}.tsx` | in-memory ↔ HTTP transport toggle |

## Constraints held

- **Red line:** `packages/*` unchanged — consumed only.
- Transport stays **app-level** (a future package-level `#14` http-fetcher can supersede it; both share the same `(built) => Promise<unknown>` signature).
- No changeset (apps-only). No `@dnd-kit`. No visual per-column editor.

## Testing

- 6 TDD tasks (subagent-driven); each passed spec + quality review.
- **71 tests pass** (fake-query, query-resources, http-fetcher, source-panel, table-builder, api/query route); `web` check-types + lint clean.
- Plan adversarially verified before execution; final whole-branch review (Opus): **no Critical/Important**, ready to merge.
- **Screenshot-verified end to end:** switching Transport = HTTP issues a real `POST /api/query/sample` (confirmed via network) and the ConfigTable renders the returned rows.

## Known (dev-only, non-blocking)

- `?error=<code>` with a value > 599 throws a `RangeError` (surfaces as 500); only `?error=500` is used.
- The route sorts using the registry's fixed columns, while the in-tool fetcher uses the live-edited columns — by design (the HTTP resource is a fixed server-side dataset).

## Follow-ups (out of scope)

- Swapping the app-level transport for the package-level `#14` http-fetcher.
- Pointing at the real `apps/api /datasets/query` needs a request/response adapter (`#13` / workbench line), since apps/api uses a structured body.

## Docs

Spec + plan under `docs/superpowers/{specs,plans}/2026-07-11-filter-api-dogfood*` (zh-TW).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
