### PR TITLE
fix(web): skip stale mount run in ToolIntro/metadata-builder localStorage persist

### DIFF
--- a/.changeset/web-restore-persist-clobber.md
+++ b/.changeset/web-restore-persist-clobber.md
@@ -1,0 +1,5 @@
+---
+"web": patch
+---
+
+Fix the restore-before-persist localStorage race in ToolIntro and metadata-builder: the persist effect's mount run fired with pre-restore defaults, transiently clobbering the stored value before the restore state landed. The persist effect now skips exactly its first run.

--- a/apps/web/src/components/shared/tool-intro.spec.tsx
+++ b/apps/web/src/components/shared/tool-intro.spec.tsx
@@ -1,5 +1,5 @@
 import { render, screen, fireEvent } from "@testing-library/react";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ToolIntro } from "./tool-intro";
 
@@ -69,6 +69,21 @@ describe("ToolIntro", () => {
     renderIntro();
     expect(screen.getByText("How does this tool work?")).toBeTruthy();
     expect(screen.queryByText("A DataResourceMeta.")).toBeNull();
+  });
+
+  it("mount never writes pre-restore defaults over stored state (no transient clobber)", () => {
+    localStorage.setItem("tool-intro:test", JSON.stringify({ open: false, dismissed: true }));
+    const spy = vi.spyOn(Storage.prototype, "setItem");
+    renderIntro();
+    // the persist effect's mount run used to fire with the pre-restore defaults
+    // ({dismissed:false}) before the restore setState landed — that write must not happen.
+    const clobber = spy.mock.calls.find(
+      ([key, value]) =>
+        key === "tool-intro:test" &&
+        (JSON.parse(value as string) as { dismissed: boolean }).dismissed === false,
+    );
+    expect(clobber).toBeUndefined();
+    spy.mockRestore();
   });
 
   it("persists open state after toggling (restore-before-persist holds)", () => {

--- a/apps/web/src/components/shared/tool-intro.tsx
+++ b/apps/web/src/components/shared/tool-intro.tsx
@@ -40,11 +40,10 @@ export function ToolIntro({
 }) {
   const [open, setOpen] = React.useState(false);
   const [dismissed, setDismissed] = React.useState(false);
-  const restoredRef = React.useRef(false);
+  const skipFirstPersistRef = React.useRef(true);
 
-  // Restore-before-persist (metadata-builder's established localStorage pattern): read once on
-  // mount, and never write until the read happened -- otherwise the first render's defaults
-  // would clobber the stored state.
+  // Restore-before-persist: read once on mount; the persist effect below skips its own mount
+  // run, which is the only run that can still see the pre-restore defaults.
   React.useEffect(() => {
     try {
       const raw = localStorage.getItem(storageKey);
@@ -56,11 +55,17 @@ export function ToolIntro({
     } catch {
       // corrupted storage -> defaults
     }
-    restoredRef.current = true;
   }, [storageKey]);
 
   React.useEffect(() => {
-    if (!restoredRef.current) return;
+    // The mount run always carries the pre-restore defaults (the restore effect's setState has
+    // not been applied yet), so writing here would clobber the stored value for one tick — skip
+    // exactly that first run. The restore's setState (or the first user action) triggers the
+    // next run with correct values.
+    if (skipFirstPersistRef.current) {
+      skipFirstPersistRef.current = false;
+      return;
+    }
     try {
       localStorage.setItem(storageKey, JSON.stringify({ open, dismissed }));
     } catch {

--- a/apps/web/src/tools/metadata-builder/ui.spec.tsx
+++ b/apps/web/src/tools/metadata-builder/ui.spec.tsx
@@ -112,6 +112,24 @@ describe("MetadataBuilderTool", () => {
     renderTool();
     expect(screen.getByTestId("meta-json").textContent).toContain('"price"');
   });
+
+  it("mount never writes the default sample over a stored meta (no transient clobber)", () => {
+    localStorage.setItem(
+      "rfjs.metadata-builder.meta",
+      JSON.stringify({ fields: [{ key: "customField", label: "Custom", dataType: "string" }] }),
+    );
+    const spy = vi.spyOn(Storage.prototype, "setItem");
+    renderTool();
+    // the persist effect's mount run used to fire with the pre-restore DEFAULT_META
+    // before the restore setMeta landed — that write must not happen.
+    const clobber = spy.mock.calls.find(([key, value]) => {
+      if (key !== "rfjs.metadata-builder.meta") return false;
+      const parsed = JSON.parse(value as string) as { fields: { key: string }[] };
+      return parsed.fields[0]?.key !== "customField";
+    });
+    expect(clobber).toBeUndefined();
+    spy.mockRestore();
+  });
 });
 
 describe("studio layout", () => {

--- a/apps/web/src/tools/metadata-builder/ui.tsx
+++ b/apps/web/src/tools/metadata-builder/ui.tsx
@@ -40,7 +40,7 @@ export function MetadataBuilderTool() {
   const [codeTab, setCodeTab] = React.useState<CodePanelTab>("meta");
   const [codeOpen, setCodeOpen] = React.useState(true); // SSR first paint is always open, to avoid a hydration mismatch
 
-  const restoredRef = React.useRef(false);
+  const skipFirstPersistRef = React.useRef(true);
   React.useEffect(() => {
     // 1) restore — must be declared before the persist effect below.
     try {
@@ -61,11 +61,16 @@ export function MetadataBuilderTool() {
       // jsdom has no matchMedia — guard it and treat that as "desktop" so tests see the default-open behavior.
       setCodeOpen(typeof window.matchMedia === "function" ? window.matchMedia("(min-width: 1024px)").matches : true);
     }
-    restoredRef.current = true;
   }, []);
   React.useEffect(() => {
-    // 2) persist — skip every run until the restore effect above has completed.
-    if (!restoredRef.current) return;
+    // 2) persist — the mount run always carries the pre-restore DEFAULT_META (the restore
+    //    effect's setMeta has not been applied yet), so writing here would clobber the stored
+    //    meta for one tick; skip exactly that first run. The restore's setMeta (or the first
+    //    user edit) triggers the next run with the correct value.
+    if (skipFirstPersistRef.current) {
+      skipFirstPersistRef.current = false;
+      return;
+    }
     localStorage.setItem(STORAGE_KEY, JSON.stringify(meta));
   }, [meta]);
 


### PR DESCRIPTION
## Summary

Fixes the restore-before-persist localStorage race carried out of PR #251's final review, at both sites that share the pattern.

**Bug:** the persist `useEffect`'s **mount run** fired with the pre-restore default state (the restore effect's `setState` had not been applied yet), transiently writing the defaults over the stored value for one tick before self-healing. The old guard (`restoredRef` flipped inside the sibling restore effect) did not prevent this — the ref reads `true` on the mount persist run while the render-scoped state is still the default.

**Fix:** the persist effect now **skips exactly its own first run** (`skipFirstPersistRef`). The restore's `setState` (or the first user action) triggers the next run with the correct values.

- `apps/web/src/components/shared/tool-intro.tsx` — ToolIntro (open/dismissed).
- `apps/web/src/tools/metadata-builder/ui.tsx` — metadata-builder (meta), where the pattern originated.

Side benefit: a first-time visit no longer writes the defaults to storage on mount — it only persists on a real change.

## Testing

- TDD: one new test per site (`vi.spyOn(Storage.prototype, "setItem")` asserting no pre-restore write survives mount) — RED before the fix, GREEN after; the existing persist/restore tests (remount restore, toggle persistence, corrupted-storage fallback) all still pass.
- web: 79 files / 425 tests, check-types, lint — all green.

## Changeset

`web` patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)