### PR TITLE
feat(sql-filter): column-path operator parity with jsonb (ILIKE fix + endswith/terms/range/iX)

### DIFF
--- a/.changeset/filter-builder-sql-ops.md
+++ b/.changeset/filter-builder-sql-ops.md
@@ -1,0 +1,5 @@
+---
+"@rfjs/filter-builder": minor
+---
+The sql-filter engine adapter now offers the new column operators
+(endswith/terms/iX for text, terms/range for numeric/date) in the editor.

--- a/.changeset/pg-filter-column-ops.md
+++ b/.changeset/pg-filter-column-ops.md
@@ -1,0 +1,5 @@
+---
+"@rfjs/pg-filter": patch
+---
+Column-target leaves transitively gain the new sql-filter operators
+(endswith/terms/range/iX); no API change.

--- a/.changeset/sql-filter-operators.md
+++ b/.changeset/sql-filter-operators.md
@@ -1,0 +1,7 @@
+---
+"@rfjs/sql-filter": minor
+---
+Column path: fix the LIKE wildcard bug (escape `%`/`_`/`\` + `ESCAPE` clause) and
+make `contains`/`startswith` case-sensitive; add `endswith`, `terms` (`= ANY`),
+`range` (`BETWEEN`) and the case-insensitive `iX` family (`ieq`/`ineq`/`icontains`/
+`istartswith`/`iendswith`), with per-type allow-lists.

--- a/docs/superpowers/plans/2026-07-15-sql-filter-operators.md
+++ b/docs/superpowers/plans/2026-07-15-sql-filter-operators.md
@@ -15,6 +15,7 @@
 - **D2 (locked):** per-type additions — `text`: `endswith, terms, ieq, ineq, icontains, istartswith, iendswith` (NO `range`); `numeric`+`timestamp`: `terms, range`; `uuid`: `terms`; `boolean`: none.
 - **LIKE escaping:** literal terms in `LIKE`/`ILIKE` must be escaped and use an `ESCAPE '\'` clause. In JS source the SQL backslash is written `\\` (so the emitted SQL text reads `escape '\'`), and `escapeLike` prefixes `\`, `%`, `_` with a backslash.
 - `terms` value = non-empty array; `range` value = 2-element array; else throw `ColumnQueryError(..., 'INVALID_VALUE')`.
+- **Typecheck command is `typecheck`** (`tsc --noEmit`) for these packages — NOT `check-types` (that's an apps/web script). And package typecheck resolves `@rfjs/*` deps from their built `dist`, so a fresh worktree must `pnpm build:packages` once (orchestrator does this before Task 3) or `filter-builder`/`pg-filter` typecheck fails `TS2307`.
 - TDD: write/adjust the failing test first, then implement. Do not weaken existing tests except the D1-mandated `ilike`→`like` updates.
 - Changeset per changed workspace package (see Task 4). Commit messages English, conventional, lowercase-lead subject, trailer `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`. Do NOT push; HOLD PR.
 
@@ -227,7 +228,7 @@ expect(ops).toContain("icontains"); // text columns now offer the ci iX family
 ```
   Optionally add `expect(ops).toContain("endswith"); expect(ops).toContain("terms");`. **Leave the "returns ok:false when a column gets an unsupported operator" test (lines 65-69)** unchanged — it uses `numeric` + `contains`, which is still unsupported (D2: numeric gains only `terms`/`range`, not `contains`).
 
-- [ ] **Step 4: Run tests** — `pnpm -F @rfjs/filter-builder vitest:run` → all PASS; `pnpm -F @rfjs/filter-builder check-types`.
+- [ ] **Step 4: Run tests** — `pnpm -F @rfjs/filter-builder vitest:run` → all PASS; `pnpm -F @rfjs/filter-builder typecheck` (dists already built by the orchestrator).
 
 - [ ] **Step 5: Commit.**
 ```bash
@@ -274,9 +275,9 @@ Column-target leaves transitively gain the new sql-filter operators
 ```
 
 - [ ] **Step 3: Full verify.** Run and confirm green:
-  - `pnpm -F @rfjs/sql-filter vitest:run` + `check-types`
-  - `pnpm -F @rfjs/filter-builder vitest:run` + `check-types`
-  - `pnpm -F @rfjs/pg-filter vitest:run` (+ `vitest:e2e:run` if present) + `check-types` — **regression check** that mixing column + jsonb leaves still works and the new column ops flow through.
+  - `pnpm -F @rfjs/sql-filter vitest:run` + `typecheck`
+  - `pnpm -F @rfjs/filter-builder vitest:run` + `typecheck`
+  - `pnpm -F @rfjs/pg-filter vitest:run` (+ `vitest:e2e:run` if present) + `typecheck` — **regression check** that mixing column + jsonb leaves still works and the new column ops flow through.
 
 - [ ] **Step 4: Commit.**
 ```bash

--- a/docs/superpowers/plans/2026-07-15-sql-filter-operators.md
+++ b/docs/superpowers/plans/2026-07-15-sql-filter-operators.md
@@ -1,0 +1,263 @@
+# sql-filter Operator Alignment Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Fix the `@rfjs/sql-filter` column-path ILIKE wildcard bug and add the missing column operators (`endswith`, `terms`, `range`, and the case-insensitive `iX` family) so the column path reaches parity with the jsonb path.
+
+**Architecture:** All operator logic lives in `sql-filter`'s column renderer (`src/column/operators.ts`); `filter-builder`'s `sql-filter` engine adapter declares which of those the UI offers; `pg-filter` reuses `ColumnOperator` transitively (no code change). TDD per task.
+
+**Tech Stack:** TypeScript, Vitest (unit only for these packages), PostgreSQL LIKE/ILIKE semantics.
+
+## Global Constraints
+
+- Work ONLY in the worktree `/home/royfw/_/code/royfw/rfjs/.claude/worktrees/feat-sql-filter-operators`. Never touch the primary checkout. Every task first asserts `git branch --show-current` == `feat-sql-filter-operators`.
+- **D1 (locked):** `contains`/`startswith`/`endswith` are **case-SENSITIVE** (`LIKE`); the `iX` family is case-insensitive (`ILIKE`). This changes the pre-existing `contains`/`startswith` behaviour (was `ILIKE`); updating their existing test assertions is expected, not a regression.
+- **D2 (locked):** per-type additions — `text`: `endswith, terms, ieq, ineq, icontains, istartswith, iendswith` (NO `range`); `numeric`+`timestamp`: `terms, range`; `uuid`: `terms`; `boolean`: none.
+- **LIKE escaping:** literal terms in `LIKE`/`ILIKE` must be escaped and use an `ESCAPE '\'` clause. In JS source the SQL backslash is written `\\` (so the emitted SQL text reads `escape '\'`), and `escapeLike` prefixes `\`, `%`, `_` with a backslash.
+- `terms` value = non-empty array; `range` value = 2-element array; else throw `ColumnQueryError(..., 'INVALID_VALUE')`.
+- TDD: write/adjust the failing test first, then implement. Do not weaken existing tests except the D1-mandated `ilike`→`like` updates.
+- Changeset per changed workspace package (see Task 4). Commit messages English, conventional, lowercase-lead subject, trailer `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`. Do NOT push; HOLD PR.
+
+## File map
+
+- `packages/sql-filter/src/column/operators.ts` — `ColumnOperator` union, `ALLOWED`, `escapeLike`, render branches (T1 + T2).
+- `packages/sql-filter/src/column/operators.spec.ts` — update `ilike` cases (T1); add new-op cases (T2).
+- `packages/sql-filter/src/column/build.spec.ts` — update the `ilike` where-clause assertion (T1).
+- `packages/filter-builder/src/engines/sql-filter.ts` — extend `TEXT_OPS`/`NUMERIC_OPS` (T3).
+- `.changeset/*` — sql-filter minor, filter-builder minor, pg-filter patch (T4).
+
+---
+
+### Task 1: ① fix the ILIKE wildcard bug (escape + case-sensitive)
+
+**Files:**
+- Modify: `packages/sql-filter/src/column/operators.ts`
+- Test: `packages/sql-filter/src/column/operators.spec.ts`, `packages/sql-filter/src/column/build.spec.ts`
+
+- [ ] **Step 1: Baseline** — branch check; `pnpm -F @rfjs/sql-filter vitest:run` → all PASS. Note the count.
+
+- [ ] **Step 2: Update the failing tests first (D1 behaviour change).** In `operators.spec.ts` replace the two assertions at lines 24-25:
+```ts
+it('renders text contains/startswith as case-sensitive escaped LIKE', () => {
+  expect(render('text', 'contains', 'ab')).toEqual({ sql: "\"name\" like '%' || $1 || '%' escape '\\'", values: ['ab'] });
+  expect(render('text', 'startswith', 'ab')).toEqual({ sql: "\"name\" like $1 || '%' escape '\\'", values: ['ab'] });
+});
+it('escapes LIKE metacharacters in the term', () => {
+  expect(render('text', 'contains', '50%_a')).toEqual({ sql: "\"name\" like '%' || $1 || '%' escape '\\'", values: ['50\\%\\_a'] });
+});
+```
+  In `build.spec.ts:20` change the expected where to the case-sensitive escaped form:
+```ts
+expect(r.where).toBe('"name" like \'%\' || $1 || \'%\' escape \'\\\' and "created_at" >= $2');
+```
+
+- [ ] **Step 3: Run tests to confirm they fail** — `pnpm -F @rfjs/sql-filter vitest:run src/column/operators.spec.ts` → the updated cases FAIL (still emitting `ilike`, unescaped).
+
+- [ ] **Step 4: Implement.** In `operators.ts`, add the helper (top-level, above `renderColumnCondition`):
+```ts
+// Escape LIKE metacharacters so the bound term matches verbatim (paired with ESCAPE '\').
+function escapeLike(v: string): string {
+  return v.replace(/[\\%_]/g, (ch) => `\\${ch}`);
+}
+```
+  Replace the two branches (`operators.ts:58-63`):
+```ts
+if (operator === 'contains') {
+  return `${quotedColumn} like '%' || ${params.add(escapeLike(String(value)))} || '%' escape '\\'`;
+}
+if (operator === 'startswith') {
+  return `${quotedColumn} like ${params.add(escapeLike(String(value)))} || '%' escape '\\'`;
+}
+```
+
+- [ ] **Step 5: Run tests** — `pnpm -F @rfjs/sql-filter vitest:run` → same count PASS (the two updated files now green).
+
+- [ ] **Step 6: Commit.**
+```bash
+git add packages/sql-filter/src/column
+git commit -m "$(printf 'fix(sql-filter): escape LIKE metachars and make contains/startswith case-sensitive\n\nThe column contains/startswith emitted ILIKE with the term concatenated around\nliteral %% wildcards, never escaping %%/_ in the term (over-match) and using\ncase-insensitive ilike. Add escapeLike + ESCAPE clause and switch to LIKE\n(case-sensitive), aligning with jsonb-query/data-filter; case-insensitive moves\nto the iX operators (Task 2).\n\nCo-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>')"
+```
+
+---
+
+### Task 2: ② add the missing column operators
+
+**Files:**
+- Modify: `packages/sql-filter/src/column/operators.ts`
+- Test: `packages/sql-filter/src/column/operators.spec.ts`
+
+**Interfaces produced:** `ColumnOperator` gains `endswith | terms | range | ieq | ineq | icontains | istartswith | iendswith`.
+
+- [ ] **Step 1: Write failing tests** in `operators.spec.ts`:
+```ts
+it('renders endswith as case-sensitive escaped LIKE', () => {
+  expect(render('text', 'endswith', 'ab')).toEqual({ sql: "\"name\" like '%' || $1 escape '\\'", values: ['ab'] });
+});
+it('renders the case-insensitive iX family', () => {
+  expect(render('text', 'ieq', 'AB')).toEqual({ sql: 'lower("name") = lower($1)', values: ['AB'] });
+  expect(render('text', 'ineq', 'AB')).toEqual({ sql: 'lower("name") <> lower($1)', values: ['AB'] });
+  expect(render('text', 'icontains', 'ab')).toEqual({ sql: "\"name\" ilike '%' || $1 || '%' escape '\\'", values: ['ab'] });
+  expect(render('text', 'istartswith', 'ab')).toEqual({ sql: "\"name\" ilike $1 || '%' escape '\\'", values: ['ab'] });
+  expect(render('text', 'iendswith', 'ab')).toEqual({ sql: "\"name\" ilike '%' || $1 escape '\\'", values: ['ab'] });
+});
+it('renders terms as = ANY(array)', () => {
+  expect(render('uuid', 'terms', ['a', 'b'])).toEqual({ sql: '"name" = any($1)', values: [['a', 'b']] });
+  expect(render('numeric', 'terms', [1, 2])).toEqual({ sql: '"name" = any($1)', values: [[1, 2]] });
+});
+it('renders range as BETWEEN two params', () => {
+  expect(render('numeric', 'range', [1, 9])).toEqual({ sql: '"name" between $1 and $2', values: [1, 9] });
+});
+it('validates terms/range value shape and per-type allow-lists', () => {
+  expect(() => render('numeric', 'terms', 5)).toThrow(ColumnQueryError);      // not an array
+  expect(() => render('numeric', 'terms', [])).toThrow(ColumnQueryError);     // empty
+  expect(() => render('numeric', 'range', [1])).toThrow(ColumnQueryError);    // not 2 elements
+  expect(() => render('boolean', 'terms', [true])).toThrow(ColumnQueryError); // not allowed on boolean
+  expect(() => render('text', 'range', ['a', 'b'])).toThrow(ColumnQueryError);// text has no range (D2)
+});
+```
+
+- [ ] **Step 2: Run → fail** — `pnpm -F @rfjs/sql-filter vitest:run src/column/operators.spec.ts` (new cases fail: operators not in union / not allowed).
+
+- [ ] **Step 3: Extend the union** (`operators.ts:5-15`):
+```ts
+export type ColumnOperator =
+  | 'eq' | 'neq' | 'isnull' | 'isnotnull'
+  | 'contains' | 'startswith' | 'endswith'
+  | 'icontains' | 'istartswith' | 'iendswith' | 'ieq' | 'ineq'
+  | 'terms' | 'range'
+  | 'gt' | 'gte' | 'lt' | 'lte';
+```
+
+- [ ] **Step 4: Extend `ALLOWED`** (per D2):
+```ts
+const ALLOWED: Record<ColumnType, ReadonlySet<ColumnOperator>> = {
+  text: new Set(['eq','neq','isnull','isnotnull','contains','startswith','endswith','icontains','istartswith','iendswith','ieq','ineq','terms','gt','gte','lt','lte']),
+  numeric: new Set(['eq','neq','isnull','isnotnull','gt','gte','lt','lte','terms','range']),
+  timestamp: new Set(['eq','neq','isnull','isnotnull','gt','gte','lt','lte','terms','range']),
+  boolean: new Set(['eq','neq','isnull','isnotnull']),
+  uuid: new Set(['eq','neq','isnull','isnotnull','terms']),
+};
+```
+
+- [ ] **Step 5: Add render branches** in `renderColumnCondition`, placed after the existing `startswith` branch and before the `COMPARATORS` lookup. `terms`/`range` validate their array shape (the generic `value === undefined` guard above already ran; arrays are defined):
+```ts
+if (operator === 'endswith') {
+  return `${quotedColumn} like '%' || ${params.add(escapeLike(String(value)))} escape '\\'`;
+}
+if (operator === 'icontains') {
+  return `${quotedColumn} ilike '%' || ${params.add(escapeLike(String(value)))} || '%' escape '\\'`;
+}
+if (operator === 'istartswith') {
+  return `${quotedColumn} ilike ${params.add(escapeLike(String(value)))} || '%' escape '\\'`;
+}
+if (operator === 'iendswith') {
+  return `${quotedColumn} ilike '%' || ${params.add(escapeLike(String(value)))} escape '\\'`;
+}
+if (operator === 'ieq') {
+  return `lower(${quotedColumn}) = lower(${params.add(value)})`;
+}
+if (operator === 'ineq') {
+  return `lower(${quotedColumn}) <> lower(${params.add(value)})`;
+}
+if (operator === 'terms') {
+  if (!Array.isArray(value) || value.length === 0) {
+    throw new ColumnQueryError(`Operator "terms" requires a non-empty array`, 'INVALID_VALUE');
+  }
+  return `${quotedColumn} = any(${params.add(value)})`;
+}
+if (operator === 'range') {
+  if (!Array.isArray(value) || value.length !== 2) {
+    throw new ColumnQueryError(`Operator "range" requires a [lo, hi] array`, 'INVALID_VALUE');
+  }
+  return `${quotedColumn} between ${params.add(value[0])} and ${params.add(value[1])}`;
+}
+```
+
+- [ ] **Step 6: Run tests** — `pnpm -F @rfjs/sql-filter vitest:run` → all PASS. Also `pnpm -F @rfjs/sql-filter check-types`.
+
+- [ ] **Step 7: Commit.**
+```bash
+git add packages/sql-filter/src/column
+git commit -m "$(printf 'feat(sql-filter): add endswith/terms/range/iX column operators\n\nExtend the column path to reach parity with jsonb: endswith (escaped LIKE),\nterms (= ANY array), range (BETWEEN), and the case-insensitive iX family\n(ieq/ineq via lower(); icontains/istartswith/iendswith via escaped ILIKE),\nwith per-type allow-lists per the design (text: no range; uuid: terms only;\nboolean: none) and terms/range value-shape validation.\n\nCo-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>')"
+```
+
+---
+
+### Task 3: filter-builder sql-filter adapter — offer the new operators
+
+**Files:**
+- Modify: `packages/filter-builder/src/engines/sql-filter.ts`
+- Test: any `packages/filter-builder/src/engines/*.spec.ts` asserting the sql-filter operator list (grep first; update if present).
+
+- [ ] **Step 1: Baseline** — branch check; `pnpm -F @rfjs/filter-builder vitest:run` → all PASS. Note count. `grep -rn "sql-filter\|TEXT_OPS\|columnOps" src/engines/*.spec.ts` to find any operator-list assertions.
+
+- [ ] **Step 2: Extend the op lists** (`sql-filter.ts:16-18`):
+```ts
+const NULL_OPS = ["isnull", "isnotnull"];
+const TEXT_OPS = ["eq", "neq", "contains", "startswith", "endswith", "icontains", "istartswith", "iendswith", "ieq", "ineq", "terms", "gt", "gte", "lt", "lte", ...NULL_OPS];
+const NUMERIC_OPS = ["eq", "neq", "gt", "gte", "lt", "lte", "terms", "range", ...NULL_OPS]; // numeric + date
+const BOOL_OPS = ["eq", "neq", ...NULL_OPS];
+```
+  (`arityOf` already maps `terms`→list, `range`→two; the `iX` ops default to `one` — correct. No change to `arity.ts`.)
+
+- [ ] **Step 3: If Step 1's grep found an operator-list assertion**, update it to include the new ops. If a test drives the editor and asserts a specific operator set for a string/number field, extend it. Do not add new tests beyond keeping existing ones accurate.
+
+- [ ] **Step 4: Run tests** — `pnpm -F @rfjs/filter-builder vitest:run` → all PASS; `pnpm -F @rfjs/filter-builder check-types`.
+
+- [ ] **Step 5: Commit.**
+```bash
+git add packages/filter-builder/src/engines
+git commit -m "$(printf 'feat(filter-builder): offer the new sql-filter column operators in the editor\n\nExtend the sql-filter engine adapter TEXT_OPS/NUMERIC_OPS so the editor offers\nendswith/terms/iX (text) and terms/range (numeric/date), matching sql-filter\n column path parity. arity map already covers terms/range.\n\nCo-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>')"
+```
+
+---
+
+### Task 4: changesets + full verification
+
+**Files:** Create `.changeset/sql-filter-operators.md`, `.changeset/filter-builder-sql-ops.md`, `.changeset/pg-filter-column-ops.md`.
+
+- [ ] **Step 1: Changesets.**
+```markdown
+---
+"@rfjs/sql-filter": minor
+---
+Column path: fix the LIKE wildcard bug (escape `%`/`_`/`\` + `ESCAPE` clause) and
+make `contains`/`startswith` case-sensitive; add `endswith`, `terms` (`= ANY`),
+`range` (`BETWEEN`) and the case-insensitive `iX` family (`ieq`/`ineq`/`icontains`/
+`istartswith`/`iendswith`), with per-type allow-lists.
+```
+```markdown
+---
+"@rfjs/filter-builder": minor
+---
+The sql-filter engine adapter now offers the new column operators
+(endswith/terms/iX for text, terms/range for numeric/date) in the editor.
+```
+```markdown
+---
+"@rfjs/pg-filter": patch
+---
+Column-target leaves transitively gain the new sql-filter operators
+(endswith/terms/range/iX); no API change.
+```
+
+- [ ] **Step 2: Full verify.** Run and confirm green:
+  - `pnpm -F @rfjs/sql-filter vitest:run` + `check-types`
+  - `pnpm -F @rfjs/filter-builder vitest:run` + `check-types`
+  - `pnpm -F @rfjs/pg-filter vitest:run` (+ `vitest:e2e:run` if present) + `check-types` — **regression check** that mixing column + jsonb leaves still works and the new column ops flow through.
+
+- [ ] **Step 3: Commit.**
+```bash
+git add .changeset
+git commit -m "$(printf 'chore: changesets for sql-filter operator alignment\n\nCo-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>')"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:** ① bug fix (T1: escapeLike + LIKE + ESCAPE + case-sensitive) ✓; ② coverage (T2: endswith/terms/range/iX + ALLOWED per D2 + validation) ✓; adapter offering (T3) ✓; changesets for all three changed packages + pg-filter regression (T4) ✓. D1/D2 locked values used verbatim. Type-narrowing correctly out of scope.
+
+**Placeholder scan:** all SQL strings, escape logic, test cases, and per-type sets are concrete. The one fragility (JS `\\` → SQL `\`) is called out in Global Constraints and shown in every affected string.
+
+**Type consistency:** `ColumnOperator` union extended once (T2 Step 3) and referenced by `ALLOWED` (T2 Step 4) and the adapter's string lists (T3). `terms`→list / `range`→two arity already in `filter-builder/arity.ts` — no change needed.

--- a/docs/superpowers/plans/2026-07-15-sql-filter-operators.md
+++ b/docs/superpowers/plans/2026-07-15-sql-filter-operators.md
@@ -4,7 +4,7 @@
 
 **Goal:** Fix the `@rfjs/sql-filter` column-path ILIKE wildcard bug and add the missing column operators (`endswith`, `terms`, `range`, and the case-insensitive `iX` family) so the column path reaches parity with the jsonb path.
 
-**Architecture:** All operator logic lives in `sql-filter`'s column renderer (`src/column/operators.ts`); `filter-builder`'s `sql-filter` engine adapter declares which of those the UI offers; `pg-filter` reuses `ColumnOperator` transitively (no code change). TDD per task.
+**Architecture:** All operator logic lives in `sql-filter`'s column renderer (`src/column/operators.ts`). Which operators the editor offers is declared by the filter-builder **engine adapters** — and there are **TWO** with column op-lists that must both be extended: `engines/sql-filter.ts` (`TEXT_OPS`/`NUMERIC_OPS`) AND `engines/pg-filter.ts` (its own `COLUMN_TEXT_OPS`/`COLUMN_NUMERIC_OPS`). The pg-filter adapter is the one the workbench dataset-explorer actually uses (`engineId="pg-filter"`), so skipping it would miss the spec's goal on the real surface. The `@rfjs/pg-filter` **package** reuses `ColumnOperator` transitively (no package code change). TDD per task.
 
 **Tech Stack:** TypeScript, Vitest (unit only for these packages), PostgreSQL LIKE/ILIKE semantics.
 
@@ -24,6 +24,9 @@
 - `packages/sql-filter/src/column/operators.spec.ts` — update `ilike` cases (T1); add new-op cases (T2).
 - `packages/sql-filter/src/column/build.spec.ts` — update the `ilike` where-clause assertion (T1).
 - `packages/filter-builder/src/engines/sql-filter.ts` — extend `TEXT_OPS`/`NUMERIC_OPS` (T3).
+- `packages/filter-builder/src/engines/pg-filter.ts` — extend `COLUMN_TEXT_OPS`/`COLUMN_NUMERIC_OPS` (T3) — the workbench's engine adapter.
+- `packages/filter-builder/src/engines/sql-filter.spec.ts` (line 13) + `pg-filter.spec.ts` (line 13) — flip the now-false `not.toContain` assertions (T3).
+- `packages/sql-filter/README.md` + `packages/sql-filter/README.zh-TW.md` — operator table + drop the "no IN/range" claim + contains/startswith case-sensitivity (T4).
 - `.changeset/*` — sql-filter minor, filter-builder minor, pg-filter patch (T4).
 
 ---
@@ -183,40 +186,69 @@ git commit -m "$(printf 'feat(sql-filter): add endswith/terms/range/iX column op
 
 ---
 
-### Task 3: filter-builder sql-filter adapter — offer the new operators
+### Task 3: filter-builder engine adapters (sql-filter AND pg-filter) — offer the new operators
+
+**BOTH adapters have their own column op-lists.** `engines/sql-filter.ts` (`TEXT_OPS`/`NUMERIC_OPS`) and `engines/pg-filter.ts` (`COLUMN_TEXT_OPS`/`COLUMN_NUMERIC_OPS`) are independent — extend both, or the workbench (which uses `engineId="pg-filter"`) won't offer the new column ops.
 
 **Files:**
-- Modify: `packages/filter-builder/src/engines/sql-filter.ts`
-- Test: any `packages/filter-builder/src/engines/*.spec.ts` asserting the sql-filter operator list (grep first; update if present).
+- Modify: `packages/filter-builder/src/engines/sql-filter.ts`, `packages/filter-builder/src/engines/pg-filter.ts`
+- Test: `packages/filter-builder/src/engines/sql-filter.spec.ts` (line 13), `packages/filter-builder/src/engines/pg-filter.spec.ts` (line 13).
 
-- [ ] **Step 1: Baseline** — branch check; `pnpm -F @rfjs/filter-builder vitest:run` → all PASS. Note count. `grep -rn "sql-filter\|TEXT_OPS\|columnOps" src/engines/*.spec.ts` to find any operator-list assertions.
+- [ ] **Step 1: Baseline** — branch check; `pnpm -F @rfjs/filter-builder vitest:run` → all PASS. Note count.
 
-- [ ] **Step 2: Extend the op lists** (`sql-filter.ts:16-18`):
+- [ ] **Step 2: Extend the op lists in BOTH adapters.**
+  In `engines/sql-filter.ts:16-18`:
 ```ts
 const NULL_OPS = ["isnull", "isnotnull"];
 const TEXT_OPS = ["eq", "neq", "contains", "startswith", "endswith", "icontains", "istartswith", "iendswith", "ieq", "ineq", "terms", "gt", "gte", "lt", "lte", ...NULL_OPS];
 const NUMERIC_OPS = ["eq", "neq", "gt", "gte", "lt", "lte", "terms", "range", ...NULL_OPS]; // numeric + date
 const BOOL_OPS = ["eq", "neq", ...NULL_OPS];
 ```
-  (`arityOf` already maps `terms`→list, `range`→two; the `iX` ops default to `one` — correct. No change to `arity.ts`.)
+  In `engines/pg-filter.ts:10-12` (mirror the same additions):
+```ts
+const NULL_OPS = ["isnull", "isnotnull"];
+const COLUMN_TEXT_OPS = ["eq", "neq", "contains", "startswith", "endswith", "icontains", "istartswith", "iendswith", "ieq", "ineq", "terms", "gt", "gte", "lt", "lte", ...NULL_OPS];
+const COLUMN_NUMERIC_OPS = ["eq", "neq", "gt", "gte", "lt", "lte", "terms", "range", ...NULL_OPS]; // numeric + date(timestamp)
+const COLUMN_BOOL_OPS = ["eq", "neq", ...NULL_OPS];
+```
+  (`arityOf` already maps `terms`→list, `range`→two; the `iX` ops default to `one` — correct. No `arity.ts` change.)
 
-- [ ] **Step 3: If Step 1's grep found an operator-list assertion**, update it to include the new ops. If a test drives the editor and asserts a specific operator set for a string/number field, extend it. Do not add new tests beyond keeping existing ones accurate.
+- [ ] **Step 3: Flip the now-false negative assertions (both spec files).**
+  `engines/sql-filter.spec.ts:13` — `TEXT_OPS` now includes `terms`, so change:
+```ts
+// before: expect(ops).not.toContain("terms"); // sql-filter column layer has no IN list
+expect(ops).toContain("terms"); // text columns now offer terms (= ANY)
+```
+  Optionally extend the `arrayContaining` at line 11 with e.g. `"endswith", "icontains", "ieq"`. **Leave line 20** (`numeric … not.toContain("contains")`) and **lines 24-26** (boolean exact set `["eq","neq","isnull","isnotnull"]`) unchanged — both stay valid (numeric never gains `contains`; boolean unchanged).
+  `engines/pg-filter.spec.ts:13` — `COLUMN_TEXT_OPS` now includes `icontains`, so change:
+```ts
+// before: expect(ops).not.toContain("icontains");
+expect(ops).toContain("icontains"); // text columns now offer the ci iX family
+```
+  Optionally add `expect(ops).toContain("endswith"); expect(ops).toContain("terms");`. **Leave the "returns ok:false when a column gets an unsupported operator" test (lines 65-69)** unchanged — it uses `numeric` + `contains`, which is still unsupported (D2: numeric gains only `terms`/`range`, not `contains`).
 
 - [ ] **Step 4: Run tests** — `pnpm -F @rfjs/filter-builder vitest:run` → all PASS; `pnpm -F @rfjs/filter-builder check-types`.
 
 - [ ] **Step 5: Commit.**
 ```bash
 git add packages/filter-builder/src/engines
-git commit -m "$(printf 'feat(filter-builder): offer the new sql-filter column operators in the editor\n\nExtend the sql-filter engine adapter TEXT_OPS/NUMERIC_OPS so the editor offers\nendswith/terms/iX (text) and terms/range (numeric/date), matching sql-filter\n column path parity. arity map already covers terms/range.\n\nCo-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>')"
+git commit -m "$(printf 'feat(filter-builder): offer the new sql-filter column operators (both adapters)\n\nExtend BOTH the sql-filter and pg-filter engine adapters (TEXT_OPS/NUMERIC_OPS\nand COLUMN_TEXT_OPS/COLUMN_NUMERIC_OPS) so the editor offers endswith/terms/iX\n(text) and terms/range (numeric/date) for column fields — including the\npg-filter engine the workbench uses. Flip the now-false not.toContain\nassertions in both specs. arity map already covers terms/range.\n\nCo-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>')"
 ```
 
 ---
 
 ### Task 4: changesets + full verification
 
-**Files:** Create `.changeset/sql-filter-operators.md`, `.changeset/filter-builder-sql-ops.md`, `.changeset/pg-filter-column-ops.md`.
+**Files:** `packages/sql-filter/README.md` + `README.zh-TW.md`; create `.changeset/sql-filter-operators.md`, `.changeset/filter-builder-sql-ops.md`, `.changeset/pg-filter-column-ops.md`.
 
-- [ ] **Step 1: Changesets.**
+- [ ] **Step 1: Update the sql-filter READMEs** (`packages/sql-filter/README.md` + `README.zh-TW.md`), which currently claim the column layer has "no IN, no range" and describe `contains`/`startswith` as case-insensitive ILIKE:
+  - Correct the "no IN, no range" claim — the column layer now emits `= ANY` (`terms`) and `BETWEEN` (`range`) for the applicable types.
+  - Update the per-type operator table to D2 (text +`endswith`/`terms`/`iX`; numeric/timestamp +`terms`/`range`; uuid +`terms`).
+  - State that `contains`/`startswith`/`endswith` are now case-**sensitive** (`LIKE`), with the `iX` family for case-insensitive.
+  - `grep -rn "ilike\|no IN\|no range\|contains" packages/filter-builder/README* packages/pg-filter/README*` and fix any stale operator claims there too.
+  Commit: `git add packages/sql-filter/README* packages/filter-builder/README* packages/pg-filter/README* 2>/dev/null; git commit -m "$(printf 'docs: update filter READMEs for the new sql-filter column operators\n\nCo-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>')"`
+
+- [ ] **Step 2: Changesets.**
 ```markdown
 ---
 "@rfjs/sql-filter": minor
@@ -241,12 +273,12 @@ Column-target leaves transitively gain the new sql-filter operators
 (endswith/terms/range/iX); no API change.
 ```
 
-- [ ] **Step 2: Full verify.** Run and confirm green:
+- [ ] **Step 3: Full verify.** Run and confirm green:
   - `pnpm -F @rfjs/sql-filter vitest:run` + `check-types`
   - `pnpm -F @rfjs/filter-builder vitest:run` + `check-types`
   - `pnpm -F @rfjs/pg-filter vitest:run` (+ `vitest:e2e:run` if present) + `check-types` — **regression check** that mixing column + jsonb leaves still works and the new column ops flow through.
 
-- [ ] **Step 3: Commit.**
+- [ ] **Step 4: Commit.**
 ```bash
 git add .changeset
 git commit -m "$(printf 'chore: changesets for sql-filter operator alignment\n\nCo-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>')"
@@ -260,4 +292,11 @@ git commit -m "$(printf 'chore: changesets for sql-filter operator alignment\n\n
 
 **Placeholder scan:** all SQL strings, escape logic, test cases, and per-type sets are concrete. The one fragility (JS `\\` → SQL `\`) is called out in Global Constraints and shown in every affected string.
 
-**Type consistency:** `ColumnOperator` union extended once (T2 Step 3) and referenced by `ALLOWED` (T2 Step 4) and the adapter's string lists (T3). `terms`→list / `range`→two arity already in `filter-builder/arity.ts` — no change needed.
+**Type consistency:** `ColumnOperator` union extended once (T2 Step 3) and referenced by `ALLOWED` (T2 Step 4) and both adapters' string lists (T3). `terms`→list / `range`→two arity already in `filter-builder/arity.ts` — no change needed.
+
+## Post-ultracode corrections (2026-07-15)
+
+Adversarial verification (5 lenses, per-finding verify) confirmed 3 distinct defects, all fixed above:
+1. **[important]** `filter-builder/src/engines/sql-filter.spec.ts:13` asserts `not.toContain("terms")`; adding `terms` to `TEXT_OPS` breaks it. T3 now explicitly flips it to `toContain` (was a vague conditional).
+2. **[important]** The filter-builder **`pg-filter` engine adapter** (`engines/pg-filter.ts`) has its OWN `COLUMN_TEXT_OPS`/`COLUMN_NUMERIC_OPS`, and it's the adapter the **workbench** uses (`engineId="pg-filter"`). T3 now extends BOTH adapters and flips `pg-filter.spec.ts:13` (`not.toContain("icontains")` → `toContain`); architecture note + file map corrected. This lives in the filter-builder package (already covered by its minor changeset — no new changeset). The numeric+`contains` ok:false test (`pg-filter.spec.ts:65-69`) stays valid.
+3. **[minor]** sql-filter READMEs (EN + zh-TW) claim "no IN/range" and describe `contains`/`startswith` as ILIKE — falsified by ①+②. T4 Step 1 now updates them (+ greps filter-builder/pg-filter READMEs).

--- a/docs/superpowers/specs/2026-07-15-sql-filter-operators-design.md
+++ b/docs/superpowers/specs/2026-07-15-sql-filter-operators-design.md
@@ -120,7 +120,7 @@ nullary/undefined 檢查風格）。
 - 手動驗證一個含 `%`/`_` 的 `contains` 不再誤配；`terms`/`range`/`endswith`/`iX` 產出正確 SQL。
 - 不 push、不動 primary checkout；HOLD PR 直到使用者說「PR」。
 
-## 待你確認的決策
-- **D1**：`contains`/`startswith`/`endswith` 改**大小寫敏感**（ci 交給 `iX`）—— 同意？
-- **D2**：每型別新增運算子集合（見表）—— text 是否也要 `range`？uuid 只加 `terms` 可否？
-- 型別收斂（`operator: string`→union）這次**不做**、列後續 —— 同意？
+## 已定案的決策（2026-07-15 使用者確認）
+- **D1 ✅**：`contains`/`startswith`/`endswith` 改**大小寫敏感**（`LIKE`），ci 交給新增的 `iX`（`ILIKE`）。
+- **D2 ✅**：每型別新增運算子照上表 —— text **不加** `range`；uuid 只加 `terms`；boolean 不加。
+- **型別收斂加購**（`operator: string`→union）：**這次不做**，列為獨立後續。

--- a/docs/superpowers/specs/2026-07-15-sql-filter-operators-design.md
+++ b/docs/superpowers/specs/2026-07-15-sql-filter-operators-design.md
@@ -1,0 +1,126 @@
+# 設計：@rfjs/sql-filter 運算子對齊（① ILIKE bug + ② column 覆蓋）
+
+- 日期：2026-07-15
+- 分支：`feat-sql-filter-operators`（新 worktree，base `ec0c8b2`）
+- 相關參考：`docs/filter-operator-matrix.md`（跨 engine 運算子矩陣，branch `docs-filter-operator-matrix`）
+
+## 背景與目標
+
+`@rfjs/sql-filter` 的 **column 層**（`src/column/operators.ts`）目前只支援
+`eq/neq/isnull/isnotnull/contains/startswith/gt/gte/lt/lte`，而同屬「同名直通群」的
+`jsonb-query` / `data-filter` 支援更廣（`terms`/`range`/`endswith`/`iX` ci 家族…）。因為
+`pg-filter` 一棵樹會混用 `target:'column'`（→ sql-filter）與 `target:'jsonb'`（→ jsonb-query）
+兩種 leaf，使用者會遇到「同一個運算子在 jsonb 欄位可用、在 column 欄位卻丟
+`UNSUPPORTED_OPERATOR`」的落差。同時 column 層的 `contains`/`startswith` 有一個 ILIKE
+萬用字元 bug。
+
+**目標（本輪範圍 = ①+②）**：
+- **① 修正 ILIKE bug**（正確性）。
+- **② 補齊 column 層運算子覆蓋**，讓 column 路徑對齊 jsonb/data-filter 的每型別運算子集合。
+
+**非目標**：不做「大改名對齊」（同名直通群拼字已一致）；不動 `es-query`/`mongo-query`
+（由 adapter map 隔離）；**不含** 把 canonical `operator: string` 收斂成 union 型別的加購
+（列為後續可選）；不改 `es-query` 的 `*`/`?` escape（另案）。
+
+## ① ILIKE bug 修正
+
+現況（`src/column/operators.ts:58-63`）：
+```ts
+if (operator === 'contains')   return `${col} ilike '%' || ${params.add(value)} || '%'`;
+if (operator === 'startswith') return `${col} ilike ${params.add(value)} || '%'`;
+```
+兩個問題：
+1. **未 escape**：term 內的 `%`/`_` 被當萬用字元，且無 `ESCAPE` 子句 → 搜 `50%`/`a_b` 會誤配。
+2. **大小寫語意不一致**：無條件用 `ilike`（不敏感），但 jsonb-query / data-filter 的
+   `contains`/`startswith` 是**大小寫敏感**（jsonb 把 ci 保留給 `iX` 家族）。
+
+### 決策 D1（需你確認）：大小寫語意
+**採「大小寫敏感」對齊 jsonb/data-filter** —— `contains`/`startswith`/`endswith` 改用
+`LIKE`（敏感）；大小寫**不**敏感交給 ② 新增的 `icontains`/`istartswith`/`iendswith`（用
+`ILIKE`）。這是**行為變更**：既有 column `contains`/`startswith` 從 ci 變 cs（此 repo 無外部
+consumer 依賴舊 ci 行為，安全；但既有 sql-filter 測試斷言 `ilike`，需一併更新）。
+
+### escape 作法
+新增純函式 `escapeLike(v: string): string`，將 `\` `%` `_` 前置 `\`；render 時 term 走
+`escapeLike(String(value))` 綁參數，並在 SQL 尾加 `ESCAPE '\'`：
+```ts
+// contains  → `${col} like '%' || $1 || '%' escape '\'`   ($1 = escapeLike(String(value)))
+// startswith→ `${col} like $1 || '%' escape '\'`
+// endswith  → `${col} like '%' || $1 escape '\'`
+```
+
+## ② column 覆蓋補齊
+
+### 決策 D2（需你確認）：每型別運算子集合（對齊 data-filter / jsonb 的 dataType 集合）
+新增運算子加入 `ColumnOperator` union 與 `ALLOWED` 每型別集合：
+
+| ColumnType | 現有 | **新增** |
+|---|---|---|
+| `text` | eq, neq, isnull, isnotnull, contains, startswith, gt, gte, lt, lte | **endswith, terms, ieq, ineq, icontains, istartswith, iendswith** |
+| `numeric` | eq, neq, isnull, isnotnull, gt, gte, lt, lte | **terms, range** |
+| `timestamp` | 同 numeric | **terms, range** |
+| `boolean` | eq, neq, isnull, isnotnull | （不加；terms 對 bool 無意義） |
+| `uuid` | eq, neq, isnull, isnotnull | **terms** |
+
+（text 不加 `range` —— 字串 BETWEEN 是字典序、幾乎不會要，且 jsonb 實務也少用；如需再議。）
+
+### 決策 D3：SQL render（`ParamBuilder.add` 已支援陣列參數 → `= ANY`）
+| op | arity（`filter-builder/arity.ts` 已定義） | SQL |
+|---|---|---|
+| `terms` | list | `${col} = any(${add(value)})`（value 為陣列；pg 驅動綁 JS 陣列為 PG 陣列） |
+| `range` | two | `${col} between ${add(v[0])} and ${add(v[1])}`（value 為 `[lo,hi]`，驗證 2 元素） |
+| `endswith` | one | `${col} like '%' || ${add(esc)} escape '\'` |
+| `ieq` | one | `lower(${col}) = lower(${add(value)})`（ci 精確，免 escape） |
+| `ineq` | one | `lower(${col}) <> lower(${add(value)})` |
+| `icontains` | one | `${col} ilike '%' || ${add(esc)} || '%' escape '\'` |
+| `istartswith` | one | `${col} ilike ${add(esc)} || '%' escape '\'` |
+| `iendswith` | one | `${col} ilike '%' || ${add(esc)} escape '\'` |
+
+value 驗證：`terms` 需非空陣列、`range` 需 2 元素陣列，否則丟 `INVALID_VALUE`（比照現有
+nullary/undefined 檢查風格）。
+
+### filter-builder adapter（`src/engines/sql-filter.ts`）同步
+`columnOps(dataType)` 的清單要加上對應新運算子，UI 才會提供：
+- `TEXT_OPS`（dataType `string`，含 uuid→text）：+ `endswith, terms, ieq, ineq, icontains, istartswith, iendswith`
+- `NUMERIC_OPS`（`numeric`/`date`）：+ `terms, range`
+- `BOOL_OPS`：不變
+
+（arity 已於 `arity.ts` 定義 `terms`=list、`range`=two；iX 家族預設 `one`，正確。）
+
+## 檔案清單
+
+- `packages/sql-filter/src/column/operators.ts` — `ColumnOperator` union、`ALLOWED`、`NULLARY`
+  不變、加 `escapeLike` + 新 render 分支 + `ilike`→`like`（cs）+ ESCAPE。
+- `packages/sql-filter/src/column/*.spec.ts` — 更新既有 `ilike` 斷言為 `like ... escape`；新增
+  escape / terms / range / endswith / iX 的測試。
+- `packages/filter-builder/src/engines/sql-filter.ts` — 擴充 `TEXT_OPS`/`NUMERIC_OPS`。
+- `packages/filter-builder/src/engines/*.spec.ts`（若有斷言 sql-filter 運算子清單）— 同步。
+- `packages/pg-filter` — 無需改碼（`PgColumnLeaf.operator: ColumnOperator` 自動涵蓋新 op）；
+  跑既有測試確認綠，視情況補 column 新運算子的 e2e/單元覆蓋。
+
+## 測試與相容性
+
+- **會變紅需更新**：既有 sql-filter column 測試中斷言 `ilike '%' || ... || '%'` 的案例（D1 改
+  `like ... escape '\'` + cs）。這是預期的行為變更、不是回歸。
+- 新增測試涵蓋：escape（`50%`/`a_b`/`\`）、cs vs ci（`contains` 敏感、`icontains` 不敏感）、
+  `terms`（`= any`）、`range`（`between` + 非 2 元素報錯）、`endswith`、每型別 `ALLOWED` 拒絕
+  （如 boolean 不接受 `terms`）。
+- `pg-filter` 既有測試維持綠。
+
+## Changeset（每個變更的 workspace 套件都要）
+
+- `@rfjs/sql-filter` — **minor**（新增 column 運算子 + 修 contains/startswith 語意）。
+- `@rfjs/filter-builder` — **minor**（sql-filter engine 對外提供的運算子集合擴充）。
+- `@rfjs/pg-filter` — **patch**（透過 sql-filter 傳遞性支援新 column 運算子；無自身改碼但行為擴充）。
+
+## 驗收
+
+- `pnpm -F @rfjs/sql-filter vitest:run`（含 e2e 若有）、`pnpm -F @rfjs/filter-builder vitest:run`、
+  `pnpm -F @rfjs/pg-filter vitest:run`（含 e2e）全綠；`pnpm -F <pkg> check-types` 綠。
+- 手動驗證一個含 `%`/`_` 的 `contains` 不再誤配；`terms`/`range`/`endswith`/`iX` 產出正確 SQL。
+- 不 push、不動 primary checkout；HOLD PR 直到使用者說「PR」。
+
+## 待你確認的決策
+- **D1**：`contains`/`startswith`/`endswith` 改**大小寫敏感**（ci 交給 `iX`）—— 同意？
+- **D2**：每型別新增運算子集合（見表）—— text 是否也要 `range`？uuid 只加 `terms` 可否？
+- 型別收斂（`operator: string`→union）這次**不做**、列後續 —— 同意？

--- a/packages/filter-builder/README.md
+++ b/packages/filter-builder/README.md
@@ -155,12 +155,12 @@ engine's behaviour.
 | `eq` | one | ✓ | ✓ | ✓ | ✓ | equals (mongo: `$eq`) |
 | `neq` | one | ✓ | ✓ | ✓ | ✓ | not equals |
 | `gt` `gte` `lt` `lte` | one | ✓ | ✓ | ✓ | ✓ | comparisons |
-| `range` | two `[min,max]` | ✓ | ✓ | – | ✓ | inclusive between |
-| `contains` | one² | ✓ | ✓ | ✓ | ✓ | substring (sql: `ILIKE`; mongo: `$regex`) |
+| `range` | two `[min,max]` | ✓ | ✓ | ✓⁴ | ✓ | inclusive between |
+| `contains` | one² | ✓ | ✓ | ✓ | ✓ | substring (sql: case-sensitive `LIKE`; mongo: `$regex`) |
 | `startswith` | one | ✓ | ✓ | ✓ | ✓ | prefix |
-| `endswith` | one | ✓ | ✓ | – | ✓ | suffix (sql column layer has no suffix op) |
-| `icontains` `istartswith` `iendswith` `ieq` `ineq` | one | – | ✓ | – | – | case-insensitive variants |
-| `terms` | list | ✓ | ✓ | – | ✓ | in a set (sql: —; mongo: `$in`) |
+| `endswith` | one | ✓ | ✓ | ✓⁴ | ✓ | suffix |
+| `icontains` `istartswith` `iendswith` `ieq` `ineq` | one | – | ✓ | ✓⁴ | – | case-insensitive variants |
+| `terms` | list | ✓ | ✓ | ✓⁴ | ✓ | in a set (sql: `= ANY`; mongo: `$in`) |
 | `nin` | list | – | – | – | ✓ | not in a set (`$nin`) |
 | `containsall` | list | ✓ | ✓ | – | – | array contains every value |
 | `isnull` `isnotnull` | none | ✓ | ✓ | ✓ | ✓ | null checks (mongo: `$eq`/`$ne null`) |
@@ -178,6 +178,11 @@ above; a leaf with `target: 'jsonb'` uses the **jsonb-query** set.
 
 ³ `elemmatch` carries a nested `BuilderGroup` (in `condition.filters`) rather
 than a scalar value.
+
+⁴ **sql-filter**'s column layer gates `range`/`terms`/the `iX` family per column
+`type` — e.g. `range` is numeric/timestamp only (not `text`), `terms` is
+unavailable on `boolean`; see the per-type table in
+[@rfjs/sql-filter](../sql-filter#column-operators--types).
 
 Arity comes from the shared `arity.ts` (the single source of truth); the
 per-engine ✓ marks are maintained against each engine's `operators()`. A

--- a/packages/filter-builder/README.zh-TW.md
+++ b/packages/filter-builder/README.zh-TW.md
@@ -135,12 +135,12 @@ const schema = inferSchema([{ age: 36, name: "Ada" }]); // → FieldSchema[]
 | `eq` | one | ✓ | ✓ | ✓ | ✓ | 等於(mongo:`$eq`) |
 | `neq` | one | ✓ | ✓ | ✓ | ✓ | 不等於 |
 | `gt` `gte` `lt` `lte` | one | ✓ | ✓ | ✓ | ✓ | 大小比較 |
-| `range` | two `[min,max]` | ✓ | ✓ | – | ✓ | 介於(含邊界) |
-| `contains` | one² | ✓ | ✓ | ✓ | ✓ | 子字串(sql:`ILIKE`;mongo:`$regex`) |
+| `range` | two `[min,max]` | ✓ | ✓ | ✓⁴ | ✓ | 介於(含邊界) |
+| `contains` | one² | ✓ | ✓ | ✓ | ✓ | 子字串(sql:區分大小寫的 `LIKE`;mongo:`$regex`) |
 | `startswith` | one | ✓ | ✓ | ✓ | ✓ | 開頭為 |
-| `endswith` | one | ✓ | ✓ | – | ✓ | 結尾為(sql 欄位層無此 op) |
-| `icontains` `istartswith` `iendswith` `ieq` `ineq` | one | – | ✓ | – | – | 不分大小寫版本 |
-| `terms` | list | ✓ | ✓ | – | ✓ | 屬於集合(sql:—;mongo:`$in`) |
+| `endswith` | one | ✓ | ✓ | ✓⁴ | ✓ | 結尾為 |
+| `icontains` `istartswith` `iendswith` `ieq` `ineq` | one | – | ✓ | ✓⁴ | – | 不分大小寫版本 |
+| `terms` | list | ✓ | ✓ | ✓⁴ | ✓ | 屬於集合(sql:`= ANY`;mongo:`$in`) |
 | `nin` | list | – | – | – | ✓ | 不屬於集合(`$nin`) |
 | `containsall` | list | ✓ | ✓ | – | – | 陣列包含全部值 |
 | `isnull` `isnotnull` | none | ✓ | ✓ | ✓ | ✓ | null 檢查(mongo:`$eq`/`$ne null`) |
@@ -154,6 +154,8 @@ const schema = inferSchema([{ age: 36, name: "Ada" }]); // → FieldSchema[]
 ² `contains` 一般是單值,但 **data-filter** 在 `string` / 字串陣列欄位上把它視為 `list` arity(contains-**any**,任一命中)。
 
 ³ `elemmatch` 帶的是巢狀 `BuilderGroup`(在 `condition.filters`),而非純量值。
+
+⁴ **sql-filter** 的欄位層對 `range`/`terms`/`iX` 家族依欄位 `type` 有不同的允許範圍 —— 例如 `range` 只有 numeric/timestamp(`text` 沒有),`terms` 在 `boolean` 上不可用;詳見 [@rfjs/sql-filter](../sql-filter#column-operator-與型別) 的每型別對照表。
 
 arity 來自共用的 `arity.ts`(單一真相);各引擎的 ✓ 標記是依各引擎 `operators()` 維護。`@rfjs/filter-builder-ui` 裡有一個 drift-guard 測試(`operators.spec.ts`)確保任何引擎回傳的 operator 都存在於 `OPERATOR_KEYS`,所以**新增**的 operator 不會被漏掉——但表中的 ✓/– 格是人工核對,若有疑問請以各引擎自己的 README 為準。
 

--- a/packages/filter-builder/src/engines/pg-filter.spec.ts
+++ b/packages/filter-builder/src/engines/pg-filter.spec.ts
@@ -10,7 +10,9 @@ describe("pgFilterEngine.operators", () => {
     expect(ops).toContain("contains");
     expect(ops).toContain("startswith");
     expect(ops).toContain("eq");
-    expect(ops).not.toContain("icontains");
+    expect(ops).toContain("icontains"); // text columns now offer the ci iX family
+    expect(ops).toContain("endswith");
+    expect(ops).toContain("terms");
   });
 
   it("returns jsonb operators for jsonb-kind fields", () => {

--- a/packages/filter-builder/src/engines/pg-filter.ts
+++ b/packages/filter-builder/src/engines/pg-filter.ts
@@ -7,8 +7,8 @@ import { jsonbEngine } from "./jsonb";
 import type { CompileContext, Engine, OperatorSpec } from "./types";
 
 const NULL_OPS = ["isnull", "isnotnull"];
-const COLUMN_TEXT_OPS = ["eq", "neq", "contains", "startswith", "gt", "gte", "lt", "lte", ...NULL_OPS];
-const COLUMN_NUMERIC_OPS = ["eq", "neq", "gt", "gte", "lt", "lte", ...NULL_OPS]; // numeric + date(timestamp)
+const COLUMN_TEXT_OPS = ["eq", "neq", "contains", "startswith", "endswith", "icontains", "istartswith", "iendswith", "ieq", "ineq", "terms", "gt", "gte", "lt", "lte", ...NULL_OPS];
+const COLUMN_NUMERIC_OPS = ["eq", "neq", "gt", "gte", "lt", "lte", "terms", "range", ...NULL_OPS]; // numeric + date(timestamp)
 const COLUMN_BOOL_OPS = ["eq", "neq", ...NULL_OPS];
 
 function columnOps(dataType: string): string[] {

--- a/packages/filter-builder/src/engines/sql-filter.spec.ts
+++ b/packages/filter-builder/src/engines/sql-filter.spec.ts
@@ -8,9 +8,12 @@ describe("sqlFilterEngine.operators", () => {
   it("offers text ops (incl. contains/startswith) for string columns", () => {
     const ops = sqlFilterEngine.operators("string").map((o) => o.op);
     expect(ops).toEqual(
-      expect.arrayContaining(["eq", "neq", "contains", "startswith", "gt", "lt", "isnull"]),
+      expect.arrayContaining([
+        "eq", "neq", "contains", "startswith", "gt", "lt", "isnull",
+        "endswith", "icontains", "ieq",
+      ]),
     );
-    expect(ops).not.toContain("terms"); // sql-filter column layer has no IN list
+    expect(ops).toContain("terms"); // text columns now offer terms (= ANY)
   });
 
   it("offers comparison ops for numeric/date columns", () => {

--- a/packages/filter-builder/src/engines/sql-filter.ts
+++ b/packages/filter-builder/src/engines/sql-filter.ts
@@ -13,8 +13,8 @@ import type { CompileContext, Engine, OperatorSpec } from "./types";
 
 const NULL_OPS = ["isnull", "isnotnull"];
 // sql-filter's column layer (ColumnOperator) is the authority on what's renderable.
-const TEXT_OPS = ["eq", "neq", "contains", "startswith", "gt", "gte", "lt", "lte", ...NULL_OPS];
-const NUMERIC_OPS = ["eq", "neq", "gt", "gte", "lt", "lte", ...NULL_OPS]; // numeric + date
+const TEXT_OPS = ["eq", "neq", "contains", "startswith", "endswith", "icontains", "istartswith", "iendswith", "ieq", "ineq", "terms", "gt", "gte", "lt", "lte", ...NULL_OPS];
+const NUMERIC_OPS = ["eq", "neq", "gt", "gte", "lt", "lte", "terms", "range", ...NULL_OPS]; // numeric + date
 const BOOL_OPS = ["eq", "neq", ...NULL_OPS];
 
 function columnOps(dataType: string): string[] {

--- a/packages/pg-filter/README.md
+++ b/packages/pg-filter/README.md
@@ -20,7 +20,7 @@ npm i @rfjs/pg-filter
 
 ```
  one PgFilterGroup (and/or/nor/not, nested)
- ├─ { target: 'column', column, operator, value }   ──▶ @rfjs/sql-filter  →  "name" ILIKE …
+ ├─ { target: 'column', column, operator, value }   ──▶ @rfjs/sql-filter  →  "name" LIKE …
  └─ { target: 'jsonb',  field,  operator, value }    ──▶ @rfjs/jsonb-query →  ("data" #>> …)::numeric > …
                          │
                          ▼
@@ -79,7 +79,7 @@ type PgSort = { target: "column"; column: string; direction?: "asc"|"desc"; null
 
 `pg-filter` does **not** define its own operators — each leaf uses its target engine's set:
 
-- `target: 'column'` → the **scalar column** operators of [@rfjs/sql-filter](../sql-filter#column-operators--types) (`eq`/`neq`/`contains`/`startswith`/`gt`/`gte`/`lt`/`lte`/`isnull`/`isnotnull`; no `IN`, no range).
+- `target: 'column'` → the **scalar column** operators of [@rfjs/sql-filter](../sql-filter#column-operators--types) (`eq`/`neq`/`contains`/`startswith`/`endswith`/the case-insensitive `iX` family/`gt`/`gte`/`lt`/`lte`/`isnull`/`isnotnull`, plus `terms` (`= ANY`) and `range` (`BETWEEN`) on the types that support them — see sql-filter's per-type table).
 - `target: 'jsonb'` → the full [@rfjs/jsonb-query](../jsonb-query) set (`terms`, `range`, `containsall`, case-insensitive variants, `haskey…`, `elemmatch`, …).
 
 See the cross-engine matrix in [@rfjs/filter-builder](../filter-builder#operator-matrix).

--- a/packages/pg-filter/README.zh-TW.md
+++ b/packages/pg-filter/README.zh-TW.md
@@ -16,7 +16,7 @@ npm i @rfjs/pg-filter
 
 ```
  一棵 PgFilterGroup(and/or/nor/not,可巢狀)
- ├─ { target: 'column', column, operator, value }   ──▶ @rfjs/sql-filter  →  "name" ILIKE …
+ ├─ { target: 'column', column, operator, value }   ──▶ @rfjs/sql-filter  →  "name" LIKE …
  └─ { target: 'jsonb',  field,  operator, value }    ──▶ @rfjs/jsonb-query →  ("data" #>> …)::numeric > …
                          │
                          ▼
@@ -73,7 +73,7 @@ type PgSort = { target: "column"; column: string; direction?: "asc"|"desc"; null
 
 `pg-filter` **不自己定義** operator —— 每個 leaf 用它 target 引擎的集合:
 
-- `target: 'column'` → [@rfjs/sql-filter](../sql-filter#column-operator-與型別) 的**純量欄位** operator(`eq`/`neq`/`contains`/`startswith`/`gt`/`gte`/`lt`/`lte`/`isnull`/`isnotnull`;無 `IN`、無 range)。
+- `target: 'column'` → [@rfjs/sql-filter](../sql-filter#column-operator-與型別) 的**純量欄位** operator(`eq`/`neq`/`contains`/`startswith`/`endswith`/不分大小寫的 `iX` 家族/`gt`/`gte`/`lt`/`lte`/`isnull`/`isnotnull`,對支援的型別還有 `terms`(`= ANY`)與 `range`(`BETWEEN`)—— 詳見 sql-filter 的每型別對照表)。
 - `target: 'jsonb'` → [@rfjs/jsonb-query](../jsonb-query) 的完整集合(`terms`、`range`、`containsall`、不分大小寫版本、`haskey…`、`elemmatch` 等)。
 
 跨引擎矩陣見 [@rfjs/filter-builder](../filter-builder#operator-矩陣)。

--- a/packages/sql-filter/README.md
+++ b/packages/sql-filter/README.md
@@ -68,7 +68,7 @@ const { where, values } = buildColumnQuery(config, {
     { column: "createdAt", operator: "gte", value: "2026-01-01" },
   ],
 });
-// where  → "\"name\" ilike '%' || $1 || '%' and \"created_at\" >= $2"
+// where  → "\"name\" like '%' || $1 || '%' escape '\\' and \"created_at\" >= $2"
 // values → ["sales", "2026-01-01"]
 ```
 
@@ -76,18 +76,29 @@ const { where, values } = buildColumnQuery(config, {
 
 ## Column operators & types
 
-The column layer is intentionally a **scalar, single-value** surface (no `IN`,
-no range — those live in the JSONB / Mongo engines). Operators are validated
-against each column's declared `type`:
+The column layer is a **scalar** surface, but not limited to single-value
+equality: alongside `eq`/`neq`/comparisons it also emits `= ANY` for an IN-list
+(`terms`) and `BETWEEN` for a range (`range`) on the types that support them.
+Operators are validated against each column's declared `type`:
 
 | `ColumnType` | allowed `ColumnOperator` |
 |--------------|--------------------------|
-| `text` | `eq` `neq` `isnull` `isnotnull` `contains` `startswith` `gt` `gte` `lt` `lte` |
-| `numeric` / `timestamp` | `eq` `neq` `isnull` `isnotnull` `gt` `gte` `lt` `lte` |
-| `boolean` / `uuid` | `eq` `neq` `isnull` `isnotnull` |
+| `text` | `eq` `neq` `isnull` `isnotnull` `contains` `startswith` `endswith` `icontains` `istartswith` `iendswith` `ieq` `ineq` `terms` `gt` `gte` `lt` `lte` |
+| `numeric` / `timestamp` | `eq` `neq` `isnull` `isnotnull` `gt` `gte` `lt` `lte` `terms` `range` |
+| `uuid` | `eq` `neq` `isnull` `isnotnull` `terms` |
+| `boolean` | `eq` `neq` `isnull` `isnotnull` |
 
-Values are single-value (`isnull`/`isnotnull` take none). An unknown column or a
-type-disallowed operator throws `ColumnQueryError`
+`contains`/`startswith`/`endswith` are case-**sensitive** substring/prefix/suffix
+matches (`LIKE`, with `%`/`_`/`\` escaped so the term matches verbatim, not as
+wildcards). For case-insensitive matching use the `iX` family: `icontains`/
+`istartswith`/`iendswith` (`ILIKE`, same escaping) and `ieq`/`ineq`
+(`lower(column) = / <> lower($n)`). `terms` takes a non-empty array and renders
+`= ANY($n)` — the whole array is bound as **one** parameter, not one per
+element. `range` takes a `[lo, hi]` pair and renders `BETWEEN $n AND $n+1`.
+
+Values are single-value except `terms` (array) and `range` (2-element array);
+`isnull`/`isnotnull` take none. An unknown column or a type-disallowed operator
+throws `ColumnQueryError`
 (`UNKNOWN_COLUMN` / `UNSUPPORTED_OPERATOR`).
 
 > For the cross-engine operator picture (which engine has `terms`/`range`/etc.),

--- a/packages/sql-filter/README.zh-TW.md
+++ b/packages/sql-filter/README.zh-TW.md
@@ -60,7 +60,7 @@ const { where, values } = buildColumnQuery(config, {
     { column: "createdAt", operator: "gte", value: "2026-01-01" },
   ],
 });
-// where  → "\"name\" ilike '%' || $1 || '%' and \"created_at\" >= $2"
+// where  → "\"name\" like '%' || $1 || '%' escape '\\' and \"created_at\" >= $2"
 // values → ["sales", "2026-01-01"]
 ```
 
@@ -68,15 +68,18 @@ const { where, values } = buildColumnQuery(config, {
 
 ## Column operator 與型別
 
-column 層刻意是**純量、單一值**的介面(沒有 `IN`、沒有 range —— 那些在 JSONB / Mongo 引擎)。operator 會依欄位宣告的 `type` 驗證:
+column 層是**純量**介面,但不僅限於單值相等:除了 `eq`/`neq`/比較運算子之外,對支援的型別它也會產生 IN-list 的 `= ANY`(`terms`)與 range 的 `BETWEEN`(`range`)。operator 會依欄位宣告的 `type` 驗證:
 
 | `ColumnType` | 允許的 `ColumnOperator` |
 |--------------|-------------------------|
-| `text` | `eq` `neq` `isnull` `isnotnull` `contains` `startswith` `gt` `gte` `lt` `lte` |
-| `numeric` / `timestamp` | `eq` `neq` `isnull` `isnotnull` `gt` `gte` `lt` `lte` |
-| `boolean` / `uuid` | `eq` `neq` `isnull` `isnotnull` |
+| `text` | `eq` `neq` `isnull` `isnotnull` `contains` `startswith` `endswith` `icontains` `istartswith` `iendswith` `ieq` `ineq` `terms` `gt` `gte` `lt` `lte` |
+| `numeric` / `timestamp` | `eq` `neq` `isnull` `isnotnull` `gt` `gte` `lt` `lte` `terms` `range` |
+| `uuid` | `eq` `neq` `isnull` `isnotnull` `terms` |
+| `boolean` | `eq` `neq` `isnull` `isnotnull` |
 
-值都是單一值(`isnull`/`isnotnull` 不帶值)。未知欄位或型別不允許的 operator 會丟 `ColumnQueryError`(`UNKNOWN_COLUMN` / `UNSUPPORTED_OPERATOR`)。
+`contains`/`startswith`/`endswith` 是**區分大小寫**的子字串/前綴/後綴比對(`LIKE`,並會跳脫 `%`/`_`/`\`,讓詞彙逐字比對而非當成萬用字元)。要不分大小寫請用 `iX` 家族:`icontains`/`istartswith`/`iendswith`(`ILIKE`,同樣的跳脫)與 `ieq`/`ineq`(`lower(欄位) = / <> lower($n)`)。`terms` 接受非空陣列,產生 `= ANY($n)`——整個陣列會綁定成**單一**參數,不是每個元素一個參數。`range` 接受 `[lo, hi]` 兩個值,產生 `BETWEEN $n AND $n+1`。
+
+值都是單一值,除了 `terms`(陣列)與 `range`(兩個值);`isnull`/`isnotnull` 不帶值。未知欄位或型別不允許的 operator 會丟 `ColumnQueryError`(`UNKNOWN_COLUMN` / `UNSUPPORTED_OPERATOR`)。
 
 > 跨引擎的 operator 全貌(哪個引擎有 `terms`/`range` 等)請見 [@rfjs/filter-builder](../filter-builder#operator-矩陣) 的矩陣。
 

--- a/packages/sql-filter/src/column/build.spec.ts
+++ b/packages/sql-filter/src/column/build.spec.ts
@@ -17,7 +17,7 @@ describe('buildColumnQuery', () => {
         { column: 'createdAt', operator: 'gte', value: '2026-01-01' },
       ],
     });
-    expect(r.where).toBe('"name" ilike \'%\' || $1 || \'%\' and "created_at" >= $2');
+    expect(r.where).toBe('"name" like \'%\' || $1 || \'%\' escape \'\\\' and "created_at" >= $2');
     expect(r.values).toEqual(['sales', '2026-01-01']);
   });
 

--- a/packages/sql-filter/src/column/operators.spec.ts
+++ b/packages/sql-filter/src/column/operators.spec.ts
@@ -20,9 +20,12 @@ describe('renderColumnCondition', () => {
     expect(render('text', 'neq', 'y')).toEqual({ sql: '"name" <> $1', values: ['y'] });
   });
 
-  it('renders text contains/startswith as parameterized ILIKE', () => {
-    expect(render('text', 'contains', 'ab')).toEqual({ sql: "\"name\" ilike '%' || $1 || '%'", values: ['ab'] });
-    expect(render('text', 'startswith', 'ab')).toEqual({ sql: "\"name\" ilike $1 || '%'", values: ['ab'] });
+  it('renders text contains/startswith as case-sensitive escaped LIKE', () => {
+    expect(render('text', 'contains', 'ab')).toEqual({ sql: "\"name\" like '%' || $1 || '%' escape '\\'", values: ['ab'] });
+    expect(render('text', 'startswith', 'ab')).toEqual({ sql: "\"name\" like $1 || '%' escape '\\'", values: ['ab'] });
+  });
+  it('escapes LIKE metacharacters in the term', () => {
+    expect(render('text', 'contains', '50%_a')).toEqual({ sql: "\"name\" like '%' || $1 || '%' escape '\\'", values: ['50\\%\\_a'] });
   });
 
   it('renders nullary operators without a param', () => {

--- a/packages/sql-filter/src/column/operators.spec.ts
+++ b/packages/sql-filter/src/column/operators.spec.ts
@@ -42,4 +42,29 @@ describe('renderColumnCondition', () => {
     expect(() => render('text', 'isnull', 'x')).toThrow(ColumnQueryError);
     expect(() => render('text', 'eq', undefined)).toThrow(ColumnQueryError);
   });
+
+  it('renders endswith as case-sensitive escaped LIKE', () => {
+    expect(render('text', 'endswith', 'ab')).toEqual({ sql: "\"name\" like '%' || $1 escape '\\'", values: ['ab'] });
+  });
+  it('renders the case-insensitive iX family', () => {
+    expect(render('text', 'ieq', 'AB')).toEqual({ sql: 'lower("name") = lower($1)', values: ['AB'] });
+    expect(render('text', 'ineq', 'AB')).toEqual({ sql: 'lower("name") <> lower($1)', values: ['AB'] });
+    expect(render('text', 'icontains', 'ab')).toEqual({ sql: "\"name\" ilike '%' || $1 || '%' escape '\\'", values: ['ab'] });
+    expect(render('text', 'istartswith', 'ab')).toEqual({ sql: "\"name\" ilike $1 || '%' escape '\\'", values: ['ab'] });
+    expect(render('text', 'iendswith', 'ab')).toEqual({ sql: "\"name\" ilike '%' || $1 escape '\\'", values: ['ab'] });
+  });
+  it('renders terms as = ANY(array)', () => {
+    expect(render('uuid', 'terms', ['a', 'b'])).toEqual({ sql: '"name" = any($1)', values: [['a', 'b']] });
+    expect(render('numeric', 'terms', [1, 2])).toEqual({ sql: '"name" = any($1)', values: [[1, 2]] });
+  });
+  it('renders range as BETWEEN two params', () => {
+    expect(render('numeric', 'range', [1, 9])).toEqual({ sql: '"name" between $1 and $2', values: [1, 9] });
+  });
+  it('validates terms/range value shape and per-type allow-lists', () => {
+    expect(() => render('numeric', 'terms', 5)).toThrow(ColumnQueryError);      // not an array
+    expect(() => render('numeric', 'terms', [])).toThrow(ColumnQueryError);     // empty
+    expect(() => render('numeric', 'range', [1])).toThrow(ColumnQueryError);    // not 2 elements
+    expect(() => render('boolean', 'terms', [true])).toThrow(ColumnQueryError); // not allowed on boolean
+    expect(() => render('text', 'range', ['a', 'b'])).toThrow(ColumnQueryError);// text has no range (D2)
+  });
 });

--- a/packages/sql-filter/src/column/operators.ts
+++ b/packages/sql-filter/src/column/operators.ts
@@ -9,6 +9,14 @@ export type ColumnOperator =
   | 'isnotnull'
   | 'contains'
   | 'startswith'
+  | 'endswith'
+  | 'icontains'
+  | 'istartswith'
+  | 'iendswith'
+  | 'ieq'
+  | 'ineq'
+  | 'terms'
+  | 'range'
   | 'gt'
   | 'gte'
   | 'lt'
@@ -17,11 +25,29 @@ export type ColumnOperator =
 const NULLARY = new Set<ColumnOperator>(['isnull', 'isnotnull']);
 
 const ALLOWED: Record<ColumnType, ReadonlySet<ColumnOperator>> = {
-  text: new Set(['eq', 'neq', 'isnull', 'isnotnull', 'contains', 'startswith', 'gt', 'gte', 'lt', 'lte']),
-  numeric: new Set(['eq', 'neq', 'isnull', 'isnotnull', 'gt', 'gte', 'lt', 'lte']),
-  timestamp: new Set(['eq', 'neq', 'isnull', 'isnotnull', 'gt', 'gte', 'lt', 'lte']),
+  text: new Set([
+    'eq',
+    'neq',
+    'isnull',
+    'isnotnull',
+    'contains',
+    'startswith',
+    'endswith',
+    'icontains',
+    'istartswith',
+    'iendswith',
+    'ieq',
+    'ineq',
+    'terms',
+    'gt',
+    'gte',
+    'lt',
+    'lte',
+  ]),
+  numeric: new Set(['eq', 'neq', 'isnull', 'isnotnull', 'gt', 'gte', 'lt', 'lte', 'terms', 'range']),
+  timestamp: new Set(['eq', 'neq', 'isnull', 'isnotnull', 'gt', 'gte', 'lt', 'lte', 'terms', 'range']),
   boolean: new Set(['eq', 'neq', 'isnull', 'isnotnull']),
-  uuid: new Set(['eq', 'neq', 'isnull', 'isnotnull']),
+  uuid: new Set(['eq', 'neq', 'isnull', 'isnotnull', 'terms']),
 };
 
 const COMPARATORS: Partial<Record<ColumnOperator, string>> = {
@@ -65,6 +91,36 @@ export function renderColumnCondition(
   }
   if (operator === 'startswith') {
     return `${quotedColumn} like ${params.add(escapeLike(String(value)))} || '%' escape '\\'`;
+  }
+  if (operator === 'endswith') {
+    return `${quotedColumn} like '%' || ${params.add(escapeLike(String(value)))} escape '\\'`;
+  }
+  if (operator === 'icontains') {
+    return `${quotedColumn} ilike '%' || ${params.add(escapeLike(String(value)))} || '%' escape '\\'`;
+  }
+  if (operator === 'istartswith') {
+    return `${quotedColumn} ilike ${params.add(escapeLike(String(value)))} || '%' escape '\\'`;
+  }
+  if (operator === 'iendswith') {
+    return `${quotedColumn} ilike '%' || ${params.add(escapeLike(String(value)))} escape '\\'`;
+  }
+  if (operator === 'ieq') {
+    return `lower(${quotedColumn}) = lower(${params.add(value)})`;
+  }
+  if (operator === 'ineq') {
+    return `lower(${quotedColumn}) <> lower(${params.add(value)})`;
+  }
+  if (operator === 'terms') {
+    if (!Array.isArray(value) || value.length === 0) {
+      throw new ColumnQueryError(`Operator "terms" requires a non-empty array`, 'INVALID_VALUE');
+    }
+    return `${quotedColumn} = any(${params.add(value)})`;
+  }
+  if (operator === 'range') {
+    if (!Array.isArray(value) || value.length !== 2) {
+      throw new ColumnQueryError(`Operator "range" requires a [lo, hi] array`, 'INVALID_VALUE');
+    }
+    return `${quotedColumn} between ${params.add(value[0])} and ${params.add(value[1])}`;
   }
   const comparator = COMPARATORS[operator];
   if (comparator === undefined) {

--- a/packages/sql-filter/src/column/operators.ts
+++ b/packages/sql-filter/src/column/operators.ts
@@ -105,10 +105,10 @@ export function renderColumnCondition(
     return `${quotedColumn} ilike '%' || ${params.add(escapeLike(String(value)))} escape '\\'`;
   }
   if (operator === 'ieq') {
-    return `lower(${quotedColumn}) = lower(${params.add(value)})`;
+    return `lower(${quotedColumn}) = lower(${params.add(String(value))})`;
   }
   if (operator === 'ineq') {
-    return `lower(${quotedColumn}) <> lower(${params.add(value)})`;
+    return `lower(${quotedColumn}) <> lower(${params.add(String(value))})`;
   }
   if (operator === 'terms') {
     if (!Array.isArray(value) || value.length === 0) {

--- a/packages/sql-filter/src/column/operators.ts
+++ b/packages/sql-filter/src/column/operators.ts
@@ -33,6 +33,11 @@ const COMPARATORS: Partial<Record<ColumnOperator, string>> = {
   lte: '<=',
 };
 
+// Escape LIKE metacharacters so the bound term matches verbatim (paired with ESCAPE '\').
+function escapeLike(v: string): string {
+  return v.replace(/[\\%_]/g, (ch) => `\\${ch}`);
+}
+
 export function renderColumnCondition(
   quotedColumn: string,
   type: ColumnType,
@@ -56,10 +61,10 @@ export function renderColumnCondition(
     throw new ColumnQueryError(`Operator "${operator}" requires a value`, 'INVALID_VALUE');
   }
   if (operator === 'contains') {
-    return `${quotedColumn} ilike '%' || ${params.add(value)} || '%'`;
+    return `${quotedColumn} like '%' || ${params.add(escapeLike(String(value)))} || '%' escape '\\'`;
   }
   if (operator === 'startswith') {
-    return `${quotedColumn} ilike ${params.add(value)} || '%'`;
+    return `${quotedColumn} like ${params.add(escapeLike(String(value)))} || '%' escape '\\'`;
   }
   const comparator = COMPARATORS[operator];
   if (comparator === undefined) {


### PR DESCRIPTION
## Summary

Brings the `@rfjs/sql-filter` **column path** to operator parity with the jsonb path, and fixes a LIKE-wildcard bug along the way.

### ① ILIKE bug fix (`packages/sql-filter/src/column/operators.ts`)
`contains`/`startswith` emitted `ILIKE` with the term concatenated around literal `%` wildcards, never escaping `%`/`_` in the term (so `50%` / `a_b` over-matched) and always case-insensitive. Now:
- case-**sensitive** `LIKE` with an `escapeLike` helper (escapes `\`/`%`/`_`) + `ESCAPE '\'` clause — aligning with `jsonb-query` / `data-filter` (which are case-sensitive; case-insensitivity lives in the `iX` family).

### ② New column operators (per-type, matching jsonb)
- `endswith`; `terms` → `= ANY($1)` (array bound as one param); `range` → `BETWEEN $1 AND $2`; and the case-insensitive `iX` family (`ieq`/`ineq` via `lower()`, `icontains`/`istartswith`/`iendswith` via escaped `ILIKE`).
- Per-type allow-lists: **text** +endswith/terms/iX (no range); **numeric/timestamp** +terms/range; **uuid** +terms; **boolean** unchanged.

### Editor wiring — both filter-builder engine adapters
`endswith`/`terms`/`range`/`iX` are now offered by **both** `engines/sql-filter.ts` and `engines/pg-filter.ts` (the adapter the workbench dataset-explorer uses). Each adapter's offered set exactly equals the renderer's `ALLOWED`, so the UI never offers an op the renderer rejects. `es-query`/`mongo-query` untouched (their divergent vocab is deliberately map-insulated).

**Out of scope (deferred):** narrowing the canonical `operator: string` to a union type for compile-time rename safety.

## Testing
- Plan adversarially verified pre-implementation (ultracode) — **3 defects fixed into the plan** before any code, incl. the pg-filter engine adapter (the workbench's) being missed, and a to-be-broken negative test assertion.
- Subagent-driven, fresh implementer + review per task; final whole-branch review on Opus: **Ready to merge, 0 Critical / 0 Important** (parity confirmed directly against the jsonb legacy dialect).
- Green: `@rfjs/sql-filter` 29 tests, `@rfjs/filter-builder` 100, `@rfjs/pg-filter` 19 (mixed column+jsonb regression) — all + `typecheck`.

## Changeset
`@rfjs/sql-filter` minor, `@rfjs/filter-builder` minor, `@rfjs/pg-filter` patch.

## Docs
Spec + plan under `docs/superpowers/{specs,plans}/2026-07-15-sql-filter-operators*` (zh-TW). The cross-engine operator matrix is in #256.

🤖 Generated with [Claude Code](https://claude.com/claude-code)