### PR TITLE
fix(es-query): escape wildcard metachars + move form-builder AI panel above tabs

### DIFF
--- a/.changeset/es-query-wildcard-escape.md
+++ b/.changeset/es-query-wildcard-escape.md
@@ -1,0 +1,8 @@
+---
+"@rfjs/es-query": patch
+---
+
+Escape `*`/`?`/`\` in the search term for `contains` and `endsWith` (which compile
+to ES `wildcard` queries) so a literal term containing those characters is matched
+verbatim instead of being interpreted as wildcards. `startsWith` was already safe
+(it compiles to a `prefix` query).

--- a/.changeset/form-builder-ai-above-tabs.md
+++ b/.changeset/form-builder-ai-above-tabs.md
@@ -1,0 +1,7 @@
+---
+"web": patch
+---
+
+Move the form-builder AI Assist panel above the Canvas/Preview/JSON tabs, matching
+table-builder / metadata-builder (AI panel above the tab strip) for a consistent
+tool layout.

--- a/apps/web/src/tools/form-builder/ui.tsx
+++ b/apps/web/src/tools/form-builder/ui.tsx
@@ -520,7 +520,6 @@ export function FormBuilderTool() {
         ]}
         labels={{ expand: t("introExpand"), collapse: t("introCollapse"), dismiss: t("introDismiss") }}
       />
-      <ToolTabs tabs={TABS} active={tab} onChange={(id) => setTab(id as "canvas" | "preview" | "json")} />
 
       <AiPanel
         title={t("aiBlockTitle")}
@@ -592,6 +591,8 @@ export function FormBuilderTool() {
           },
         ]}
       />
+
+      <ToolTabs tabs={TABS} active={tab} onChange={(id) => setTab(id as "canvas" | "preview" | "json")} />
 
       {tab === "canvas" ? (
         <>

--- a/packages/es-query/src/toClause.spec.ts
+++ b/packages/es-query/src/toClause.spec.ts
@@ -42,6 +42,9 @@ describe('toClause', () => {
       .toEqual({ wildcard: { name: { value: '*a\\*b\\?c*' } } });
     expect(toClause({ field: 'name', condition: 'endsWith', value: 'a*b' }, ES))
       .toEqual({ wildcard: { name: { value: '*a\\*b' } } });
+    // a literal backslash in the term must itself be escaped
+    expect(toClause({ field: 'name', condition: 'contains', value: 'a\\b' }, ES))
+      .toEqual({ wildcard: { name: { value: '*a\\\\b*' } } });
   });
   it('startsWith → prefix', () => {
     expect(toClause({ field: 'name', condition: 'startsWith', value: 'fo' }, ES))

--- a/packages/es-query/src/toClause.spec.ts
+++ b/packages/es-query/src/toClause.spec.ts
@@ -37,6 +37,12 @@ describe('toClause', () => {
     expect(toClause({ field: 'name', condition: 'contains', value: 'foo' }, ES))
       .toEqual({ wildcard: { name: { value: '*foo*' } } });
   });
+  it('contains/endsWith escape * and ? in the term (not treated as wildcards)', () => {
+    expect(toClause({ field: 'name', condition: 'contains', value: 'a*b?c' }, ES))
+      .toEqual({ wildcard: { name: { value: '*a\\*b\\?c*' } } });
+    expect(toClause({ field: 'name', condition: 'endsWith', value: 'a*b' }, ES))
+      .toEqual({ wildcard: { name: { value: '*a\\*b' } } });
+  });
   it('startsWith → prefix', () => {
     expect(toClause({ field: 'name', condition: 'startsWith', value: 'fo' }, ES))
       .toEqual({ prefix: { name: 'fo' } });

--- a/packages/es-query/src/toClause.ts
+++ b/packages/es-query/src/toClause.ts
@@ -3,6 +3,11 @@ import * as c from './clauses';
 import { EsQueryError, UnsupportedClauseError } from './errors';
 import type { EsClause, EsDialect, EsFieldCondition } from './types';
 
+/** Escape ES wildcard metacharacters (`*` `?` `\`) so a literal term isn't treated as a pattern. */
+function escapeWildcard(v: string): string {
+  return v.replace(/[\\*?]/g, (ch) => `\\${ch}`);
+}
+
 /** Clauses unavailable on a given dialect. */
 const DIALECT_UNSUPPORTED: Record<EsDialect, Set<string>> = {
   elasticsearch: new Set<string>(),
@@ -49,11 +54,11 @@ export function toClause(cond: EsFieldCondition, dialect: EsDialect): EsClause {
     case 'between':
       return c.range(field, { gte: values[0], lte: values[1] });
     case 'contains':
-      return c.wildcard(field, `*${String(first)}*`);
+      return c.wildcard(field, `*${escapeWildcard(String(first))}*`);
     case 'startsWith':
       return c.prefix(field, first);
     case 'endsWith':
-      return c.wildcard(field, `*${String(first)}`);
+      return c.wildcard(field, `*${escapeWildcard(String(first))}`);
     case 'exists':
       return c.exists(field);
     case 'isNull':


### PR DESCRIPTION
Two small, independent wins.

## 1. `@rfjs/es-query` — escape wildcard metacharacters (correctness)
`contains` / `endsWith` compile to ES `wildcard` queries with the search term interpolated into a `*…*` / `*…` pattern. The term's own `*` / `?` were treated as wildcards → over-match (e.g. searching `a*b` matched anything containing `a` then `b`). Add `escapeWildcard` (escapes `\` `*` `?`, single-pass) applied to both. `startsWith` is unaffected — it compiles to a `prefix` query (no wildcard interpretation); `regex` intentionally keeps the term as-is.

## 2. form-builder — AI panel above the tabs (consistency)
Move `AiPanel` above the Canvas/Preview/JSON `ToolTabs` so it matches table-builder / metadata-builder (AI panel above the tab strip). Pure JSX reorder — the panel still renders once, unconditionally.

## Testing
- `@rfjs/es-query`: 28 tests (new cases: `*`/`?` and a literal `\` escaped) + `typecheck` green.
- `web`: 118 form-builder tests + `check-types` green; reorder screenshot-verified (AI above tabs).
- Opus review: **ready to merge, 0 Critical / 0 Important** — verified `c.wildcard` is the only wildcard sink and the reorder has no order-dependent assertions.

## Changeset
`@rfjs/es-query` patch, `web` patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)