### PR TITLE
fix(jwt): default-import CJS-only jsonwebtoken for ESM consumers

### DIFF
--- a/.changeset/gov-jwt-esm-cjs.md
+++ b/.changeset/gov-jwt-esm-cjs.md
@@ -1,0 +1,5 @@
+---
+"@rfjs/jwt": patch
+---
+
+Fix ESM build to default-import CJS-only `jsonwebtoken` so ESM consumers no longer hit `SyntaxError: Named export 'sign' not found`.

--- a/packages/jwt/src/jwt.ts
+++ b/packages/jwt/src/jwt.ts
@@ -1,13 +1,17 @@
-import {
-  sign,
-  verify,
-  decode,
+import jwt from 'jsonwebtoken';
+import type {
   Jwt as DecodedJwt,
   JwtPayload,
   VerifyErrors,
   SignOptions,
   VerifyOptions,
 } from 'jsonwebtoken';
+
+// `jsonwebtoken@9` is CJS-only (no `exports`, no ESM named exports), so a
+// named `import { sign, ... }` fails under Node/vitest ESM with
+// `SyntaxError: Named export 'sign' not found`. Take the default (the CJS
+// `module.exports`) and destructure the functions off it instead.
+const { sign, verify, decode } = jwt;
 
 export type Secret = string | Buffer;
 


### PR DESCRIPTION
Named imports from the CJS-only `jsonwebtoken` were emitted verbatim into `dist/index.mjs`, so any ESM consumer failed to load `@rfjs/jwt` with `SyntaxError: Named export 'sign' not found`. Switch to a default import + destructure (types stay `import type`).

Verified: 16 tests + typecheck green, plus an ESM smoke-import of the built dist.

Changeset: `@rfjs/jwt` patch.

Closes #264

_Governa dogfood #19._

🤖 Generated with [Claude Code](https://claude.com/claude-code)