### PR TITLE
feat(pg-filter): expose paramOffset on buildPgFilter

### DIFF
--- a/.changeset/gov-pg-filter-paramoffset.md
+++ b/.changeset/gov-pg-filter-paramoffset.md
@@ -1,0 +1,5 @@
+---
+"@rfjs/pg-filter": minor
+---
+
+buildPgFilter now accepts an optional `paramOffset` so its `$N` placeholders can start after an app-owned WHERE fragment (RLS, multi-tenancy, visibility pushdown).

--- a/packages/pg-filter/README.md
+++ b/packages/pg-filter/README.md
@@ -65,6 +65,32 @@ const total = await client.query(`SELECT count(*) FROM datasets WHERE ${where}`,
 - `where` is never empty (`'true'` when there's no filter); `orderBy` is `''` when there's no sort.
 - `values` = WHERE params **++** ORDER BY params (for the main query). `countValues` = WHERE params only (a prefix of `values`) — use it for the `COUNT(*)` query.
 
+### Composing an app-owned fragment (`paramOffset`)
+
+Pass `paramOffset: k` to start every `$N` placeholder at `$(k + 1)` instead of `$1`,
+so you can AND an app-owned SQL fragment (RLS, multi-tenancy, visibility pushdown)
+that already consumed `$1..$k` **before** the generated `where` / `orderBy`. It only
+shifts the numbering — `values` / `countValues` are unchanged, and `limit` / `offset`
+are interpolated as SQL literals (they never enter the parameter array).
+
+```ts
+const scope = [tenantId]; // your fragment owns $1
+const { where, orderBy, values, countValues } = buildPgFilter(config, {
+  filter,
+  sort,
+  paramOffset: scope.length, // generated placeholders now start at $2
+});
+
+const rows = await client.query(
+  `SELECT * FROM datasets WHERE tenant_id = $1 AND (${where})${orderBy ? ` ORDER BY ${orderBy}` : ""}`,
+  [...scope, ...values],
+);
+const total = await client.query(
+  `SELECT count(*) FROM datasets WHERE tenant_id = $1 AND (${where})`,
+  [...scope, ...countValues],
+);
+```
+
 ## Leaf & sort shapes
 
 ```ts

--- a/packages/pg-filter/README.zh-TW.md
+++ b/packages/pg-filter/README.zh-TW.md
@@ -59,6 +59,31 @@ const total = await client.query(`SELECT count(*) FROM datasets WHERE ${where}`,
 - `where` 永不為空(無條件時為 `'true'`);`orderBy` 無排序時為 `''`。
 - `values` = WHERE 參數 **++** ORDER BY 參數(主查詢用);`countValues` = 只有 WHERE 參數(是 `values` 的前綴)—— 給 `COUNT(*)` 查詢用。
 
+### 疊上應用自己的片段(`paramOffset`)
+
+傳入 `paramOffset: k`,可讓每個 `$N` 佔位符從 `$(k + 1)` 開始(而非 `$1`),
+這樣你就能把應用自己、已經吃掉 `$1..$k` 的 SQL 片段(RLS、多租戶、可見性下推)
+接在產生的 `where` / `orderBy` **之前** 用 AND 串起來。它只調整編號 ——
+`values` / `countValues` 不變,`limit` / `offset` 則是以 SQL 字面值內插(永不進入參數陣列)。
+
+```ts
+const scope = [tenantId]; // 你的片段擁有 $1
+const { where, orderBy, values, countValues } = buildPgFilter(config, {
+  filter,
+  sort,
+  paramOffset: scope.length, // 產生的佔位符現在從 $2 開始
+});
+
+const rows = await client.query(
+  `SELECT * FROM datasets WHERE tenant_id = $1 AND (${where})${orderBy ? ` ORDER BY ${orderBy}` : ""}`,
+  [...scope, ...values],
+);
+const total = await client.query(
+  `SELECT count(*) FROM datasets WHERE tenant_id = $1 AND (${where})`,
+  [...scope, ...countValues],
+);
+```
+
 ## Leaf 與 sort 結構
 
 ```ts

--- a/packages/pg-filter/src/build.spec.ts
+++ b/packages/pg-filter/src/build.spec.ts
@@ -40,4 +40,38 @@ describe('buildPgFilter', () => {
     expect(res.limit).toBe(10);
     expect(res.offset).toBe(10);
   });
+
+  it('shifts placeholders by paramOffset while leaving values unchanged', () => {
+    const input = {
+      filter: {
+        logic: 'and' as const,
+        filters: [{ target: 'column' as const, column: 'name', operator: 'contains' as const, value: 'cust' }],
+      },
+      sort: [{ target: 'jsonb' as const, field: 'score', dataType: 'numeric' as const, direction: 'desc' as const }],
+    };
+    const base = buildPgFilter(config, input);
+    const offset = buildPgFilter(config, { ...input, paramOffset: 3 });
+
+    // WHERE param moves $1 → $4, ORDER BY jsonb path param moves $2 → $5
+    expect(base.where).toContain('$1');
+    expect(base.orderBy).toContain('$2');
+    expect(offset.where).toContain('$4');
+    expect(offset.where).not.toContain('$1');
+    expect(offset.orderBy).toContain('$5');
+    expect(offset.orderBy).not.toContain('$2');
+
+    // values payload is identical — only the $N numbering changed
+    expect(offset.values).toEqual(base.values);
+    expect(offset.countValues).toEqual(base.countValues);
+  });
+
+  it('treats paramOffset: 0 as the default (no shift)', () => {
+    const input = {
+      filter: {
+        logic: 'and' as const,
+        filters: [{ target: 'column' as const, column: 'name', operator: 'eq' as const, value: 'x' }],
+      },
+    };
+    expect(buildPgFilter(config, { ...input, paramOffset: 0 })).toEqual(buildPgFilter(config, input));
+  });
 });

--- a/packages/pg-filter/src/build.ts
+++ b/packages/pg-filter/src/build.ts
@@ -6,8 +6,13 @@ import type { PgFilterConfig, PgFilterGroup, PgFilterInput, PgFilterResult } fro
 const MATCH_ALL: PgFilterGroup = { logic: 'and', filters: [] };
 
 export function buildPgFilter(config: PgFilterConfig, input: PgFilterInput): PgFilterResult {
-  const { where, values: whereValues } = buildPgWhere(config, input.filter ?? MATCH_ALL, 0);
-  const { orderBy, values: orderByValues } = buildPgOrderBy(config, input.sort ?? [], whereValues.length);
+  const paramOffset = input.paramOffset ?? 0;
+  const { where, values: whereValues } = buildPgWhere(config, input.filter ?? MATCH_ALL, paramOffset);
+  const { orderBy, values: orderByValues } = buildPgOrderBy(
+    config,
+    input.sort ?? [],
+    paramOffset + whereValues.length,
+  );
   const { limit, offset } = computeLimitOffset({ page: input.page, pageSize: input.pageSize });
   return {
     where,

--- a/packages/pg-filter/src/types.ts
+++ b/packages/pg-filter/src/types.ts
@@ -48,6 +48,14 @@ export interface PgFilterInput {
   sort?: PgSort[];
   page?: number; // 1-based; default 1
   pageSize?: number; // omit → no LIMIT
+  /**
+   * Number of parameters already consumed by an app-owned SQL fragment placed
+   * *before* this filter. Placeholders in `where`/`orderBy` then start at
+   * `$(paramOffset + 1)` instead of `$1`, so the emitted SQL + `values` can be
+   * concatenated after that fragment (RLS, multi-tenancy, visibility pushdown).
+   * Default `0`. Does not change the `values` payload, only the `$N` numbering.
+   */
+  paramOffset?: number;
 }
 
 export interface PgFilterResult {


### PR DESCRIPTION
`buildPgFilter` started placeholders at `$1`, forcing consumers composing an app-owned WHERE fragment (RLS / multi-tenancy / visibility pushdown) to reverse-engineer the values layout. Add optional `paramOffset` — where/orderBy placeholders start at `$(offset+1)`, `values` unchanged.

Verified: 21 tests (incl. non-zero offset) + typecheck green; README (en + zh-TW) documents composing a fragment.

Changeset: `@rfjs/pg-filter` minor.

Closes #277

_Governa dogfood #27._

🤖 Generated with [Claude Code](https://claude.com/claude-code)