### PR TITLE
docs: refresh filter-operator matrix + document configToZod/zod-dts gotchas

### DIFF
--- a/.changeset/gov-docs-form-builder.md
+++ b/.changeset/gov-docs-form-builder.md
@@ -1,0 +1,8 @@
+---
+"@rfjs/form-builder": patch
+---
+
+Docs: document `configToZod`'s boolean/`Switch` coercion behaviour — `Switch` /
+`dataType: 'boolean'` fields map to a plain `z.boolean()` with no string coercion
+(consumers must send a real JSON boolean), and clarify the built-in
+`emptyToUndefined` empty-value guard so consumers don't rebuild that layer.

--- a/.changeset/gov-docs-tpl-toolkit.md
+++ b/.changeset/gov-docs-tpl-toolkit.md
@@ -1,0 +1,7 @@
+---
+"@rfjs/tpl-toolkit": patch
+---
+
+Docs: note that exported Zod builders (especially recursive `z.lazy` ones) need an
+explicit `z.ZodType<T>` annotation under the tsdown `dts` output path and can't rely
+on inference — a build-toolchain gotcha for consumers copying the rfjs pattern.

--- a/docs/filter-operator-matrix.md
+++ b/docs/filter-operator-matrix.md
@@ -5,7 +5,7 @@ identifier each engine uses for each concept, what each engine supports, and whe
 operator-name translation happens. See also the "Filter / Query-Builder Package Stack"
 section of [`CLAUDE.md`](../CLAUDE.md).
 
-> Snapshot: 2026-07-15 (`main` @ `ec0c8b2`). Regenerate if the engines' operator sets change.
+> Snapshot: 2026-07-29 (`main` @ `a16fef1`). Regenerate if the engines' operator sets change.
 
 ## How operators are wired
 
@@ -46,20 +46,20 @@ from the canonical spelling for the same concept.
 |---|---|---|---|---|---|---|
 | equals | `eq` | `eq` | `eq` | `eq` | `eq` | `eq` |
 | notEquals | `neq` | `neq` | `neq` | `neq` | `neq` | `neq` |
-| in / anyOf | `terms` | — | `terms` | `terms` | `terms` (+`term`) | **`in`** |
+| in / anyOf | `terms` | `terms` | `terms` | `terms` | `terms` (+`term`) | **`in`** |
 | notIn | `nin` | — | — | — | `nin` | **`notIn`** |
-| between | `range` | — | `range` | `range` | `range` | **`between`** |
-| contains (substring) | `contains` | `contains` ⚠ | `contains` | `contains` | →`regex` | `contains` |
-| startsWith | `startswith` | `startswith` ⚠ | `startswith` | `startswith` | →`regex` | **`startsWith`** |
-| endsWith | `endswith` | — | `endswith` | `endswith` | →`regex` | **`endsWith`** |
+| between | `range` | `range` | `range` | `range` | `range` | **`between`** |
+| contains (substring) | `contains` | `contains` | `contains` | `contains` | →`regex` | `contains` |
+| startsWith | `startswith` | `startswith` | `startswith` | `startswith` | →`regex` | **`startsWith`** |
+| endsWith | `endswith` | `endswith` | `endswith` | `endswith` | →`regex` | **`endsWith`** |
 | gt / gte / lt / lte | `gt`/`gte`/`lt`/`lte` | same | same | same | same | same |
 | isNull | `isnull` | `isnull` | `isnull` | `isnull` | →`eq` null | **`isNull`** |
 | isNotNull | `isnotnull` | `isnotnull` | `isnotnull` | `isnotnull` | →`neq` null | **`exists`** |
-| ci equals | `ieq` | — | `ieq` | — | — | — |
-| ci notEquals | `ineq` | — | `ineq` | — | — | — |
-| ci contains | `icontains` | — | `icontains` | — | — | — |
-| ci startsWith | `istartswith` | — | `istartswith` | — | — | — |
-| ci endsWith | `iendswith` | — | `iendswith` | — | — | — |
+| ci equals | `ieq` | `ieq` | `ieq` | — | — | — |
+| ci notEquals | `ineq` | `ineq` | `ineq` | — | — | — |
+| ci contains | `icontains` | `icontains` | `icontains` | — | — | — |
+| ci startsWith | `istartswith` | `istartswith` | `istartswith` | — | — | — |
+| ci endsWith | `iendswith` | `iendswith` | `iendswith` | — | — | — |
 | containsAll | `containsall` | — | `containsall` | `containsall` | — | — |
 | isEmpty | `isempty` | — | `isempty` | — | — | — |
 | isNotEmpty | `isnotempty` | — | `isnotempty` | — | — | — |
@@ -70,15 +70,16 @@ from the canonical spelling for the same concept.
 | regex | *(none)* | — | — | — | `regex` | `regex` |
 | logic | `and`/`or`/`nor`/`not` | (tree layer) | all | all | `and`/`or`/`nor` (no `not`) | all |
 
-⚠ = the `sql-filter` column path has an ILIKE-wildcard issue on `contains`/`startswith`
-(see below).
-
 ## Per-engine notes
 
 - **`sql-filter`** — the tree layer (`FilterGroup<L>`) is operator-agnostic (only `and/or/nor/not`
   + a pluggable `renderLeaf`). The built-in **column** vocabulary (`sql-filter/src/column/operators.ts`)
-  is just `eq, neq, isnull, isnotnull, contains, startswith, gt, gte, lt, lte` — no
-  `terms`/`range`/`endswith`/`iX`/object/array ops (those throw `UNSUPPORTED_OPERATOR`).
+  covers scalar comparisons (`eq, neq, gt, gte, lt, lte`), null checks (`isnull, isnotnull`), the
+  LIKE text ops (`contains, startswith, endswith`), the case-insensitive `iX` family
+  (`ieq, ineq, icontains, istartswith, iendswith`), and `terms`/`range` — all **type-scoped** via
+  `ALLOWED` (e.g. LIKE + `iX` are text-only, `range` is numeric/timestamp, `boolean` allows only
+  `eq/neq/isnull/isnotnull`). Object/array ops (`haskey`/`containsall`/`isempty`/`elemmatch`) are
+  not supported and throw `UNSUPPORTED_OPERATOR`.
 - **`jsonb-query`** — the widest set and the canonical spelling: scalar + `terms`/`range`/`iX`
   family, object ops (`haskey`/…), array ops (`containsall`/`isempty`/`elemmatch`). Two
   dialects (`legacy` `#>>`+cast, `jsonpath` for PG12+).
@@ -91,16 +92,18 @@ from the canonical spelling for the same concept.
 - **`es-query`** — deliberately divergent native vocab to match ES conventions (`in`, `notIn`,
   `between`, camelCase `startsWith/endsWith`, `isNull`/`exists`, plus `match`/`fuzzy`/… ES-only).
 
-## Known issues
+## Wildcard / LIKE escaping
 
-- **`sql-filter` column ILIKE wildcards** (`sql-filter/src/column/operators.ts`): `contains`/
-  `startswith` concatenate literal `%` wildcards around the bound term but never escape `%`/`_`
-  in the term and add no `ESCAPE` clause — so a term like `50%` or `a_b` over-matches. It also
-  uses `ilike` (case-insensitive) unconditionally, diverging from jsonb-query's case-*sensitive*
-  `contains`/`startswith` (jsonb reserves case-insensitivity to the `iX` family). `jsonb-query`
-  and `data-filter` are not affected (they don't use LIKE).
-- **`es-query` wildcards** (`es-query/src/toClause.ts`): `contains`/`endsWith` build `*term*`/
-  `*term` patterns without escaping `*`/`?` in the term — an analogous (separate) concern.
+- **`sql-filter` column** (`sql-filter/src/column/operators.ts`): the LIKE-based text ops
+  (`contains`/`startswith`/`endswith`) escape `%`/`_`/`\` in the bound term and emit an
+  `ESCAPE '\'` clause, so a term like `50%` or `a_b` matches verbatim. These three are
+  case-**sensitive** (`like`), matching jsonb-query's `contains`/`startswith`/`endswith`;
+  case-insensitivity lives in the separate `iX` family (`icontains`/`istartswith`/`iendswith`
+  → `ilike`, `ieq`/`ineq` → `lower(col) …`).
+- **`es-query`** (`es-query/src/toClause.ts`): `contains`/`endsWith` escape the ES wildcard
+  metachars (`*`/`?`/`\`) in the term before building the `*term*`/`*term` pattern (`startsWith`
+  uses a prefix query, so no wildcard escaping is needed).
+- `jsonb-query` and `data-filter` don't use SQL `LIKE` or ES wildcards, so neither concern applies.
 
 ## Where translation happens (rename blast radius)
 

--- a/packages/form-builder/README.md
+++ b/packages/form-builder/README.md
@@ -64,3 +64,17 @@ schema.safeParse({ name: '', agree: true, role: 'user' });
 - **Required numeric**: empty string `''` fails (preprocessed to `undefined` before `z.coerce.number()` rejects it).
 - **Optional fields**: any `''` input is coerced to `undefined`; the key is omitted from the parsed output (never `0` or `''`).
 - **Select / enum**: validated against `options` at all times; an invalid value (including `''`) always fails a required field.
+
+### Coercion vs. empty-value handling
+
+Two behaviours are easy to conflate but are deliberately separate:
+
+- **Boolean / `Switch` — no string coercion.** Only `Number` / `dataType: 'numeric'` fields get
+  `z.coerce.number()`. A `Switch` (or any `dataType: 'boolean'`) field maps to a plain `z.boolean()`,
+  which does **not** coerce strings — sending the string `"true"` fails validation. The delivery/UI
+  layer must send a real JSON boolean (e.g. back a controlled boolean value in the form), not a string.
+- **`emptyToUndefined` — built-in empty-value guard.** `configToZod` preprocesses every field so an
+  empty string `''` becomes `undefined` before validation. For a required `Number` this means
+  `'' → undefined → rejected by required`; for optional fields the key is simply omitted. This is
+  generic empty-value handling (not type coercion), so consumers **don't** need their own pre-submit
+  empty-string cleanup — the schema already covers it.

--- a/packages/tpl-toolkit/README.md
+++ b/packages/tpl-toolkit/README.md
@@ -26,6 +26,29 @@ const appConfig = createTsdownConfig('app', { entry: './src/main.ts' });
 
 Config types: `'app' | 'lib' | 'bin' | 'orm' | 'bullmq'`
 
+> **Gotcha — exported Zod builders need an explicit `z.ZodType<T>` annotation under the tsdown
+> `dts` output.** When a package built with `createTsdownConfig` exports a Zod schema whose type
+> tsdown can't fully name — most commonly a **recursive** `z.lazy(...)` builder — dts emission can
+> fail or emit an unusable type because it can't infer the schema's type from itself. Declare the
+> shape as an `interface` first and annotate the export with an explicit `z.ZodType<T>`, rather than
+> relying on inference:
+>
+> ```typescript
+> interface Category {
+>   name: string;
+>   children: Category[];
+> }
+>
+> // Explicit annotation — required so tsdown's dts output can name the type.
+> export const categorySchema: z.ZodType<Category> = z.lazy(() =>
+>   z.object({ name: z.string(), children: z.array(categorySchema) }),
+> );
+> ```
+>
+> This is a tsdown dts-build constraint, not a Zod one: the same pattern compiles without the
+> annotation under other build paths (e.g. an app/lib whose types are emitted by `tsc`), so it's
+> easy to miss until an external consumer copies the pattern into a tsdown-built package.
+
 ### `createVitestConfig(overrides)`
 
 Create a Vitest test configuration with sensible defaults.


### PR DESCRIPTION
Three Governa doc findings:

- **#281** — `docs/filter-operator-matrix.md` was stale: 8 sql-filter column cells understated support (they predated the operator expansion). Corrected the cells, moved the snapshot marker to current `main`, and removed the now-fixed `⚠`/"Known issues" section (the ILIKE-wildcard and es-query-wildcard bugs are fixed on main).
- **#274** — documented `configToZod`'s boolean/Switch coercion (no string coercion for booleans; `emptyToUndefined` handles empties) in the form-builder README.
- **#275** — noted that exported Zod builders need an explicit `z.ZodType<T>` annotation under tsdown dts (tpl-toolkit README).

Changesets: `@rfjs/form-builder` + `@rfjs/tpl-toolkit` patch (the matrix is pure `docs/`, no package).

Closes #281
Closes #274
Closes #275

_Governa dogfood #33 / #11+#18 / #12._

🤖 Generated with [Claude Code](https://claude.com/claude-code)