### PR TITLE
feat(data-filter,filter-builder): operator contract cluster (i-family, validator, arity)

### DIFF
--- a/.changeset/gov-filter-data-filter.md
+++ b/.changeset/gov-filter-data-filter.md
@@ -1,0 +1,14 @@
+---
+"@rfjs/data-filter": minor
+---
+
+Add the full case-insensitive text operator family for the `string` dataType —
+`icontains`, `istartswith`, `iendswith`, `ieq`, `ineq` (both sides coerced with
+`String(...)` then lower-cased, so a numeric/boolean/date operand never throws),
+matching the vocabulary already exposed by the SQL/JSONB engines so filter trees
+stay portable. The `∃` substring i-ops (`icontains`/`istartswith`/`iendswith`)
+are also allowed on `string`-element arrays (evaluated per-element). Also
+document the `array` membership vocabulary (`terms` = any-membership,
+`containsall` = all-membership, `eq` = single membership, `contains` =
+per-element substring by design) in the README so membership isn't confused with
+substring matching.

--- a/.changeset/gov-filter-filter-builder.md
+++ b/.changeset/gov-filter-filter-builder.md
@@ -1,0 +1,10 @@
+---
+"@rfjs/filter-builder": minor
+---
+
+Add `validateTree(tree, schema, options?)` with per-node error reporting;
+unify `contains` arity to `one` across all engine adapters (cross-engine
+portability); expose the full case-insensitive i-family
+(`icontains`/`istartswith`/`iendswith`/`ieq`/`ineq`) in the data-filter engine
+for cross-engine parity; and surface a malformed condition from `runLiveMatch`
+as a distinct `invalid` flag instead of collapsing it into `uncoverable`.

--- a/packages/data-filter/README.md
+++ b/packages/data-filter/README.md
@@ -80,9 +80,15 @@ resolvePath(data, 'user.missing', { fallbackOnEmpty: false }); // null instead o
 |----------|-----------|
 | Default | `eq`, `neq`, `isnull`, `isnotnull` |
 | Text | `contains`, `startswith`, `endswith`, `terms` |
+| Text (case-insensitive) | `icontains`, `istartswith`, `iendswith`, `ieq`, `ineq` |
 | Numeric | `gt`, `gte`, `lt`, `lte`, `range`, `terms` |
 | Date | `gt`, `gte`, `lt`, `lte`, `range`, `terms` |
 | Boolean | `eq`, `neq`, `isnull`, `isnotnull` |
+
+The `i*` text operators are the case-insensitive counterparts of their base
+operators (both sides are lower-cased before comparison); they match the
+`contains`/`startswith`/`endswith`/`eq`/`neq` vocabulary exposed by the SQL and
+JSONB engines, so a filter tree stays portable across engines.
 
 **Logic operators**: `and`, `or`, `nor`, `not`
 
@@ -114,6 +120,24 @@ matchQuery(data, wrap({
   ] },
 }));
 ```
+
+#### `array` membership vs substring — pick the right operator
+
+For an `array` dataType, choose the operator by intent — **`contains` is
+substring, not membership**:
+
+| Operator | Meaning | Semantics |
+|----------|---------|-----------|
+| `eq` | single membership / 單一成員 | `∃` element **exactly equal** to the value |
+| `terms` | any-membership / 任一成員 | `∃` element exactly equal to **any** of the values (cross-engine portable) |
+| `containsall` | all-membership / 全部成員 | **every** value has an exactly-equal element |
+| `contains` | per-element substring / 逐元素子字串 (NOT membership) | `∃` element that **substring-contains** the value |
+
+So `contains 'manager'` matches a `'skip_manager'` role (substring), whereas
+`terms 'manager'` / `eq 'manager'` do not (exact membership). Use `terms` (any)
+or `containsall` (all) for membership; reserve `contains` for genuine substring
+search. `terms` is the membership operator that stays portable across the SQL
+and JSONB engines.
 
 `array` `neq` is excluded (use `not` + `eq` for "does not contain"). Wildcard/jsonpath
 `field` forms (`users[*].x`) are **not supported and throw** — compose with

--- a/packages/data-filter/README.zh-TW.md
+++ b/packages/data-filter/README.zh-TW.md
@@ -79,9 +79,13 @@ resolvePath(data, 'user.missing', { fallbackOnEmpty: false }); // null instead o
 |------|--------|
 | 預設 | `eq`, `neq`, `isnull`, `isnotnull` |
 | 文字 | `contains`, `startswith`, `endswith`, `terms` |
+| 文字(不分大小寫) | `icontains`, `istartswith`, `iendswith`, `ieq`, `ineq` |
 | 數值 | `gt`, `gte`, `lt`, `lte`, `range`, `terms` |
 | 日期 | `gt`, `gte`, `lt`, `lte`, `range`, `terms` |
 | 布林 | `eq`, `neq`, `isnull`, `isnotnull` |
+
+`i*` 文字運算子是對應基礎運算子的不分大小寫版本(比對前兩側都轉小寫),與 SQL、JSONB
+引擎所提供的 `contains`／`startswith`／`endswith`／`eq`／`neq` 詞彙一致,讓過濾樹能跨引擎沿用。
 
 **邏輯運算子**：`and`, `or`, `nor`, `not`
 
@@ -114,9 +118,23 @@ matchQuery(data, wrap({
 }));
 ```
 
-陣列的元素運算子是 ∃(「某元素符合」),`containsall` 是 ∀(成員全含)。`array` 的 `neq`
-已排除(「不含」用 `not` + `eq`)。wildcard/jsonpath `field` 形式(`users[*].x`)**不支援、
-會丟錯**——用 `elemmatch`／`array` 組合,或 `=` 運算式。
+#### `array` 成員 vs 子字串——選對運算子
+
+`array` dataType 請依語意選運算子——**`contains` 是子字串,不是成員判定**:
+
+| 運算子 | 意義 | 語意 |
+|--------|------|------|
+| `eq` | 單一成員 | `∃` 某元素**完全等於**該值 |
+| `terms` | 任一成員 | `∃` 某元素完全等於**任一個**值(跨引擎可攜) |
+| `containsall` | 全部成員 | **每個**值都有一個完全相等的元素 |
+| `contains` | 逐元素子字串(**非**成員) | `∃` 某元素以**子字串**包含該值 |
+
+所以 `contains 'manager'` 會命中 `'skip_manager'` 角色(子字串),而 `terms 'manager'`／
+`eq 'manager'` 不會(精確成員)。成員判定請用 `terms`(任一)或 `containsall`(全部);
+`contains` 只保留給真正的子字串搜尋。`terms` 是能跨 SQL、JSONB 引擎沿用的成員運算子。
+
+`array` 的 `neq` 已排除(「不含」用 `not` + `eq`)。wildcard/jsonpath `field` 形式
+(`users[*].x`)**不支援、會丟錯**——用 `elemmatch`／`array` 組合,或 `=` 運算式。
 
 #### 何時用 collection dataType
 

--- a/packages/data-filter/src/match/ArrayMatch.spec.ts
+++ b/packages/data-filter/src/match/ArrayMatch.spec.ts
@@ -14,6 +14,23 @@ describe('ArrayMatch (scalar elements)', () => {
     expect(new ArrayMatch('scores', 'numeric', 'range', [50, 70], data).isMatch).toBe(true);
     expect(new ArrayMatch('tags', 'string', 'terms', ['admin', 'staff'], data).isMatch).toBe(true);
   });
+  it('terms is any-membership by exact value (the portable membership op, #267)', () => {
+    // exact equality, NOT substring: `manager` must not match `skip_manager`
+    const roles = { roles: ['skip_manager', 'staff'] };
+    expect(new ArrayMatch('roles', 'string', 'terms', 'manager', roles).isMatch).toBe(false);
+    expect(new ArrayMatch('roles', 'string', 'contains', 'manager', roles).isMatch).toBe(true); // substring, for contrast
+    // any of the wanted values present → match
+    expect(new ArrayMatch('tags', 'string', 'terms', ['x', 'staff'], data).isMatch).toBe(true);
+    expect(new ArrayMatch('tags', 'string', 'terms', ['x', 'y'], data).isMatch).toBe(false);
+  });
+  it('evaluates the ∃ substring i-ops per-element without throwing (issue #279 parity)', () => {
+    const roles = { roles: ['Engineering', 'Sales'] };
+    expect(() => new ArrayMatch('roles', 'string', 'icontains', 'GINE', roles).isMatch).not.toThrow();
+    expect(new ArrayMatch('roles', 'string', 'icontains', 'GINE', roles).isMatch).toBe(true);
+    expect(new ArrayMatch('roles', 'string', 'contains', 'GINE', roles).isMatch).toBe(false); // case-sensitive
+    expect(new ArrayMatch('roles', 'string', 'istartswith', 'eng', roles).isMatch).toBe(true);
+    expect(new ArrayMatch('roles', 'string', 'iendswith', 'ING', roles).isMatch).toBe(true);
+  });
   it('containsall requires every value present', () => {
     expect(new ArrayMatch('tags', 'string', 'containsall', ['vip', 'staff'], data).isMatch).toBe(true);
     expect(new ArrayMatch('tags', 'string', 'containsall', ['vip', 'x'], data).isMatch).toBe(false);

--- a/packages/data-filter/src/match/TextMatch.spec.ts
+++ b/packages/data-filter/src/match/TextMatch.spec.ts
@@ -602,5 +602,83 @@ describe('arrayQuery', () => {
                 () => new TextMatch('s', 'endswith', '(', { s: 'test' }).isMatch,
             ).not.toThrow();
         });
+
+        describe('icontains (case-insensitive contains, issue #268)', () => {
+            it('matches regardless of casing on either side', () => {
+                expect(
+                    new TextMatch('s', 'icontains', 'eng', { s: 'Engineering' }).isMatch,
+                ).toBe(true);
+                expect(
+                    new TextMatch('s', 'icontains', 'ENG', { s: 'engineering' }).isMatch,
+                ).toBe(true);
+            });
+            it('contrasts with case-sensitive contains', () => {
+                expect(
+                    new TextMatch('s', 'contains', 'eng', { s: 'Engineering' }).isMatch,
+                ).toBe(false);
+                expect(
+                    new TextMatch('s', 'icontains', 'eng', { s: 'Engineering' }).isMatch,
+                ).toBe(true);
+            });
+            it('returns false when no case-insensitive substring is present', () => {
+                expect(
+                    new TextMatch('s', 'icontains', 'zzz', { s: 'Engineering' }).isMatch,
+                ).toBe(false);
+            });
+            it('supports contains-any over a list of values', () => {
+                expect(
+                    new TextMatch('s', 'icontains', ['nope', 'GINE'], { s: 'Engineering' }).isMatch,
+                ).toBe(true);
+            });
+        });
+
+        describe('case-insensitive family (istartswith/iendswith/ieq/ineq, issues #268/#279)', () => {
+            it('istartswith matches a prefix regardless of case where startswith does not', () => {
+                expect(new TextMatch('s', 'startswith', 'eng', { s: 'Engineering' }).isMatch).toBe(false);
+                expect(new TextMatch('s', 'istartswith', 'eng', { s: 'Engineering' }).isMatch).toBe(true);
+                expect(new TextMatch('s', 'istartswith', 'ENG', { s: 'engineering' }).isMatch).toBe(true);
+                expect(new TextMatch('s', 'istartswith', 'zzz', { s: 'Engineering' }).isMatch).toBe(false);
+            });
+            it('iendswith matches a suffix regardless of case where endswith does not', () => {
+                expect(new TextMatch('s', 'endswith', 'ING', { s: 'Engineering' }).isMatch).toBe(false);
+                expect(new TextMatch('s', 'iendswith', 'ING', { s: 'Engineering' }).isMatch).toBe(true);
+                expect(new TextMatch('s', 'iendswith', 'ring', { s: 'EngineeRING' }).isMatch).toBe(true);
+                expect(new TextMatch('s', 'iendswith', 'xyz', { s: 'Engineering' }).isMatch).toBe(false);
+            });
+            it('ieq matches equal strings regardless of case where eq does not', () => {
+                expect(new TextMatch('s', 'eq', 'admin', { s: 'ADMIN' }).isMatch).toBe(false);
+                expect(new TextMatch('s', 'ieq', 'admin', { s: 'ADMIN' }).isMatch).toBe(true);
+                expect(new TextMatch('s', 'ieq', 'admin', { s: 'administrator' }).isMatch).toBe(false);
+            });
+            it('ineq is the case-insensitive negation of ieq', () => {
+                // present (case-insensitively) → not "not-equal"
+                expect(new TextMatch('s', 'ineq', 'admin', { s: 'ADMIN' }).isMatch).toBe(false);
+                // genuinely different → matches
+                expect(new TextMatch('s', 'ineq', 'admin', { s: 'staff' }).isMatch).toBe(true);
+            });
+
+            // The i-family must never throw on non-string operands: typeTransfer(_, 'string')
+            // is a no-op, so a numeric/boolean/date value stays its type. Coercing with
+            // String(...) keeps it robust — a throw here would be caught by runLiveMatch and
+            // mislabeled `invalid` (issues #266/#268).
+            it('does NOT throw on a numeric target/value, matching String-coerced (issue #266)', () => {
+                expect(() => new TextMatch('n', 'ieq', '42', { n: 42 }).isMatch).not.toThrow();
+                expect(new TextMatch('n', 'ieq', '42', { n: 42 }).isMatch).toBe(true); // consistent with eq's 42=='42'
+                expect(new TextMatch('n', 'ieq', '43', { n: 42 }).isMatch).toBe(false);
+                expect(new TextMatch('n', 'ineq', '43', { n: 42 }).isMatch).toBe(true);
+                expect(new TextMatch('n', 'ineq', '42', { n: 42 }).isMatch).toBe(false);
+                expect(new TextMatch('n', 'icontains', '2', { n: 42 }).isMatch).toBe(true);
+                expect(new TextMatch('n', 'istartswith', '4', { n: 42 }).isMatch).toBe(true);
+                expect(new TextMatch('n', 'iendswith', '2', { n: 42 }).isMatch).toBe(true);
+            });
+            it('does NOT throw on a boolean or date target (issue #266)', () => {
+                expect(() => new TextMatch('b', 'ieq', 'true', { b: true }).isMatch).not.toThrow();
+                expect(new TextMatch('b', 'ieq', 'TRUE', { b: true }).isMatch).toBe(true);
+                // mid-year + midday so the year is 2024 in every timezone offset
+                const d = new Date('2024-06-15T12:00:00.000Z');
+                expect(() => new TextMatch('d', 'icontains', '2024', { d }).isMatch).not.toThrow();
+                expect(new TextMatch('d', 'icontains', '2024', { d }).isMatch).toBe(true);
+            });
+        });
     });
 });

--- a/packages/data-filter/src/match/TextMatch.ts
+++ b/packages/data-filter/src/match/TextMatch.ts
@@ -97,6 +97,125 @@ export class TextMatch {
         return isMatchCount > 0;
     }
 
+    // Case-insensitive `contains`. Same contains-any semantics as `contains`
+    // (match if any target substring-contains any value), but both sides are
+    // lower-cased before comparison. Operands are coerced with `String(...)`
+    // first so a numeric/boolean/date value never throws. See issues #268/#266.
+    private icontains() {
+        this.matchs = this.values.reduce(
+            (pre, cur) => {
+                const needle = String(cur).toLowerCase();
+                const targetMatchs = this.targets.reduce(
+                    (tarPre, target) => {
+                        const isTargetMatch = String(target)
+                            .toLowerCase()
+                            .includes(needle);
+                        if (isTargetMatch) tarPre.push(isTargetMatch);
+                        return tarPre;
+                    },
+                    <boolean[]>[],
+                );
+                const isMatch =
+                    this.targets.length > 0 && targetMatchs.length > 0;
+                if (isMatch) pre.push(cur);
+                return pre;
+            },
+            <string[]>[],
+        );
+        const isMatchCount = this.matchs.length;
+        return isMatchCount > 0;
+    }
+
+    // Case-insensitive equality (mirror of `eq`, both sides `String(...)`-coerced
+    // then lower-cased so non-string operands never throw). #268/#279/#266.
+    private ieq() {
+        this.matchs = this.values.reduce(
+            (pre, cur) => {
+                const needle = String(cur).toLowerCase();
+                const targetMatchs = this.targets.reduce(
+                    (tarPre, target) => {
+                        const isTargetMatch = String(target).toLowerCase() == needle;
+                        if (isTargetMatch) tarPre.push(isTargetMatch);
+                        return tarPre;
+                    },
+                    <boolean[]>[],
+                );
+                const isMatch =
+                    this.targets.length > 0 &&
+                    targetMatchs.length == this.targets.length;
+                if (isMatch) pre.push(cur);
+                return pre;
+            },
+            <string[]>[],
+        );
+        const isMatchCount = this.matchs.length;
+        return isMatchCount == this.values.length;
+    }
+
+    // Case-insensitive inequality (mirror of `neq`, both sides `String(...)`-coerced
+    // then lower-cased so non-string operands never throw).
+    private ineq() {
+        const lowerTargets = this.targets.map((t) => String(t).toLowerCase());
+        this.matchs = this.values.filter(
+            (value) => !lowerTargets.includes(String(value).toLowerCase()),
+        );
+        return this.matchs.length === this.values.length;
+    }
+
+    // Case-insensitive prefix match (mirror of `startswith`, both sides
+    // `String(...)`-coerced then lower-cased so non-string operands never throw).
+    private istartswith() {
+        this.matchs = this.values.reduce(
+            (pre, cur) => {
+                const needle = String(cur).toLowerCase();
+                const targetMatchs = this.targets.reduce(
+                    (tarPre, target) => {
+                        const isTargetMatch = String(target)
+                            .toLowerCase()
+                            .startsWith(needle);
+                        if (isTargetMatch) tarPre.push(isTargetMatch);
+                        return tarPre;
+                    },
+                    <boolean[]>[],
+                );
+                const isMatch =
+                    this.targets.length > 0 && targetMatchs.length > 0;
+                if (isMatch) pre.push(cur);
+                return pre;
+            },
+            <string[]>[],
+        );
+        const isMatchCount = this.matchs.length;
+        return isMatchCount > 0;
+    }
+
+    // Case-insensitive suffix match (mirror of `endswith`, both sides
+    // `String(...)`-coerced then lower-cased so non-string operands never throw).
+    private iendswith() {
+        this.matchs = this.values.reduce(
+            (pre, cur) => {
+                const needle = String(cur).toLowerCase();
+                const targetMatchs = this.targets.reduce(
+                    (tarPre, target) => {
+                        const isTargetMatch = String(target)
+                            .toLowerCase()
+                            .endsWith(needle);
+                        if (isTargetMatch) tarPre.push(isTargetMatch);
+                        return tarPre;
+                    },
+                    <boolean[]>[],
+                );
+                const isMatch =
+                    this.targets.length > 0 && targetMatchs.length > 0;
+                if (isMatch) pre.push(cur);
+                return pre;
+            },
+            <string[]>[],
+        );
+        const isMatchCount = this.matchs.length;
+        return isMatchCount > 0;
+    }
+
     private startswith() {
         this.matchs = this.values.reduce(
             (pre, cur) => {

--- a/packages/data-filter/src/match/operators.ts
+++ b/packages/data-filter/src/match/operators.ts
@@ -1,11 +1,16 @@
 export const STRING_OPERATORS = [
   'eq',
   'neq',
+  'ieq',
+  'ineq',
   'isnull',
   'isnotnull',
   'contains',
+  'icontains',
   'startswith',
+  'istartswith',
   'endswith',
+  'iendswith',
   'terms',
 ] as const;
 
@@ -40,7 +45,8 @@ export const OBJECT_OPERATORS = [
 ] as const;
 
 export const STRING_ARRAY_OPERATORS = [
-  'eq', 'contains', 'startswith', 'endswith', 'terms', 'containsall', 'isnull', 'isnotnull',
+  'eq', 'contains', 'icontains', 'startswith', 'istartswith', 'endswith', 'iendswith',
+  'terms', 'containsall', 'isnull', 'isnotnull',
 ] as const;
 export const NUMERIC_ARRAY_OPERATORS = [
   'eq', 'gt', 'gte', 'lt', 'lte', 'range', 'terms', 'containsall', 'isnull', 'isnotnull',

--- a/packages/data-filter/src/types/filter.ts
+++ b/packages/data-filter/src/types/filter.ts
@@ -43,7 +43,8 @@ export interface ObjectCondition {
 }
 
 export type StringArrayOperator =
-  | 'eq' | 'contains' | 'startswith' | 'endswith' | 'terms'
+  | 'eq' | 'contains' | 'icontains' | 'startswith' | 'istartswith'
+  | 'endswith' | 'iendswith' | 'terms'
   | 'containsall' | 'isnull' | 'isnotnull';
 export type NumericArrayOperator =
   | 'eq' | 'gt' | 'gte' | 'lt' | 'lte' | 'range' | 'terms'
@@ -96,8 +97,13 @@ export type DefaultFilterOperator = 'eq' | 'neq' | 'isnull' | 'isnotnull';
 
 export type TextFilterOperator =
   | 'contains'
+  | 'icontains'
   | 'startswith'
+  | 'istartswith'
   | 'endswith'
+  | 'iendswith'
+  | 'ieq'
+  | 'ineq'
   | 'terms'
   | DefaultFilterOperator;
 

--- a/packages/filter-builder/src/engines/arity-consistency.spec.ts
+++ b/packages/filter-builder/src/engines/arity-consistency.spec.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+import { getEngine } from "./index";
+import type { EngineId } from "./types";
+
+// Issue #279: `contains` must report the SAME arity across every engine adapter,
+// or a tree authored against one engine silently mismatches on another (a
+// multi-value input pushed to the SQL column layer becomes String(value)).
+const ENGINES: EngineId[] = ["data-filter", "sql-filter", "pg-filter", "jsonb"];
+
+function opArity(id: EngineId, op: string, dataType: string, elementType?: string): string | undefined {
+  return getEngine(id)
+    .operators(dataType, elementType)
+    .find((o) => o.op === op)?.arity;
+}
+
+function containsArity(id: EngineId, dataType: string, elementType?: string): string | undefined {
+  return opArity(id, "contains", dataType, elementType);
+}
+
+describe("cross-engine `contains` arity (issue #279)", () => {
+  it("agrees on a single arity for string `contains` across all engines", () => {
+    const arities = ENGINES.map((id) => containsArity(id, "string"));
+    // every engine exposes contains on string...
+    for (const [i, a] of arities.entries()) {
+      expect(a, `${ENGINES[i]} should expose contains on string`).toBeDefined();
+    }
+    // ...and they all agree it is single-value ("one")
+    expect(new Set(arities)).toEqual(new Set(["one"]));
+  });
+
+  it("agrees on a single arity for string-array `contains` (data-filter vs jsonb)", () => {
+    const df = containsArity("data-filter", "array", "string");
+    const jb = containsArity("jsonb", "array", "string");
+    expect(df).toBe("one");
+    expect(jb).toBe("one");
+    expect(df).toBe(jb);
+  });
+
+  it("advertises `icontains` with arity `one` on string-element arrays across data-filter and jsonb", () => {
+    const df = opArity("data-filter", "icontains", "array", "string");
+    const jb = opArity("jsonb", "icontains", "array", "string");
+    expect(df).toBe("one");
+    expect(jb).toBe("one");
+    expect(df).toBe(jb);
+  });
+});

--- a/packages/filter-builder/src/engines/data-filter.spec.ts
+++ b/packages/filter-builder/src/engines/data-filter.spec.ts
@@ -5,10 +5,11 @@ import type { BuilderGroup } from "../types";
 import { dataFilterEngine, DATA_FILTER_OPS } from "./data-filter";
 
 describe("dataFilterEngine.operators", () => {
-  it("offers substring ops but NOT case-insensitive ops for string", () => {
+  it("offers the full case-insensitive i-family for string (issues #268/#279)", () => {
     const ops = dataFilterEngine.operators("string").map((o) => o.op);
     expect(ops).toContain("contains");
-    expect(ops).not.toContain("icontains"); // data-filter has no case-insensitive
+    // data-filter now reaches cross-engine parity on the i-family
+    expect(ops).toEqual(expect.arrayContaining(["icontains", "istartswith", "iendswith", "ieq", "ineq"]));
   });
 
   it("offers comparison ops for numeric", () => {
@@ -27,9 +28,9 @@ describe("dataFilterEngine.operators", () => {
     expect(dataFilterEngine.operators("array", "object").map((o) => o.op)).toEqual(["elemmatch"]);
   });
 
-  it("exposes `contains` as a multi-value (list) op on strings (contains-any)", () => {
+  it("exposes `contains` as a single-value (one) op on strings for cross-engine parity (issue #279)", () => {
     const contains = dataFilterEngine.operators("string").find((o) => o.op === "contains");
-    expect(contains?.arity).toBe("list");
+    expect(contains?.arity).toBe("one");
   });
 
   it("keeps `contains` single-value on object fields", () => {
@@ -37,9 +38,18 @@ describe("dataFilterEngine.operators", () => {
     expect(contains?.arity).toBe("one");
   });
 
-  it("exposes `contains` as a multi-value (list) op on string-element arrays", () => {
+  it("keeps `contains` single-value on string-element arrays (issue #279)", () => {
     const contains = dataFilterEngine.operators("array", "string").find((o) => o.op === "contains");
-    expect(contains?.arity).toBe("list");
+    expect(contains?.arity).toBe("one");
+  });
+
+  it("exposes `terms` as any-membership (list) on string/numeric arrays (issue #267)", () => {
+    const strTerms = dataFilterEngine.operators("array", "string").find((o) => o.op === "terms");
+    expect(strTerms?.arity).toBe("list");
+    const numTerms = dataFilterEngine.operators("array", "numeric").find((o) => o.op === "terms");
+    expect(numTerms?.arity).toBe("list");
+    // membership operators are exact; substring `contains` is NOT membership
+    expect(dataFilterEngine.operators("array", "string").map((o) => o.op)).not.toContain("containsany");
   });
 });
 
@@ -58,9 +68,14 @@ describe("dataFilterEngine.compile", () => {
 });
 
 describe("DATA_FILTER_OPS coverage set", () => {
-  it("contains data-filter operators and excludes jsonb-only ones", () => {
+  it("contains data-filter operators including the i-family and excludes jsonb-only ones", () => {
     expect(DATA_FILTER_OPS.has("contains")).toBe(true);
-    expect(DATA_FILTER_OPS.has("icontains")).toBe(false);
+    expect(DATA_FILTER_OPS.has("icontains")).toBe(true); // added in issue #268
+    // full case-insensitive family reaches cross-engine parity (issue #279)
+    for (const op of ["istartswith", "iendswith", "ieq", "ineq"]) {
+      expect(DATA_FILTER_OPS.has(op)).toBe(true);
+    }
+    expect(DATA_FILTER_OPS.has("containsany")).toBe(false); // removed (use terms/containsall)
     expect(DATA_FILTER_OPS.has("haskey")).toBe(false);
   });
 });

--- a/packages/filter-builder/src/engines/data-filter.ts
+++ b/packages/filter-builder/src/engines/data-filter.ts
@@ -3,15 +3,18 @@ import { arityOf } from "./arity";
 import type { Engine, OperatorSpec } from "./types";
 
 const NULL_OPS = ["isnull", "isnotnull"];
-const STRING_OPS = ["eq", "neq", "contains", "startswith", "endswith", "terms", ...NULL_OPS];
+// `contains` is single-value (arity "one") to stay portable with the SQL engines
+// (see issue #279). data-filter carries the full case-insensitive i-family
+// (icontains/istartswith/iendswith/ieq/ineq) so it stays at parity with the
+// jsonb/pg/sql adapters (issues #268/#279).
+const STRING_OPS = [
+  "eq", "neq", "ieq", "ineq",
+  "contains", "icontains", "startswith", "istartswith", "endswith", "iendswith", "terms",
+  ...NULL_OPS,
+];
 const COMPARABLE_OPS = ["eq", "neq", "gt", "gte", "lt", "lte", "range", "terms", ...NULL_OPS];
 const BOOLEAN_OPS = ["eq", "neq", ...NULL_OPS];
 const OBJECT_OPS = ["eq", "neq", "contains", ...NULL_OPS];
-
-// data-filter evaluates `contains` over a list of values (match if the target
-// contains ANY of them — see @rfjs/data-filter TextMatch.contains), so on string
-// fields `contains` is exposed as a multi-value op rather than a single value.
-const STRING_LIST_OPS = new Set(["contains"]);
 
 function scalarOps(dataType: string): string[] {
   if (dataType === "string") return STRING_OPS;
@@ -21,24 +24,32 @@ function scalarOps(dataType: string): string[] {
 
 function arrayOps(elementType?: string): string[] {
   if (elementType === "object") return ["elemmatch"];
+  // For exact array membership use `terms` (any) / `containsall` (all); `contains`
+  // is per-element substring by design, not membership (see issue #267 and the
+  // data-filter README operator table).
   if (elementType === "boolean") return ["eq", "containsall", ...NULL_OPS];
   if (elementType === "numeric" || elementType === "date") {
     return ["eq", "gt", "gte", "lt", "lte", "range", "terms", "containsall", ...NULL_OPS];
   }
-  return ["eq", "contains", "startswith", "endswith", "terms", "containsall", ...NULL_OPS]; // string
+  // string — advertise the ∃ substring i-ops too (icontains/istartswith/iendswith),
+  // which ArrayMatch evaluates per-element via TextMatch, matching the jsonb engine's
+  // string-array vocabulary. `ieq`/`ineq` are intentionally omitted: array equality is
+  // the dedicated ∃ `eq` path, whereas TextMatch.ieq is ∀-over-elements (issue #279 parity).
+  return [
+    "eq", "contains", "icontains", "startswith", "istartswith", "endswith", "iendswith",
+    "terms", "containsall", ...NULL_OPS,
+  ];
 }
 
-function toSpecs(ops: string[], listOps?: Set<string>): OperatorSpec[] {
-  return [...new Set(ops)].map((op) => ({
-    op,
-    arity: listOps?.has(op) ? "list" : arityOf(op),
-  }));
+function toSpecs(ops: string[]): OperatorSpec[] {
+  return [...new Set(ops)].map((op) => ({ op, arity: arityOf(op) }));
 }
 
 // Coverage set for live match: every operator data-filter can evaluate.
 export const DATA_FILTER_OPS = new Set<string>([
   ...STRING_OPS, ...COMPARABLE_OPS, ...BOOLEAN_OPS, ...OBJECT_OPS,
-  "contains", "startswith", "endswith", "containsall", "elemmatch",
+  "contains", "icontains", "startswith", "istartswith", "endswith", "iendswith",
+  "ieq", "ineq", "containsall", "elemmatch",
 ]);
 
 export const dataFilterEngine: Engine = {
@@ -46,13 +57,7 @@ export const dataFilterEngine: Engine = {
   label: "data-filter (in-memory)",
   operators(dataType, elementType) {
     if (dataType === "object") return toSpecs(OBJECT_OPS);
-    if (dataType === "array") {
-      // string-element arrays support multi-value `contains` (contains-any) too —
-      // ArrayMatch routes `contains` through TextMatch, which evaluates over a list.
-      const listOps = elementType === undefined || elementType === "string" ? STRING_LIST_OPS : undefined;
-      return toSpecs(arrayOps(elementType), listOps);
-    }
-    if (dataType === "string") return toSpecs(STRING_OPS, STRING_LIST_OPS);
+    if (dataType === "array") return toSpecs(arrayOps(elementType));
     return toSpecs(scalarOps(dataType));
   },
   compile(group: FilterGroupLike) {

--- a/packages/filter-builder/src/index.ts
+++ b/packages/filter-builder/src/index.ts
@@ -7,5 +7,6 @@ export * from './field-kind';
 export * from './field-create';
 export * from './schema-infer';
 export * from './live-match';
+export * from './validate';
 export * from './engines';
 export * from './pg-group';

--- a/packages/filter-builder/src/live-match.spec.ts
+++ b/packages/filter-builder/src/live-match.spec.ts
@@ -18,10 +18,10 @@ describe("runLiveMatch", () => {
     expect(r.matched).toEqual([{ age: 30 }, { age: 40 }]);
   });
 
-  it("flags uncoverable when a jsonb-only operator is present", () => {
+  it("flags uncoverable when an operator data-filter cannot cover is present", () => {
     const tree: BuilderGroup = {
       kind: "group", id: "g", logic: "and",
-      children: [{ kind: "condition", id: "c", field: "name", dataType: "string", operator: "icontains", value: "x" }],
+      children: [{ kind: "condition", id: "c", field: "name", dataType: "string", operator: "nin", value: "x" }],
     };
     const r = runLiveMatch([{ name: "X" }], tree);
     expect(r.uncoverable).toBe(true);
@@ -32,18 +32,56 @@ describe("runLiveMatch", () => {
     expect(runLiveMatch(rows, empty).count).toBe(3);
   });
 
-  it("flags uncoverable for a jsonb-only op nested inside a group", () => {
+  it("flags uncoverable for an uncoverable op nested inside a group", () => {
     const tree: BuilderGroup = {
       kind: "group", id: "outer", logic: "and",
       children: [{
         kind: "group", id: "inner", logic: "or",
-        children: [{ kind: "condition", id: "c", field: "name", dataType: "string", operator: "icontains", value: "x" }],
+        children: [{ kind: "condition", id: "c", field: "name", dataType: "string", operator: "nin", value: "x" }],
       }],
     };
     expect(runLiveMatch([{ name: "X" }], tree).uncoverable).toBe(true);
   });
 
-  it("flags uncoverable for a jsonb-only op inside an elemmatch filter", () => {
+  it("surfaces a malformed condition as `invalid`, distinct from no-match (issue #266)", () => {
+    // an `array` condition missing `elementType` makes ArrayMatch throw at match time
+    const malformed: BuilderGroup = {
+      kind: "group", id: "g", logic: "and",
+      children: [{ kind: "condition", id: "c", field: "roles", dataType: "array", operator: "eq", value: "admin" }],
+    };
+    const r = runLiveMatch([{ roles: ["staff"] }], malformed);
+    expect(r.invalid).toBe(true);
+    expect(r.uncoverable).toBe(false); // NOT swallowed into uncoverable
+    expect(r.count).toBe(0);
+    expect(r.error).toBeTruthy();
+  });
+
+  it("a genuine zero-match is distinguishable from a malformed rule (issue #266)", () => {
+    const noMatch: BuilderGroup = {
+      kind: "group", id: "g", logic: "and",
+      children: [{ kind: "condition", id: "c", field: "age", dataType: "numeric", operator: "gt", value: 999 }],
+    };
+    const r = runLiveMatch(rows, noMatch);
+    expect(r.count).toBe(0);
+    expect(r.invalid).toBe(false); // nobody matched, but the rule is fine
+    expect(r.uncoverable).toBe(false);
+  });
+
+  it("a covered match reports invalid=false", () => {
+    expect(runLiveMatch(rows, adults).invalid).toBe(false);
+  });
+
+  it("an uncoverable op is not flagged invalid", () => {
+    const tree: BuilderGroup = {
+      kind: "group", id: "g", logic: "and",
+      children: [{ kind: "condition", id: "c", field: "name", dataType: "string", operator: "nin", value: "x" }],
+    };
+    const r = runLiveMatch([{ name: "X" }], tree);
+    expect(r.uncoverable).toBe(true);
+    expect(r.invalid).toBe(false);
+  });
+
+  it("flags uncoverable for an uncoverable op inside an elemmatch filter", () => {
     const tree: BuilderGroup = {
       kind: "group", id: "g", logic: "and",
       children: [{
@@ -51,7 +89,7 @@ describe("runLiveMatch", () => {
         operator: "elemmatch",
         filters: {
           kind: "group", id: "fg", logic: "and",
-          children: [{ kind: "condition", id: "fc", field: "name", dataType: "string", operator: "icontains", value: "x" }],
+          children: [{ kind: "condition", id: "fc", field: "name", dataType: "string", operator: "nin", value: "x" }],
         },
       }],
     };

--- a/packages/filter-builder/src/live-match.ts
+++ b/packages/filter-builder/src/live-match.ts
@@ -7,7 +7,21 @@ import type { BuilderGroup } from "./types";
 export interface LiveMatchResult {
   matched: unknown[];
   count: number;
+  /**
+   * The tree references an operator data-filter can't evaluate (or a field the
+   * engine treats as absent) — the query is *runnable* but some branch can't be
+   * covered in-memory. This is "we can't be sure nobody matched", NOT an error.
+   */
   uncoverable: boolean;
+  /**
+   * The tree's shape is itself broken and the engine THREW while evaluating it
+   * (e.g. an `array` condition missing `elementType`). Distinct from both
+   * `uncoverable` and a genuine zero-match so consumers can tell "the rule is
+   * malformed" apart from "nobody matched". See issue #266.
+   */
+  invalid: boolean;
+  /** The thrown message, present only when `invalid` is true. */
+  error?: string;
 }
 
 function hasUncoverableOp(group: FilterGroupLike): boolean {
@@ -22,11 +36,20 @@ function hasUncoverableOp(group: FilterGroupLike): boolean {
 export function runLiveMatch(rows: unknown[], tree: BuilderGroup): LiveMatchResult {
   const group = treeToFilterGroup(tree);
   const uncoverable = hasUncoverableOp(group);
-  if (uncoverable) return { matched: [], count: 0, uncoverable: true };
+  if (uncoverable) return { matched: [], count: 0, uncoverable: true, invalid: false };
   try {
     const matched = rows.filter((row) => matchQuery(row as ObjectData, group as unknown as FilterMatchQuery));
-    return { matched, count: matched.length, uncoverable: false };
-  } catch {
-    return { matched: [], count: 0, uncoverable: true };
+    return { matched, count: matched.length, uncoverable: false, invalid: false };
+  } catch (err) {
+    // The condition passed the coverage check but the engine still threw — the
+    // rule's shape is invalid. Surface it distinctly instead of collapsing it
+    // into `uncoverable` (which is indistinguishable from no-match). Issue #266.
+    return {
+      matched: [],
+      count: 0,
+      uncoverable: false,
+      invalid: true,
+      error: err instanceof Error ? err.message : String(err),
+    };
   }
 }

--- a/packages/filter-builder/src/validate.spec.ts
+++ b/packages/filter-builder/src/validate.spec.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "vitest";
+
+import type { BuilderGroup, FieldSchema } from "./types";
+import { validateTree } from "./validate";
+
+const schema: FieldSchema[] = [
+  { path: "title", dataType: "string", include: true, kind: "jsonb" },
+  { path: "age", dataType: "numeric", include: true, kind: "column" },
+  { path: "roles", dataType: "array", elementType: "string", include: true, kind: "jsonb" },
+  { path: "items", dataType: "array", elementType: "object", include: true, kind: "jsonb" },
+];
+
+function group(children: BuilderGroup["children"]): BuilderGroup {
+  return { kind: "group", id: "root", logic: "and", children };
+}
+
+describe("validateTree (issue #278)", () => {
+  it("accepts a valid single-level tree", () => {
+    const tree = group([
+      { kind: "condition", id: "c1", field: "title", dataType: "string", operator: "contains", value: "eng" },
+      { kind: "condition", id: "c2", field: "age", dataType: "numeric", operator: "gte", value: 18 },
+    ]);
+    const r = validateTree(tree, schema);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.tree).toBe(tree);
+  });
+
+  it("rejects an empty group (and-of-empty ≡ matches everyone)", () => {
+    const r = validateTree(group([]), schema);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.errors.map((e) => e.code)).toContain("emptyGroup");
+  });
+
+  it("rejects an unknown field, reporting the offending nodeId", () => {
+    const tree = group([
+      { kind: "condition", id: "bad", field: "nope", dataType: "string", operator: "eq", value: "x" },
+    ]);
+    const r = validateTree(tree, schema);
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.errors).toEqual([{ nodeId: "bad", path: "nope", code: "unknownField" }]);
+    }
+  });
+
+  it("rejects a dataType that disagrees with the field catalog", () => {
+    const tree = group([
+      { kind: "condition", id: "c", field: "age", dataType: "string", operator: "eq", value: "18" },
+    ]);
+    const r = validateTree(tree, schema);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.errors.map((e) => e.code)).toContain("dataTypeMismatch");
+  });
+
+  it("rejects an array condition missing elementType (guards issue #266)", () => {
+    const tree = group([
+      { kind: "condition", id: "c", field: "roles", dataType: "array", operator: "eq", value: "admin" },
+    ]);
+    const r = validateTree(tree, schema);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.errors.map((e) => e.code)).toContain("missingElementType");
+  });
+
+  it("rejects an operator outside the app allowlist", () => {
+    const tree = group([
+      { kind: "condition", id: "c", field: "title", dataType: "string", operator: "icontains", value: "x" },
+    ]);
+    const r = validateTree(tree, schema, { operators: { string: ["eq", "contains"] } });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.errors.map((e) => e.code)).toContain("operatorNotAllowed");
+  });
+
+  it("accepts an allowlisted operator", () => {
+    const tree = group([
+      { kind: "condition", id: "c", field: "title", dataType: "string", operator: "contains", value: "x" },
+    ]);
+    expect(validateTree(tree, schema, { operators: { string: ["eq", "contains"] } }).ok).toBe(true);
+  });
+
+  it("rejects a missing value for a value-bearing operator, but not for null-checks", () => {
+    const missing = group([
+      { kind: "condition", id: "c", field: "title", dataType: "string", operator: "contains" },
+    ]);
+    const r = validateTree(missing, schema);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.errors.map((e) => e.code)).toContain("missingValue");
+
+    const nullCheck = group([
+      { kind: "condition", id: "c", field: "title", dataType: "string", operator: "isnull" },
+    ]);
+    expect(validateTree(nullCheck, schema).ok).toBe(true);
+  });
+
+  it("rejects nested groups when allowNestedGroups is false", () => {
+    const tree = group([
+      { kind: "group", id: "inner", logic: "or", children: [
+        { kind: "condition", id: "c", field: "age", dataType: "numeric", operator: "gte", value: 1 },
+      ] },
+    ]);
+    expect(validateTree(tree, schema, { allowNestedGroups: false }).ok).toBe(false);
+    expect(validateTree(tree, schema).ok).toBe(true); // allowed by default
+  });
+
+  it("rejects a non-group root and non-object input", () => {
+    expect(validateTree(null, schema).ok).toBe(false);
+    expect(validateTree({ kind: "condition" }, schema).ok).toBe(false);
+  });
+
+  it("validates an elemmatch condition as a leaf and does NOT descend into its inner group", () => {
+    // Inner conditions reference element-relative paths (sku/qty) absent from the
+    // flat top-level schema; recursing would spuriously flag them. Pin: ok:true
+    // even though the inner group would be "invalid" against this schema.
+    const tree = group([
+      {
+        kind: "condition", id: "em", field: "items", dataType: "array", elementType: "object",
+        operator: "elemmatch",
+        filters: {
+          kind: "group", id: "ig", logic: "and",
+          children: [
+            { kind: "condition", id: "s", field: "sku", dataType: "string", operator: "eq", value: "A" },
+            { kind: "condition", id: "q", field: "qty", dataType: "numeric", operator: "gt", value: 1 },
+          ],
+        },
+      },
+    ]);
+    expect(validateTree(tree, schema).ok).toBe(true);
+  });
+
+  it("collects errors from multiple offending nodes", () => {
+    const tree = group([
+      { kind: "condition", id: "a", field: "nope", dataType: "string", operator: "eq", value: "x" },
+      { kind: "condition", id: "b", field: "roles", dataType: "array", operator: "eq", value: "admin" },
+    ]);
+    const r = validateTree(tree, schema);
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      const ids = r.errors.map((e) => e.nodeId);
+      expect(ids).toContain("a");
+      expect(ids).toContain("b");
+    }
+  });
+});

--- a/packages/filter-builder/src/validate.ts
+++ b/packages/filter-builder/src/validate.ts
@@ -1,0 +1,167 @@
+import { arityOf } from "./engines/arity";
+import type { BuilderGroup, FieldSchema, FieldType, LogicOp } from "./types";
+
+/**
+ * Error codes emitted by {@link validateTree}. Stable strings so a UI can map
+ * them to messages / highlight the offending row (via `nodeId`).
+ */
+export type ValidateErrorCode =
+  | "notAGroup"
+  | "invalidLogic"
+  | "emptyGroup"
+  | "nestedGroupNotAllowed"
+  | "invalidNode"
+  | "unknownField"
+  | "dataTypeMismatch"
+  | "missingElementType"
+  | "operatorNotAllowed"
+  | "missingValue";
+
+export interface ValidateError {
+  /** `id` of the offending group / condition, when the node carries one. */
+  nodeId?: string;
+  /** Field path of the offending condition, for messages that name the field. */
+  path?: string;
+  code: ValidateErrorCode;
+}
+
+export interface ValidateOptions {
+  /**
+   * App-level operator allowlist per dataType. When an entry exists for a
+   * condition's `dataType`, its `operator` must be in the list. Intended to be
+   * the intersection the consumer cares about (e.g. what both `data-filter` and
+   * `pg-filter` support) — compute it with `getEngine(id).operators(...)`.
+   */
+  operators?: Partial<Record<FieldType, string[]>>;
+  /** Reject nested groups (single-level trees only). Default: true (allowed). */
+  allowNestedGroups?: boolean;
+  /** Minimum children per group. Default 1 — rejects the `and`-of-empty ≡ true that matches everyone. */
+  minChildren?: number;
+}
+
+export type ValidateResult =
+  | { ok: true; tree: BuilderGroup }
+  | { ok: false; errors: ValidateError[] };
+
+const LOGIC_OPS: readonly LogicOp[] = ["and", "or", "nor", "not"];
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null;
+}
+
+function walkGroup(
+  node: unknown,
+  schema: Map<string, FieldSchema>,
+  options: Required<Pick<ValidateOptions, "allowNestedGroups" | "minChildren">> &
+    Pick<ValidateOptions, "operators">,
+  errors: ValidateError[],
+): void {
+  if (!isRecord(node) || node.kind !== "group") {
+    errors.push({ code: "notAGroup", nodeId: isRecord(node) ? (node.id as string | undefined) : undefined });
+    return;
+  }
+  const nodeId = typeof node.id === "string" ? node.id : undefined;
+  if (!LOGIC_OPS.includes(node.logic as LogicOp)) {
+    errors.push({ nodeId, code: "invalidLogic" });
+  }
+  const children = Array.isArray(node.children) ? node.children : [];
+  if (children.length < options.minChildren) {
+    errors.push({ nodeId, code: "emptyGroup" });
+  }
+  for (const child of children) {
+    if (isRecord(child) && child.kind === "group") {
+      if (!options.allowNestedGroups) {
+        errors.push({ nodeId: child.id as string | undefined, code: "nestedGroupNotAllowed" });
+        continue;
+      }
+      walkGroup(child, schema, options, errors);
+    } else {
+      walkCondition(child, schema, options, errors);
+    }
+  }
+}
+
+function walkCondition(
+  node: unknown,
+  schema: Map<string, FieldSchema>,
+  options: Pick<ValidateOptions, "operators">,
+  errors: ValidateError[],
+): void {
+  if (!isRecord(node) || node.kind !== "condition") {
+    errors.push({ code: "invalidNode", nodeId: isRecord(node) ? (node.id as string | undefined) : undefined });
+    return;
+  }
+  const nodeId = typeof node.id === "string" ? node.id : undefined;
+  const field = typeof node.field === "string" ? node.field : undefined;
+  const operator = typeof node.operator === "string" ? node.operator : undefined;
+  const path = field;
+
+  if (!field || !operator) {
+    errors.push({ nodeId, path, code: "invalidNode" });
+    return;
+  }
+
+  const fieldSchema = schema.get(field);
+  if (!fieldSchema) {
+    errors.push({ nodeId, path, code: "unknownField" });
+    return; // no schema → the remaining checks can't be trusted
+  }
+
+  if (node.dataType !== fieldSchema.dataType) {
+    errors.push({ nodeId, path, code: "dataTypeMismatch" });
+  }
+
+  // Array conditions must carry elementType, or the engine throws at match time
+  // and the failure is swallowed into `uncoverable` (see issue #266).
+  if (fieldSchema.dataType === "array" && !node.elementType) {
+    errors.push({ nodeId, path, code: "missingElementType" });
+  }
+
+  const allowlist = options.operators?.[fieldSchema.dataType];
+  if (allowlist && !allowlist.includes(operator)) {
+    errors.push({ nodeId, path, code: "operatorNotAllowed" });
+  }
+
+  // Value presence: everything except the "none"-arity ops (isnull, isnotnull,
+  // elemmatch, …) needs a value. elemmatch carries `filters`, not `value`.
+  if (arityOf(operator) !== "none" && operator !== "elemmatch") {
+    if (node.value === undefined || node.value === null) {
+      errors.push({ nodeId, path, code: "missingValue" });
+    }
+  }
+
+  // DECISION: an `elemmatch` condition is validated as a leaf — we do NOT descend
+  // into its inner `filters` group. The inner conditions reference element-relative
+  // paths (e.g. `sku`, `qty` inside each array element) that are absent from the
+  // flat, top-level `FieldSchema[]` this validator is given, so recursing would
+  // spuriously report every inner field as `unknownField`. Validating the element
+  // sub-schema is out of scope here; callers with an element schema should validate
+  // the inner group separately. (Pinned by test.)
+}
+
+/**
+ * Validate a candidate `BuilderGroup` against a field-schema allowlist before
+ * persisting or evaluating it. Reports **per-node** errors (`nodeId`/`path`) so
+ * a UI can highlight the offending row. This is the write-time flip side of the
+ * evaluation-time silent failure in issue #266. See issue #278.
+ */
+export function validateTree(
+  tree: unknown,
+  schema: FieldSchema[],
+  options: ValidateOptions = {},
+): ValidateResult {
+  const errors: ValidateError[] = [];
+  const schemaMap = new Map(schema.map((f) => [f.path, f]));
+  walkGroup(
+    tree,
+    schemaMap,
+    {
+      allowNestedGroups: options.allowNestedGroups ?? true,
+      minChildren: options.minChildren ?? 1,
+      operators: options.operators,
+    },
+    errors,
+  );
+  if (errors.length > 0) return { ok: false, errors };
+  return { ok: true, tree: tree as BuilderGroup };
+}


### PR DESCRIPTION
Governa's dual-projection work (in-memory + SQL pushdown) surfaced five coupled filter-stack findings; fixed together so operator vocabulary and arity stay consistent across `@rfjs/data-filter` + `@rfjs/filter-builder`.

- **#266** — `runLiveMatch` now distinguishes three states: malformed rule (`invalid:true`), unsupported/absent op (`uncoverable:true`), genuine zero-match (both false). A thrown invalid condition no longer masquerades as no-match.
- **#267** — array **exact-membership** was already covered by `terms` (any) / `containsall` (all) / `eq` (single); the gap was discoverability, not a missing operator. Documented the membership-vs-substring vocabulary in the data-filter README (en + zh-TW) rather than adding a redundant, data-filter-only operator.
- **#268** — completed the case-insensitive **i-family** in data-filter (`icontains`/`istartswith`/`iendswith`/`ieq`/`ineq`), coercing both sides via `String(...).toLowerCase()` so non-string operands match gracefully instead of throwing. Advertised the ∃ substring i-ops on string-element arrays too (allowlisted to avoid a match-time throw).
- **#278** — new `validateTree(tree, schema, options?)`: validates a `BuilderGroup` against `FieldSchema[]` with per-node error codes, so malformed rules are rejected at write time. (`elemmatch` inner groups are intentionally not descended — documented; empty-string rejection deferred as a follow-up.)
- **#279** — unified `contains` arity to `one` across all engine adapters (removed data-filter's `STRING_LIST_OPS` override). A `list` value pushed to a SQL column layer degraded to `String(value)` and silently matched nothing; the multi-value capability stays reachable via the explicitly-named `terms`.

Verified: data-filter 248 tests + filter-builder 120 tests + typecheck green. Opus-reviewed (one blocking i-family non-string-throw bug found and fixed).

Changesets: `@rfjs/data-filter` + `@rfjs/filter-builder` minor.

Closes #266
Closes #267
Closes #268
Closes #278
Closes #279

_Governa dogfood #22+#23 / #24 / #25 / #31 / #29._

🤖 Generated with [Claude Code](https://claude.com/claude-code)