### PR TITLE
feat(flow-core): timeout on condition nodes + graph traversal primitives

### DIFF
--- a/.changeset/gov-flow-core-primitives.md
+++ b/.changeset/gov-flow-core-primitives.md
@@ -1,0 +1,37 @@
+---
+"@rfjs/flow-core": minor
+---
+
+Add graph-traversal primitives and support condition-node timeouts (approval-escalation).
+
+**#280 — graph traversal / reachability API.** New public helpers so consumers no
+longer hand-roll BFS/DFS over `doc.edges`:
+
+- `nodeById(doc)` — `id → FlowNode` index (replaces the O(n) `doc.nodes.find`).
+- `outgoingEdges(doc)` — `source → FlowEdge[]` index (array order preserved).
+- `reachableNodes(doc, fromId, options?)` — forward BFS; visited-set cycle cutoff.
+- `ancestorNodes(doc, toId, options?)` — reverse BFS ("which nodes can reach here").
+- `TraversalOptions` — `includeSelf` (default false), `filter` (collection semantics:
+  which nodes enter the result; filtered-out nodes are still expanded), and `follow`
+  (traversal semantics: whether to walk an edge, e.g. exclude `trigger: 'timeout'`).
+
+Edges whose endpoint is missing from the node index (schema does not enforce
+referential integrity) are skipped, not treated as reachable. An unknown
+`fromId`/`toId` returns `[]`. Visitation order is deterministic given the
+`doc.edges` array order.
+
+**#265 — `timeout` events now support `condition` nodes.** The `advance` `"timeout"`
+case previously accepted only `form`/`action` nodes and rejected condition nodes with
+`FlowError('wrong-event')`, even though "an approval step times out and escalates" is
+the most typical BPM timeout scenario. It now also follows a `trigger: 'timeout'`
+out-edge from a `condition` node (no schema change — `edge.trigger` was already free
+text).
+
+Behavior notes:
+
+- When landing on a `condition` node, `trigger: 'timeout'` out-edges are now excluded
+  from the human-selectable `options` (they are automatic escalation paths, not
+  decisions a user picks).
+- Feeding a `timeout` event to a `condition` node that has no timeout out-edge now
+  throws `FlowError('no-edge')` (previously `wrong-event`), consistent with `form`/
+  `action` timeout behavior.

--- a/packages/flow-core/src/graph.spec.ts
+++ b/packages/flow-core/src/graph.spec.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import type { FlowDoc, FlowEdge, FlowNode } from "./schema";
+import { ancestorNodes, nodeById, outgoingEdges, reachableNodes } from "./graph";
+
+const ids = (nodes: FlowNode[]): string[] => nodes.map((n) => n.id);
+
+// 請假流(含 back edge 與 timeout 邊,以及一條 dangling 邊):
+// start → form1 → review(yes → act1;reject → form1[back edge])
+//                 form1 --timeout--> esc(auto → end)
+// act1 → final(condition) → end;act1 → ghost(不存在的節點,dangling)
+const doc: FlowDoc = {
+  version: 1,
+  nodes: [
+    { id: "start", type: "start", position: { x: 0, y: 0 } },
+    { id: "form1", type: "form", position: { x: 0, y: 0 } },
+    { id: "review", type: "condition", position: { x: 0, y: 0 } },
+    { id: "act1", type: "action", position: { x: 0, y: 0 } },
+    { id: "final", type: "condition", position: { x: 0, y: 0 } },
+    { id: "esc", type: "condition", position: { x: 0, y: 0 } },
+    { id: "end", type: "end", position: { x: 0, y: 0 } },
+  ],
+  edges: [
+    { id: "e0", source: "start", target: "form1" },
+    { id: "e1", source: "form1", target: "review", trigger: "onSubmit" },
+    { id: "et", source: "form1", target: "esc", trigger: "timeout" },
+    { id: "e2", source: "review", target: "act1", sourceHandle: "yes" },
+    { id: "e3", source: "review", target: "form1", sourceHandle: "reject" }, // back edge → 環
+    { id: "e4", source: "act1", target: "final" },
+    { id: "e5", source: "final", target: "end", sourceHandle: "done" },
+    { id: "e6", source: "esc", target: "end", sourceHandle: "auto" },
+    { id: "e7", source: "act1", target: "ghost" }, // dangling:無 ghost 節點
+  ],
+};
+
+const isCondition = (n: FlowNode): boolean => n.type === "condition";
+const notTimeout = (e: FlowEdge): boolean => e.trigger !== "timeout";
+
+describe("nodeById", () => {
+  it("建成 id → node 索引,含全部節點", () => {
+    const map = nodeById(doc);
+    expect(map.size).toBe(doc.nodes.length);
+    expect(map.get("review")?.type).toBe("condition");
+    expect(map.get("nope")).toBeUndefined();
+  });
+});
+
+describe("outgoingEdges", () => {
+  it("依 source 分組並維持陣列順序", () => {
+    const map = outgoingEdges(doc);
+    expect(map.get("form1")?.map((e) => e.target)).toEqual(["review", "esc"]);
+    expect(map.get("review")?.map((e) => e.sourceHandle)).toEqual(["yes", "reject"]);
+    expect(map.get("end")).toBeUndefined(); // 無出邊
+  });
+});
+
+describe("reachableNodes —— 前向", () => {
+  it("BFS 造訪順序(邊依陣列順序展開)", () => {
+    expect(ids(reachableNodes(doc, "form1"))).toEqual(["review", "esc", "act1", "end", "final"]);
+  });
+  it("includeSelf 把起點放在最前", () => {
+    expect(ids(reachableNodes(doc, "form1", { includeSelf: true }))).toEqual([
+      "form1",
+      "review",
+      "esc",
+      "act1",
+      "end",
+      "final",
+    ]);
+  });
+  it("filter 只收集 condition(收集語意:被濾掉的節點仍被展開)", () => {
+    // act1 被 filter 濾掉,但 final 只透過 act1 才可達 —— 仍出現,證明是收集而非剪枝。
+    expect(ids(reachableNodes(doc, "form1", { filter: isCondition }))).toEqual(["review", "esc", "final"]);
+  });
+  it("follow 排除 trigger:'timeout' 邊 —— esc 不被計入", () => {
+    expect(ids(reachableNodes(doc, "form1", { follow: notTimeout }))).toEqual(["review", "act1", "final", "end"]);
+  });
+  it("back edge 造成的環被 visited 切斷,每個節點僅一次、不無限迴圈", () => {
+    const result = ids(reachableNodes(doc, "review"));
+    expect(result).toEqual(["act1", "form1", "final", "esc", "end"]);
+    expect(new Set(result).size).toBe(result.length); // 無重複
+  });
+  it("dangling target(ghost)被跳過、不丟例外", () => {
+    expect(ids(reachableNodes(doc, "act1"))).toEqual(["final", "end"]);
+  });
+  it("未知 fromId → []", () => {
+    expect(reachableNodes(doc, "nope")).toEqual([]);
+  });
+});
+
+describe("ancestorNodes —— 反向", () => {
+  it("反向 BFS:能到達 end 的節點", () => {
+    expect(ids(ancestorNodes(doc, "end"))).toEqual(["final", "esc", "act1", "form1", "review", "start"]);
+  });
+  it("支援同樣的 options:includeSelf", () => {
+    expect(ids(ancestorNodes(doc, "esc", { includeSelf: true }))).toEqual(["esc", "form1", "start", "review"]);
+  });
+  it("follow 排除 timeout 邊 —— esc 唯一入邊是 timeout,故無祖先(前向 esc-only-via-timeout 的反向對稱)", () => {
+    expect(ids(ancestorNodes(doc, "esc", { follow: notTimeout }))).toEqual([]);
+  });
+  it("filter 只收集 condition", () => {
+    expect(ids(ancestorNodes(doc, "end", { filter: isCondition }))).toEqual(["final", "esc", "review"]);
+  });
+  it("未知 toId → []", () => {
+    expect(ancestorNodes(doc, "nope")).toEqual([]);
+  });
+});

--- a/packages/flow-core/src/graph.ts
+++ b/packages/flow-core/src/graph.ts
@@ -1,0 +1,106 @@
+import type { FlowDoc, FlowEdge, FlowNode } from "./schema";
+
+export interface TraversalOptions {
+  /** 是否把起點節點本身納入結果(仍受 filter 約束)。預設 false。 */
+  includeSelf?: boolean;
+  /**
+   * 收集語意:決定哪些節點「進入結果」,而非剪枝。
+   * 被 filter 排除的節點仍會被展開(其出/入邊照樣走)。
+   */
+  filter?: (node: FlowNode) => boolean;
+  /**
+   * 走訪語意:決定是否沿某條邊前進(例如排除 trigger:'timeout' 邊)。
+   * 預設走所有邊。
+   */
+  follow?: (edge: FlowEdge) => boolean;
+}
+
+/** doc.nodes 建成 id → node 索引(取代 O(n) 的 doc.nodes.find)。後出現的同 id 會覆蓋前者。 */
+export function nodeById(doc: FlowDoc): Map<string, FlowNode> {
+  const map = new Map<string, FlowNode>();
+  for (const n of doc.nodes) map.set(n.id, n);
+  return map;
+}
+
+/** 依 source 分組的出邊索引;每組維持 doc.edges 的原始陣列順序。 */
+export function outgoingEdges(doc: FlowDoc): Map<string, FlowEdge[]> {
+  const map = new Map<string, FlowEdge[]>();
+  for (const e of doc.edges) {
+    const list = map.get(e.source);
+    if (list) list.push(e);
+    else map.set(e.source, [e]);
+  }
+  return map;
+}
+
+/** 依 target 分組的入邊索引(反向走訪用);每組維持 doc.edges 的原始陣列順序。 */
+function incomingEdges(doc: FlowDoc): Map<string, FlowEdge[]> {
+  const map = new Map<string, FlowEdge[]>();
+  for (const e of doc.edges) {
+    const list = map.get(e.target);
+    if (list) list.push(e);
+    else map.set(e.target, [e]);
+  }
+  return map;
+}
+
+/**
+ * 廣度優先走訪的共用核心。
+ * - 結果順序 = BFS 造訪順序;同一節點的鄰邊依 doc.edges 的陣列順序展開(故對同一 doc 結果穩定)。
+ * - visited 集合切斷環(back edge),每個節點最多造訪一次,不會無限迴圈。
+ * - 邊指向不存在的節點(schema 不強制參照完整性)時跳過,不視為可達。
+ * - 未知起點 → 回 [](不丟例外)。
+ */
+function traverse(
+  doc: FlowDoc,
+  startId: string,
+  direction: "forward" | "reverse",
+  options: TraversalOptions,
+): FlowNode[] {
+  const index = nodeById(doc);
+  const startNode = index.get(startId);
+  if (!startNode) return [];
+
+  const { includeSelf = false, filter, follow } = options;
+  const adjacency = direction === "forward" ? outgoingEdges(doc) : incomingEdges(doc);
+  const nextIdOf = (e: FlowEdge): string => (direction === "forward" ? e.target : e.source);
+
+  const result: FlowNode[] = [];
+  const collect = (node: FlowNode): void => {
+    if (!filter || filter(node)) result.push(node);
+  };
+  if (includeSelf) collect(startNode);
+
+  const visited = new Set<string>([startId]);
+  const queue: string[] = [startId];
+  while (queue.length > 0) {
+    const currentId = queue.shift() as string;
+    for (const edge of adjacency.get(currentId) ?? []) {
+      if (follow && !follow(edge)) continue;
+      const nextId = nextIdOf(edge);
+      if (visited.has(nextId)) continue;
+      const node = index.get(nextId);
+      if (!node) continue; // dangling 端點:跳過,不算可達
+      visited.add(nextId);
+      queue.push(nextId);
+      collect(node);
+    }
+  }
+  return result;
+}
+
+/**
+ * 從 fromId 沿邊「往前」可達的節點(預設不含 fromId 本身);環由 visited 集合切斷。
+ * 未知 fromId → []。
+ */
+export function reachableNodes(doc: FlowDoc, fromId: string, options: TraversalOptions = {}): FlowNode[] {
+  return traverse(doc, fromId, "forward", options);
+}
+
+/**
+ * 反向:能「到達」toId 的節點(預設不含 toId 本身),用來回溯「為何走到這一步」。
+ * 未知 toId → []。
+ */
+export function ancestorNodes(doc: FlowDoc, toId: string, options: TraversalOptions = {}): FlowNode[] {
+  return traverse(doc, toId, "reverse", options);
+}

--- a/packages/flow-core/src/index.ts
+++ b/packages/flow-core/src/index.ts
@@ -2,3 +2,4 @@ export * from "./schema";
 export * from "./projection";
 export * from "./runtime";
 export * from "./condition";
+export * from "./graph";

--- a/packages/flow-core/src/runtime.spec.ts
+++ b/packages/flow-core/src/runtime.spec.ts
@@ -104,6 +104,62 @@ describe("advance —— timeout(含條件式)", () => {
   });
 });
 
+// #265:核准步驟(condition)逾時逃逸(approval-escalation)。
+// start → capprove(condition: yes/no + timeout→esc2)→ act1/act2 → end;esc2 為逃逸 condition。
+const escDoc: FlowDoc = {
+  version: 1,
+  nodes: [
+    { id: "start", type: "start", position: { x: 0, y: 0 } },
+    { id: "capprove", type: "condition", position: { x: 0, y: 0 } },
+    { id: "act1", type: "action", position: { x: 0, y: 0 } },
+    { id: "act2", type: "action", position: { x: 0, y: 0 } },
+    { id: "esc2", type: "condition", position: { x: 0, y: 0 } },
+    { id: "end", type: "end", position: { x: 0, y: 0 } },
+  ],
+  edges: [
+    { id: "e0", source: "start", target: "capprove" },
+    { id: "e1", source: "capprove", target: "act1", sourceHandle: "yes" },
+    { id: "e2", source: "capprove", target: "act2", sourceHandle: "no" },
+    // 逃逸邊帶 sourceHandle,用以證明 Q2 過濾:它不該出現在 options。
+    { id: "et", source: "capprove", target: "esc2", sourceHandle: "escalate", trigger: "timeout" },
+    { id: "e3", source: "esc2", target: "end", sourceHandle: "auto" },
+    { id: "e4", source: "act1", target: "end" },
+    { id: "e5", source: "act2", target: "end" },
+  ],
+};
+
+describe("advance —— condition 節點 timeout(approval-escalation, #265)", () => {
+  it("落在 condition 時 options 排除 trigger:'timeout' 邊(Q2)", () => {
+    const s = startFlow(escDoc);
+    expect(s).toMatchObject({ at: "capprove", awaiting: "decision" });
+    expect(s.options).toEqual(["yes", "no"]);
+    expect(s.options).not.toContain("escalate");
+  });
+  it("condition 節點 timeout → 沿 trigger:'timeout' 邊落在逃逸目標", () => {
+    const start = startFlow(escDoc);
+    const s = advance(escDoc, start, { type: "timeout" });
+    expect(s).toMatchObject({ at: "esc2", awaiting: "decision" });
+  });
+  it("逃逸目標仍是 condition → 新 state 列出其 options", () => {
+    const s = advance(
+      escDoc,
+      { at: "capprove", status: "running", awaiting: "decision", context: { days: 3 } },
+      { type: "timeout" },
+    );
+    expect(s.at).toBe("esc2");
+    expect(s.options).toEqual(["auto"]);
+    // context 透傳但不共享物件(與 form/action timeout 一致,不 merge 新資料)。
+    expect(s.context).toEqual({ days: 3 });
+  });
+  it("condition 無 timeout 邊 → FlowError no-edge(#265 向後相容註記:原為 wrong-event)", () => {
+    // 原 doc 的 cond1 無 timeout 邊
+    expectFlowError(
+      () => advance(doc, { at: "cond1", status: "running", awaiting: "decision", context: {} }, { type: "timeout" }),
+      "no-edge",
+    );
+  });
+});
+
 describe("advance —— 錯誤", () => {
   it("wrong-event:awaiting decision 卻餵 submit", () => {
     expectFlowError(

--- a/packages/flow-core/src/runtime.ts
+++ b/packages/flow-core/src/runtime.ts
@@ -30,7 +30,7 @@ export class FlowError extends Error {
   }
 }
 
-const nodeById = (doc: FlowDoc, id: string): FlowNode => {
+const requireNode = (doc: FlowDoc, id: string): FlowNode => {
   const n = doc.nodes.find((x) => x.id === id);
   if (!n) throw new FlowError("no-path", `node not found: ${id}`);
   return n;
@@ -48,11 +48,13 @@ function awaitingFor(type: FlowNode["type"]): FlowAwaiting {
 
 /** 到達 nodeId,計算落地狀態。 */
 function land(doc: FlowDoc, nodeId: string, context: Record<string, unknown>): FlowState {
-  const node = nodeById(doc, nodeId);
+  const node = requireNode(doc, nodeId);
   if (node.type === "end") return { at: nodeId, status: "done", awaiting: null, context };
   const state: FlowState = { at: nodeId, status: "running", awaiting: awaitingFor(node.type), context };
   if (node.type === "condition") {
+    // timeout 出邊是自動逃逸路徑(escalation),不是人可選的決策選項,故排除。
     state.options = outEdges(doc, nodeId)
+      .filter((e) => e.trigger !== "timeout")
       .map((e) => e.sourceHandle)
       .filter((h): h is string => typeof h === "string");
   }
@@ -88,7 +90,7 @@ export function startFlow(doc: FlowDoc): FlowState {
 /** 走一步:事件須配得上目前節點,否則丟 FlowError。 */
 export function advance(doc: FlowDoc, state: FlowState, event: FlowEvent): FlowState {
   if (state.status !== "running") throw new FlowError("wrong-event", `flow is ${state.status}`);
-  const node = nodeById(doc, state.at);
+  const node = requireNode(doc, state.at);
   const ctx = state.context;
 
   switch (event.type) {
@@ -109,7 +111,9 @@ export function advance(doc: FlowDoc, state: FlowState, event: FlowEvent): FlowS
       return land(doc, edge.target, { ...ctx });
     }
     case "timeout":
-      if (node.type !== "form" && node.type !== "action") throw new FlowError("wrong-event", `timeout at ${node.type}`);
+      // condition 節點也支援 timeout(approval-escalation:核准步驟逾時 → 沿 trigger:'timeout' 邊逃逸)。
+      if (node.type !== "form" && node.type !== "action" && node.type !== "condition")
+        throw new FlowError("wrong-event", `timeout at ${node.type}`);
       return land(doc, timeoutTarget(doc, node.id), { ...ctx });
   }
 }


### PR DESCRIPTION
Two flow-core primitives the BPM/approval scenario surfaced (the engine gaps flagged in `docs/bpm-engine-readiness.md`).

- **#265** — timeout events now fire on `condition` nodes (approval-escalation), not just `form`/`action`. Schema needed no change (`edge.trigger` was already free-form); the `advance` guard was relaxed. A condition's `trigger:'timeout'` edges are excluded from the human-selectable `options`. Behavior notes: a condition with no timeout edge now yields `FlowError('no-edge')` (was `wrong-event`).
- **#280** — new graph layer (`graph.ts`): `reachableNodes`/`ancestorNodes` (forward/reverse BFS, visited-set cycle cutoff, `filter` = collection vs `follow` = traversal semantics, `includeSelf`), plus `nodeById(doc)`/`outgoingEdges(doc)` indexes. Dangling edge targets are skipped; unknown ids return `[]`. Frees consumers from hand-rolling BFS over `doc.edges`. (The private `nodeById(doc,id)` helper was renamed `requireNode`.)

Verified: 49 tests + typecheck green. Opus-reviewed — 0 findings (filter/follow semantics, cycle cutoff, rename, and options-filter all confirmed). No in-repo consumer breakage.

Changeset: `@rfjs/flow-core` minor.

Closes #265
Closes #280

_Governa dogfood #8 / #32._

🤖 Generated with [Claude Code](https://claude.com/claude-code)