### PR TITLE
feat(data-filter,flow-core): export the condition vocabulary the evaluator dispatches on

### DIFF
--- a/.changeset/gov-data-filter-condition-vocabulary.md
+++ b/.changeset/gov-data-filter-condition-vocabulary.md
@@ -1,0 +1,56 @@
+---
+"@rfjs/data-filter": minor
+---
+
+Put the condition **vocabulary** on the public surface, so a consumer can ask
+"can the engine evaluate this condition?" before evaluating it — against the
+same tables the evaluator dispatches on.
+
+The gap this closes: a condition can be perfectly well-*shaped* and still name a
+`dataType` the engine has never heard of. `{ field: 'x', dataType: 'wat',
+operator: 'eq', value: 1 }` passes any shape check, and only throws
+`[data-filter] unsupported dataType 'wat'` at evaluation time — which for a
+consumer that validates at authoring time and evaluates later is a 500 at
+runtime instead of a 400 at save time. The operator allowlists existed as real
+`as const` arrays but were not exported; the dataType vocabulary had no runtime
+counterpart at all.
+
+**New exports**
+
+- `validateCondition(condition)` / `validateMatchQuery(query)` —
+  `{ ok: true } | { ok: false, issues }`, where each issue carries a stable
+  `code`, the evaluator's own `message`, and a `path` naming the offending node.
+  `validateMatchQuery` walks nested groups and `elemmatch` sub-groups and also
+  checks each group's `logic`.
+- `supportedOperators(dataType, elementType?)` — what the engine accepts there,
+  or `undefined` when the type combination itself is not evaluable.
+- `MATCH_QUERY_DATA_TYPES`, `MATCH_QUERY_ELEMENT_TYPES`, `LOGICAL_OPERATORS`,
+  `OPERATORS_BY_DATA_TYPE`, `ELEM_MATCH_OPERATORS`,
+  `assertMatchQueryDataType`, and the previously-internal operator module
+  (`STRING_OPERATORS`, `NUMERIC_OPERATORS`, `DATE_OPERATORS`,
+  `BOOLEAN_OPERATORS`, `OBJECT_OPERATORS`, `*_ARRAY_OPERATORS`,
+  `ARRAY_OPERATORS_BY_ELEMENT`, `operatorsForArrayElement`, `assertOperator`).
+- Types `MatchQueryConditionDataType` (= `MatchQueryMetadata['dataType']`),
+  `MatchQueryElementType`, `ConditionIssue`, `ConditionIssueCode`,
+  `VocabularyResult`.
+
+**No second copy.** The operator tables *are* the arrays the matchers pass to
+`assertOperator`, and the dataType/elementType/logic lists are `Object.keys` of
+presence maps typed against `MatchQueryMetadata` / `LogicalOperator` — so a
+dataType added to the union (and therefore to the `never`-exhaustive
+`createMatchQuery` switch) fails to compile until it is listed.
+`createMatchQuery` now gates on `MATCH_QUERY_DATA_TYPES` before dispatching, so
+the exported list is load-bearing rather than descriptive: a dataType in the
+switch but missing from the list stops evaluating.
+
+**Behaviour**
+
+- `dataType: 'array'` with an unknown `elementType` now throws
+  `[data-filter] unsupported elementType '…' for dataType 'array'` instead of a
+  `TypeError` from indexing the operator table blind (only reachable from
+  untyped JSON input).
+- Everything else is unchanged; the `unsupported dataType` message is identical.
+
+Scope is vocabulary only — it does not validate tree *shape* (that is
+`parseFilterGroup` in `@rfjs/filter-builder`) nor operator/value arity (`range`
+still throws at runtime when not given two values).

--- a/.changeset/gov-filter-builder-vocabulary-guard.md
+++ b/.changeset/gov-filter-builder-vocabulary-guard.md
@@ -1,0 +1,20 @@
+---
+"@rfjs/filter-builder": patch
+---
+
+Stop the data-filter engine adapter from offering an operator the engine
+rejects, and derive its coverage set from `@rfjs/data-filter`'s exported
+vocabulary instead of a hand-maintained copy.
+
+`operators('array', 'boolean')` advertised `containsall`, which
+`BOOLEAN_ARRAY_OPERATORS` does not carry (`containsall` is string/numeric/date
+by design) — so picking it in the editor produced a condition the evaluator
+throws on: the validator says fine, the engine throws. Removed, and pinned by a
+new subset guard that fails whenever the adapter offers anything
+`supportedOperators()` does not accept. The adapter's lists stay hand-written
+(offering a deliberate *subset* is legitimate — `ieq`/`ineq` are still withheld
+on string arrays); only offering a *superset* is now impossible.
+
+`DATA_FILTER_OPS` (the live-match coverage set) is now computed from
+`MATCH_QUERY_DATA_TYPES` × `supportedOperators()` rather than re-listed, so it
+cannot drift from what `matchQuery` accepts.

--- a/.changeset/gov-flow-core-condition-vocabulary.md
+++ b/.changeset/gov-flow-core-condition-vocabulary.md
@@ -1,0 +1,26 @@
+---
+"@rfjs/flow-core": minor
+---
+
+Add `validateFlowConditions(doc)` and re-export `@rfjs/data-filter`'s condition
+vocabulary from the copy flow-core actually evaluates with.
+
+`edge.condition` is `unknown` in the schema, so an edge whose condition names a
+`dataType`/`operator` the evaluator doesn't know saves and publishes fine and
+then throws inside `resolveCondition` — at the moment a user submits, not at the
+moment an author saves. `validateFlowConditions(doc)` walks every edge with a
+condition and returns each problem as `{ edgeId, code, message, path }`, so a
+consumer can turn it into a 400 that names the offending edge.
+
+The re-export is the point, not a convenience. `resolveCondition` evaluates with
+the `@rfjs/data-filter` in *flow-core's* dependency tree; a consumer that
+depends on `@rfjs/data-filter` separately can resolve a different copy (pnpm
+installs both without complaint), and then the vocabulary it validates against
+is not the vocabulary that evaluates — the exact drift the vocabulary API exists
+to prevent, one layer deeper. Importing `validateCondition`,
+`validateMatchQuery`, `supportedOperators`, `MATCH_QUERY_DATA_TYPES`,
+`MATCH_QUERY_ELEMENT_TYPES`, `LOGICAL_OPERATORS`, `OPERATORS_BY_DATA_TYPE` or
+`ARRAY_OPERATORS_BY_ELEMENT` from `@rfjs/flow-core` makes that impossible.
+
+Vocabulary only: tree *shape* is `@rfjs/filter-builder`'s `parseFilterGroup`,
+and operator/value arity is still a runtime throw.

--- a/packages/data-filter/README.md
+++ b/packages/data-filter/README.md
@@ -92,6 +92,63 @@ JSONB engines, so a filter tree stays portable across engines.
 
 **Logic operators**: `and`, `or`, `nor`, `not`
 
+### Condition vocabulary — validate before you evaluate
+
+A condition can be perfectly well-*shaped* and still name a `dataType` or
+`operator` the engine has never heard of. The evaluator throws on it, which for
+a consumer that validated at authoring time and evaluated later means a 500 at
+runtime rather than a 400 at save time:
+
+```typescript
+matchQuery(data, { logic: 'and', filters: [
+  { field: 'x', dataType: 'wat', operator: 'eq', value: 1 },
+]});
+// Error: [data-filter] unsupported dataType 'wat'
+```
+
+The vocabulary the evaluator dispatches on is exported, so a consumer checks the
+condition against the engine's own tables instead of hand-rolling a copy that
+drifts:
+
+```typescript
+import { validateCondition, validateMatchQuery, supportedOperators } from '@rfjs/data-filter';
+
+validateCondition({ field: 'x', dataType: 'wat', operator: 'eq', value: 1 });
+// { ok: false, issues: [{ code: 'unsupportedDataType',
+//                         message: "[data-filter] unsupported dataType 'wat'", path: '' }] }
+
+validateMatchQuery(tree);          // walks nested groups and elemmatch sub-groups
+supportedOperators('array', 'string');  // readonly ['eq', 'contains', …] — populate a picker
+```
+
+| Export | What it is |
+|--------|------------|
+| `validateCondition(condition)` | One leaf: `{ ok: true }` or `{ ok: false, issues }`. Descends into an `elemmatch` sub-group. |
+| `validateMatchQuery(query)` | A whole `FilterMatchQuery`: walks nested groups, also checks each group's `logic`. Every issue carries a `path` (`filters[1].filters[0]`). |
+| `supportedOperators(dataType, elementType?)` | The operators the engine accepts there, or `undefined` if the type combination itself is not evaluable. |
+| `MATCH_QUERY_DATA_TYPES` | Every `dataType` a leaf may declare — `string`, `numeric`, `date`, `boolean`, `object`, `array`. |
+| `MATCH_QUERY_ELEMENT_TYPES` | Every `elementType` an `array` leaf may declare (adds `object`). |
+| `LOGICAL_OPERATORS` | `and`, `or`, `nor`, `not`. |
+| `OPERATORS_BY_DATA_TYPE`, `ARRAY_OPERATORS_BY_ELEMENT`, `STRING_OPERATORS` … | The raw allowlists the matchers pass to `assertOperator`. |
+| `assertOperator(dataType, operator, allowed)` | The throwing check the matchers use. |
+
+These are the *same* arrays the matchers assert against, and
+`MATCH_QUERY_DATA_TYPES` is what `createMatchQuery` gates on before it
+dispatches — so the exported vocabulary cannot say "yes" to something the
+engine then rejects. The lists are `Object.keys` of presence maps typed against
+`MatchQueryMetadata`, so a dataType added to the union (and therefore to the
+`never`-exhaustive dispatch switch) fails to compile until it is listed.
+
+Scope: **vocabulary only**. It does not check the tree's shape (use
+`parseFilterGroup` from [`@rfjs/filter-builder`](../filter-builder)) nor whether
+`value` suits the operator (`range` wanting exactly two values is still a
+runtime throw).
+
+> `MatchQueryDataType` is **not** this list — it is the narrower scalar/element
+> vocabulary (`string | numeric | boolean | date`), which is what an `array`
+> condition's `elementType` may be. The leaf-level set is
+> `MatchQueryConditionDataType` (= `MatchQueryMetadata['dataType']`).
+
 ### Match Classes
 
 Under-the-hood match classes for each data type:
@@ -197,10 +254,19 @@ type FilterMatchQuery = {
   filters: (MatchQueryMetadata | FilterMatchQuery)[];
 };
 
-type MatchQueryMetadata = {
-  field: string;
-  dataType: 'string' | 'numeric' | 'boolean' | 'date';
-  operator: DefaultFilterOperator | TextFilterOperator | NumericFilterOperator | DateFilterOperator;
-  value: ValueType;
-};
+// A discriminated union, one variant per dataType — an operator invalid for its
+// dataType is a compile error. `MATCH_QUERY_DATA_TYPES` is the runtime list of
+// the discriminants below.
+type MatchQueryMetadata =
+  | StringCondition   // dataType: 'string'
+  | NumericCondition  // dataType: 'numeric'
+  | DateCondition     // dataType: 'date'
+  | BooleanCondition  // dataType: 'boolean'
+  | ObjectCondition   // dataType: 'object'
+  | StringArrayCondition | NumericArrayCondition | DateArrayCondition | BooleanArrayCondition
+  | ElemMatchCondition;  // dataType: 'array', elementType: 'object'
+
+// The scalar/element vocabulary — an `array` condition's `elementType`.
+// NOT the leaf-level dataType set; that is `MatchQueryConditionDataType`.
+type MatchQueryDataType = 'string' | 'numeric' | 'boolean' | 'date';
 ```

--- a/packages/data-filter/README.zh-TW.md
+++ b/packages/data-filter/README.zh-TW.md
@@ -89,6 +89,57 @@ resolvePath(data, 'user.missing', { fallbackOnEmpty: false }); // null instead o
 
 **邏輯運算子**：`and`, `or`, `nor`, `not`
 
+### 條件詞彙——求值前先驗證
+
+條件的**形狀**完全合法,卻寫了引擎不認得的 `dataType` 或 `operator`,是兩回事。後者引擎
+會丟例外——對「編輯時驗證、之後才求值」的消費端來說,那是執行期的 500,而不是存檔當下
+的 400:
+
+```typescript
+matchQuery(data, { logic: 'and', filters: [
+  { field: 'x', dataType: 'wat', operator: 'eq', value: 1 },
+]});
+// Error: [data-filter] unsupported dataType 'wat'
+```
+
+引擎派送時依據的詞彙表已對外開放,消費端可直接拿引擎那份來驗,不必自己抄一份、然後
+慢慢走鐘:
+
+```typescript
+import { validateCondition, validateMatchQuery, supportedOperators } from '@rfjs/data-filter';
+
+validateCondition({ field: 'x', dataType: 'wat', operator: 'eq', value: 1 });
+// { ok: false, issues: [{ code: 'unsupportedDataType',
+//                         message: "[data-filter] unsupported dataType 'wat'", path: '' }] }
+
+validateMatchQuery(tree);          // 會走進巢狀群組與 elemmatch 子群組
+supportedOperators('array', 'string');  // readonly ['eq', 'contains', …] — 可直接餵給選單
+```
+
+| 匯出 | 說明 |
+|------|------|
+| `validateCondition(condition)` | 單一葉節點:`{ ok: true }` 或 `{ ok: false, issues }`;會下探 `elemmatch` 子群組。 |
+| `validateMatchQuery(query)` | 整棵 `FilterMatchQuery`:走訪巢狀群組,並檢查每個群組的 `logic`。每個 issue 都帶 `path`(`filters[1].filters[0]`)。 |
+| `supportedOperators(dataType, elementType?)` | 該型別組合下引擎接受的運算子;型別組合本身不可求值時回 `undefined`。 |
+| `MATCH_QUERY_DATA_TYPES` | 葉節點可宣告的所有 `dataType`——`string`、`numeric`、`date`、`boolean`、`object`、`array`。 |
+| `MATCH_QUERY_ELEMENT_TYPES` | `array` 葉節點可宣告的所有 `elementType`(多一個 `object`)。 |
+| `LOGICAL_OPERATORS` | `and`、`or`、`nor`、`not`。 |
+| `OPERATORS_BY_DATA_TYPE`、`ARRAY_OPERATORS_BY_ELEMENT`、`STRING_OPERATORS` … | 比對類別丟給 `assertOperator` 的原始允許清單。 |
+| `assertOperator(dataType, operator, allowed)` | 比對類別自己用的那個會丟例外的檢查。 |
+
+這些就是比對類別實際拿來斷言的**同一批**陣列,而 `MATCH_QUERY_DATA_TYPES` 是
+`createMatchQuery` 派送前把關的那份——所以詞彙表不可能說 OK、引擎卻拒收。清單本身是
+以 `MatchQueryMetadata` 定型的 presence map 取 `Object.keys` 而來,union(以及因此
+`never` 窮盡的派送 switch)新增一個 dataType 時,沒補進來就編不過。
+
+範圍:**只驗詞彙**。不驗樹的形狀(那是
+[`@rfjs/filter-builder`](../filter-builder) 的 `parseFilterGroup`),也不驗 `value`
+與運算子的搭配(`range` 需要剛好兩個值,仍是執行期例外)。
+
+> `MatchQueryDataType` **不是**這份清單,它是較窄的純量/元素詞彙
+> (`string | numeric | boolean | date`),也就是 `array` 條件的 `elementType` 可用值。
+> 葉節點層級的集合叫 `MatchQueryConditionDataType`(= `MatchQueryMetadata['dataType']`)。
+
 ### 比對類別
 
 各資料型別底層的比對類別：
@@ -188,10 +239,18 @@ type FilterMatchQuery = {
   filters: (MatchQueryMetadata | FilterMatchQuery)[];
 };
 
-type MatchQueryMetadata = {
-  field: string;
-  dataType: 'string' | 'numeric' | 'boolean' | 'date';
-  operator: DefaultFilterOperator | TextFilterOperator | NumericFilterOperator | DateFilterOperator;
-  value: ValueType;
-};
+// 以 dataType 區分的 discriminated union,一個 dataType 一個變體——用錯運算子會編譯失敗。
+// `MATCH_QUERY_DATA_TYPES` 就是下面這些判別值的執行期清單。
+type MatchQueryMetadata =
+  | StringCondition   // dataType: 'string'
+  | NumericCondition  // dataType: 'numeric'
+  | DateCondition     // dataType: 'date'
+  | BooleanCondition  // dataType: 'boolean'
+  | ObjectCondition   // dataType: 'object'
+  | StringArrayCondition | NumericArrayCondition | DateArrayCondition | BooleanArrayCondition
+  | ElemMatchCondition;  // dataType: 'array', elementType: 'object'
+
+// 純量/元素詞彙——即 `array` 條件的 `elementType`。
+// 這不是葉節點層級的 dataType 集合,那個叫 `MatchQueryConditionDataType`。
+type MatchQueryDataType = 'string' | 'numeric' | 'boolean' | 'date';
 ```

--- a/packages/data-filter/src/filter/index.ts
+++ b/packages/data-filter/src/filter/index.ts
@@ -1,3 +1,4 @@
+export * from './vocabulary';
 export * from './matchQuery';
 export * from './matchAndMap';
 export * from './compileMatchQuery';

--- a/packages/data-filter/src/filter/matchQuery.ts
+++ b/packages/data-filter/src/filter/matchQuery.ts
@@ -15,6 +15,7 @@ import type {
   LogicalOperator,
 } from '../types';
 import { isExpression } from '@rfjs/data-expr';
+import { assertMatchQueryDataType } from './vocabulary';
 
 export function matchQueryArray(
   data: ObjectData[],
@@ -100,6 +101,11 @@ export function createMatchQuery(
       `[data-filter] '=' expression slots require the async api — use compileMatchQuery or matchQueryAsync`,
     );
   }
+  // Gate on the exported vocabulary rather than only on the switch's `default`
+  // arm, so `MATCH_QUERY_DATA_TYPES` is the list the engine actually dispatches
+  // through: a dataType present in the switch but missing from it stops
+  // evaluating, and every test for that dataType goes red.
+  assertMatchQueryDataType(metadata.dataType);
   switch (metadata.dataType) {
     case 'string':
       return new TextMatch(metadata.field, metadata.operator, metadata.value, data);

--- a/packages/data-filter/src/filter/vocabulary.spec.ts
+++ b/packages/data-filter/src/filter/vocabulary.spec.ts
@@ -1,0 +1,299 @@
+import { describe, it, expect } from 'vitest';
+import {
+  LOGICAL_OPERATORS,
+  MATCH_QUERY_DATA_TYPES,
+  MATCH_QUERY_ELEMENT_TYPES,
+  supportedOperators,
+  validateCondition,
+  validateMatchQuery,
+} from './vocabulary';
+import { createMatchQuery } from './matchQuery';
+import type { MatchQueryMetadata, ObjectData } from '../types';
+
+/** A row rich enough that every dataType resolves to a plausible value. */
+const ROW: ObjectData = {
+  s: 'abc',
+  n: 3,
+  b: true,
+  d: '2026-01-01',
+  o: { k: 1 },
+  arr: ['a'],
+  items: [{ sku: 'A' }],
+};
+
+const FIELD_BY_TYPE: Record<string, string> = {
+  string: 's',
+  numeric: 'n',
+  boolean: 'b',
+  date: 'd',
+  object: 'o',
+  array: 'arr',
+};
+
+/**
+ * A minimally plausible condition for a (dataType, elementType, operator)
+ * triple. Values are chosen so only *vocabulary* errors can be thrown — arity
+ * errors (`range` wants two values) are avoided.
+ */
+function conditionFor(
+  dataType: string,
+  operator: string,
+  elementType?: string,
+): MatchQueryMetadata {
+  const base: Record<string, unknown> = {
+    field: elementType === 'object' ? 'items' : FIELD_BY_TYPE[dataType],
+    dataType,
+    operator,
+  };
+  if (elementType !== undefined) base.elementType = elementType;
+  if (operator === 'elemmatch') {
+    base.filters = {
+      logic: 'and',
+      filters: [{ field: 'sku', dataType: 'string', operator: 'eq', value: 'A' }],
+    };
+    return base as unknown as MatchQueryMetadata;
+  }
+  const scalar = elementType ?? dataType;
+  const one =
+    scalar === 'numeric' ? 1 : scalar === 'boolean' ? true : scalar === 'date' ? '2026-01-01' : 'a';
+  base.value =
+    operator === 'range'
+      ? [one, one]
+      : operator === 'terms' || operator === 'containsall'
+        ? [one]
+        : dataType === 'object'
+          ? { k: 1 }
+          : one;
+  return base as unknown as MatchQueryMetadata;
+}
+
+/** Run the engine and report only whether it rejected the *vocabulary*. */
+function vocabularyErrorFrom(condition: MatchQueryMetadata): string | null {
+  try {
+    createMatchQuery(ROW, condition);
+    return null;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return /unsupported (dataType|operator|elementType)/.test(message) ? message : null;
+  }
+}
+
+/** Every (dataType, elementType) pair the exported vocabulary claims is evaluable. */
+const TYPE_PAIRS: { dataType: string; elementType?: string }[] =
+  MATCH_QUERY_DATA_TYPES.flatMap((dataType) =>
+    dataType === 'array'
+      ? MATCH_QUERY_ELEMENT_TYPES.map((elementType) => ({ dataType, elementType }))
+      : [{ dataType }],
+  );
+
+describe('vocabulary ↔ evaluator divergence guard', () => {
+  it('claims a non-empty operator set for every type pair it lists', () => {
+    for (const { dataType, elementType } of TYPE_PAIRS) {
+      const ops = supportedOperators(dataType, elementType);
+      expect(ops, `${dataType}<${String(elementType)}>`).toBeDefined();
+      expect(ops!.length, `${dataType}<${String(elementType)}>`).toBeGreaterThan(0);
+    }
+  });
+
+  it('the evaluator accepts every dataType/operator the vocabulary advertises', () => {
+    for (const { dataType, elementType } of TYPE_PAIRS) {
+      for (const operator of supportedOperators(dataType, elementType)!) {
+        const label = `${dataType}<${String(elementType)}>.${operator}`;
+        expect(
+          vocabularyErrorFrom(conditionFor(dataType, operator, elementType)),
+          label,
+        ).toBeNull();
+      }
+    }
+  });
+
+  it('the evaluator rejects every operator the vocabulary withholds', () => {
+    // Sampled from the union of all operators the package knows, so an operator
+    // dropped from one table but still dispatched by a matcher shows up here.
+    const allOperators = new Set(
+      TYPE_PAIRS.flatMap(({ dataType, elementType }) => [
+        ...supportedOperators(dataType, elementType)!,
+      ]),
+    );
+    const accepted: string[] = [];
+    for (const { dataType, elementType } of TYPE_PAIRS) {
+      // `array<object>` is exempt: `createMatchQuery` routes on `elementType`
+      // and hands the leaf to `ElemMatch`, which never reads `operator` — so
+      // the engine cannot reject one. `validateCondition` is stricter than the
+      // engine here on purpose (see its own spec below).
+      if (elementType === 'object') continue;
+      const allowed = new Set(supportedOperators(dataType, elementType));
+      for (const operator of allOperators) {
+        if (allowed.has(operator)) continue;
+        const error = vocabularyErrorFrom(conditionFor(dataType, operator, elementType));
+        if (error === null) accepted.push(`${dataType}<${String(elementType)}>.${operator}`);
+      }
+    }
+    expect(accepted).toEqual([]);
+  });
+
+  it('validateCondition agrees with the evaluator on every advertised pair', () => {
+    for (const { dataType, elementType } of TYPE_PAIRS) {
+      for (const operator of supportedOperators(dataType, elementType)!) {
+        const condition = conditionFor(dataType, operator, elementType);
+        const label = `${dataType}<${String(elementType)}>.${operator}`;
+        expect(validateCondition(condition).ok, label).toBe(true);
+        expect(vocabularyErrorFrom(condition), label).toBeNull();
+      }
+    }
+  });
+
+  it('validateCondition agrees with the evaluator on every withheld operator', () => {
+    const disagreed: string[] = [];
+    for (const { dataType, elementType } of TYPE_PAIRS) {
+      if (elementType === 'object') continue; // see the exemption above
+      const allowed = new Set(supportedOperators(dataType, elementType));
+      for (const operator of ['wat', 'constructor', 'toString', 'containsall', 'range']) {
+        if (allowed.has(operator)) continue;
+        const condition = conditionFor(dataType, operator, elementType);
+        const engineRejected = vocabularyErrorFrom(condition) !== null;
+        if (validateCondition(condition).ok !== !engineRejected) {
+          disagreed.push(`${dataType}<${String(elementType)}>.${operator}`);
+        }
+        if (!engineRejected) disagreed.push(`${dataType}<${String(elementType)}>.${operator} (engine accepted)`);
+      }
+    }
+    expect(disagreed).toEqual([]);
+  });
+
+  it('lists the logic operators logicMatchQuery implements', () => {
+    expect([...LOGICAL_OPERATORS].sort()).toEqual(['and', 'nor', 'not', 'or']);
+  });
+});
+
+describe('validateCondition', () => {
+  // The leaf that motivated this API: shape-valid, vocabulary-invalid. It used
+  // to pass authoring-time validation and throw at evaluation time instead.
+  const wat = { field: 'x', dataType: 'wat', operator: 'eq', value: 1 };
+
+  it("rejects the dataType 'wat' leaf with the evaluator's own message", () => {
+    const result = validateCondition(wat);
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.issues).toEqual([
+      {
+        code: 'unsupportedDataType',
+        message: "[data-filter] unsupported dataType 'wat'",
+        path: '',
+      },
+    ]);
+  });
+
+  it('the leaf it rejects is exactly the leaf the evaluator throws on', () => {
+    expect(() =>
+      createMatchQuery(ROW, wat as unknown as MatchQueryMetadata),
+    ).toThrow("[data-filter] unsupported dataType 'wat'");
+  });
+
+  it('accepts a well-formed leaf', () => {
+    expect(
+      validateCondition({ field: 's', dataType: 'string', operator: 'icontains', value: 'b' }),
+    ).toEqual({ ok: true });
+  });
+
+  it('rejects an operator that belongs to another dataType', () => {
+    const result = validateCondition({ field: 'b', dataType: 'boolean', operator: 'gt', value: 1 });
+    expect(result.ok === false && result.issues[0]!.code).toBe('unsupportedOperator');
+  });
+
+  it('rejects an array leaf with no elementType', () => {
+    const result = validateCondition({ field: 'arr', dataType: 'array', operator: 'eq', value: 'a' });
+    expect(result.ok === false && result.issues[0]!.code).toBe('missingElementType');
+  });
+
+  it('rejects an unknown elementType the way the evaluator now does', () => {
+    const bad = { field: 'arr', dataType: 'array', elementType: 'wat', operator: 'eq', value: 'a' };
+    expect(validateCondition(bad).ok).toBe(false);
+    expect(() => createMatchQuery(ROW, bad as unknown as MatchQueryMetadata)).toThrow(
+      "[data-filter] unsupported elementType 'wat' for dataType 'array'",
+    );
+  });
+
+  it('descends into an elemmatch sub-group', () => {
+    const result = validateCondition({
+      field: 'items',
+      dataType: 'array',
+      elementType: 'object',
+      operator: 'elemmatch',
+      filters: {
+        logic: 'and',
+        filters: [{ field: 'sku', dataType: 'wat', operator: 'eq', value: 'A' }],
+      },
+    });
+    expect(result.ok === false && result.issues).toEqual([
+      {
+        code: 'unsupportedDataType',
+        message: "[data-filter] unsupported dataType 'wat'",
+        path: 'filters.filters[0]',
+      },
+    ]);
+  });
+
+  it("rejects an array<object> leaf whose operator is not 'elemmatch'", () => {
+    // The evaluator routes on elementType and never looks at the operator here,
+    // so a typo'd operator silently evaluates as elemmatch. Caught at authoring.
+    const result = validateCondition({
+      field: 'items',
+      dataType: 'array',
+      elementType: 'object',
+      operator: 'eq',
+      filters: { logic: 'and', filters: [] },
+    });
+    expect(result.ok === false && result.issues[0]!.code).toBe('unsupportedOperator');
+  });
+
+  it('rejects a non-object', () => {
+    expect(validateCondition(null).ok).toBe(false);
+    expect(validateCondition('nope').ok).toBe(false);
+  });
+});
+
+describe('validateMatchQuery', () => {
+  it('accepts a well-formed tree', () => {
+    expect(
+      validateMatchQuery({
+        logic: 'and',
+        filters: [
+          { field: 's', dataType: 'string', operator: 'eq', value: 'abc' },
+          {
+            logic: 'or',
+            filters: [{ field: 'n', dataType: 'numeric', operator: 'gt', value: 1 }],
+          },
+        ],
+      }),
+    ).toEqual({ ok: true });
+  });
+
+  it('reports every offending leaf with its path', () => {
+    const result = validateMatchQuery({
+      logic: 'and',
+      filters: [
+        { field: 'x', dataType: 'wat', operator: 'eq', value: 1 },
+        {
+          logic: 'or',
+          filters: [{ field: 'b', dataType: 'boolean', operator: 'gt', value: 1 }],
+        },
+      ],
+    });
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.issues.map((i) => [i.code, i.path])).toEqual([
+      ['unsupportedDataType', 'filters[0]'],
+      ['unsupportedOperator', 'filters[1].filters[0]'],
+    ]);
+  });
+
+  it('rejects an unknown logic, which the evaluator silently treats as no-match', () => {
+    const query = { logic: 'xor', filters: [] };
+    const result = validateMatchQuery(query);
+    expect(result.ok === false && result.issues[0]!.code).toBe('unsupportedLogic');
+  });
+
+  it('rejects a missing filters array', () => {
+    const result = validateMatchQuery({ logic: 'and' });
+    expect(result.ok === false && result.issues[0]!.code).toBe('invalidFilters');
+  });
+});

--- a/packages/data-filter/src/filter/vocabulary.ts
+++ b/packages/data-filter/src/filter/vocabulary.ts
@@ -1,0 +1,325 @@
+import {
+  BOOLEAN_OPERATORS,
+  DATE_OPERATORS,
+  NUMERIC_OPERATORS,
+  OBJECT_OPERATORS,
+  STRING_OPERATORS,
+  operatorsForArrayElement,
+} from '../match/operators';
+import type { LogicalOperator, MatchQueryMetadata } from '../types';
+
+/**
+ * The `dataType` discriminant of every condition the evaluator can dispatch —
+ * derived from `MatchQueryMetadata`, never re-typed. `MatchQueryDataType` is a
+ * *different*, narrower set: it is the scalar/element vocabulary (no `object`,
+ * no `array`) and is what an `array` condition's `elementType` may be.
+ */
+export type MatchQueryConditionDataType = MatchQueryMetadata['dataType'];
+
+/** What `dataType: 'array'` may declare as its `elementType`, derived from the union. */
+export type MatchQueryElementType = Extract<
+  MatchQueryMetadata,
+  { dataType: 'array' }
+>['elementType'];
+
+/**
+ * Presence maps, not hand-written lists. TypeScript rejects the literal if a
+ * member of the union is missing (and rejects an extra key), and
+ * `createMatchQuery`'s `default` arm is a `never` exhaustiveness assertion — so
+ * the union, the dispatch switch, and these tables cannot drift apart. The
+ * exported arrays are the `Object.keys` of the maps, so there is exactly one
+ * declaration of each vocabulary in the package.
+ */
+const DATA_TYPE_PRESENCE: Record<MatchQueryConditionDataType, true> = {
+  string: true,
+  numeric: true,
+  date: true,
+  boolean: true,
+  object: true,
+  array: true,
+};
+
+const ELEMENT_TYPE_PRESENCE: Record<MatchQueryElementType, true> = {
+  string: true,
+  numeric: true,
+  date: true,
+  boolean: true,
+  object: true,
+};
+
+const LOGICAL_OPERATOR_PRESENCE: Record<LogicalOperator, true> = {
+  and: true,
+  or: true,
+  nor: true,
+  not: true,
+};
+
+/** Every `dataType` a condition leaf may declare. */
+export const MATCH_QUERY_DATA_TYPES = Object.keys(
+  DATA_TYPE_PRESENCE,
+) as readonly MatchQueryConditionDataType[];
+
+/** Every `elementType` a `dataType: 'array'` leaf may declare. */
+export const MATCH_QUERY_ELEMENT_TYPES = Object.keys(
+  ELEMENT_TYPE_PRESENCE,
+) as readonly MatchQueryElementType[];
+
+/** Every `logic` a filter group may declare. */
+export const LOGICAL_OPERATORS = Object.keys(
+  LOGICAL_OPERATOR_PRESENCE,
+) as readonly LogicalOperator[];
+
+/** `elemmatch` is the only operator for `dataType: 'array'` + `elementType: 'object'`. */
+export const ELEM_MATCH_OPERATORS = ['elemmatch'] as const;
+
+/**
+ * Operator allowlist per non-`array` `dataType` — the very arrays the matchers
+ * pass to `assertOperator`, not a copy of them. `array` is absent because its
+ * operators depend on `elementType`; use {@link supportedOperators}.
+ */
+export const OPERATORS_BY_DATA_TYPE: Record<
+  Exclude<MatchQueryConditionDataType, 'array'>,
+  readonly string[]
+> = {
+  string: STRING_OPERATORS,
+  numeric: NUMERIC_OPERATORS,
+  date: DATE_OPERATORS,
+  boolean: BOOLEAN_OPERATORS,
+  object: OBJECT_OPERATORS,
+};
+
+function ownOperators(dataType: string): readonly string[] | undefined {
+  return Object.prototype.hasOwnProperty.call(OPERATORS_BY_DATA_TYPE, dataType)
+    ? OPERATORS_BY_DATA_TYPE[
+        dataType as Exclude<MatchQueryConditionDataType, 'array'>
+      ]
+    : undefined;
+}
+
+/**
+ * The operators the evaluator accepts for a `dataType` (+ `elementType` when
+ * the dataType is `array`), or `undefined` when the type combination itself is
+ * not evaluable. Use this to populate a picker; use {@link validateCondition}
+ * to check one condition.
+ */
+export function supportedOperators(
+  dataType: string,
+  elementType?: string,
+): readonly string[] | undefined {
+  if (dataType === 'array') {
+    if (elementType === undefined) return undefined;
+    if (elementType === 'object') return ELEM_MATCH_OPERATORS;
+    return operatorsForArrayElement(elementType);
+  }
+  return ownOperators(dataType);
+}
+
+/**
+ * Throw the evaluator's own "unsupported dataType" error for a `dataType` that
+ * is not in {@link MATCH_QUERY_DATA_TYPES}. Called by `createMatchQuery` before
+ * it dispatches, which is what makes the exported list load-bearing: a dataType
+ * that reaches the switch but is missing here fails every test that uses it.
+ */
+export function assertMatchQueryDataType(dataType: string): void {
+  if (
+    !(MATCH_QUERY_DATA_TYPES as readonly string[]).includes(dataType)
+  ) {
+    throw new Error(`[data-filter] unsupported dataType '${dataType}'`);
+  }
+}
+
+export type ConditionIssueCode =
+  | 'notAnObject'
+  | 'unsupportedLogic'
+  | 'invalidFilters'
+  | 'unsupportedDataType'
+  | 'missingElementType'
+  | 'unsupportedElementType'
+  | 'unsupportedOperator';
+
+export interface ConditionIssue {
+  code: ConditionIssueCode;
+  /**
+   * The wording the evaluator itself throws for this case, where it has one —
+   * so an authoring-time 400 and a runtime 500 read the same.
+   */
+  message: string;
+  /**
+   * Location of the offending node inside the validated value. `''` for a leaf
+   * validated on its own; `filters[0].filters[2]` inside a group.
+   */
+  path: string;
+}
+
+export type VocabularyResult =
+  | { ok: true }
+  | { ok: false; issues: ConditionIssue[] };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+/**
+ * Render an untrusted vocabulary token for an error message. Never falls back
+ * to `[object Object]` — a non-primitive is reported as its `typeof`.
+ */
+function token(value: unknown): string {
+  if (typeof value === 'string') return value;
+  if (value === null || value === undefined) return String(value);
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  return typeof value;
+}
+
+/**
+ * Mirrors `matchQuery`'s own group/leaf discrimination (`_.has(filter, 'logic')`)
+ * so the validator walks exactly the nodes the evaluator walks.
+ */
+function isGroupNode(node: Record<string, unknown>): boolean {
+  return Object.prototype.hasOwnProperty.call(node, 'logic');
+}
+
+function collectConditionIssues(
+  condition: unknown,
+  path: string,
+  issues: ConditionIssue[],
+): void {
+  if (!isRecord(condition)) {
+    issues.push({
+      code: 'notAnObject',
+      message: `[data-filter] condition must be an object`,
+      path,
+    });
+    return;
+  }
+  const dataType = token(condition.dataType);
+  const operator = token(condition.operator);
+
+  if (!(MATCH_QUERY_DATA_TYPES as readonly string[]).includes(dataType)) {
+    issues.push({
+      code: 'unsupportedDataType',
+      message: `[data-filter] unsupported dataType '${dataType}'`,
+      path,
+    });
+    return;
+  }
+
+  if (dataType === 'array') {
+    if (condition.elementType === undefined) {
+      issues.push({
+        code: 'missingElementType',
+        message: `[data-filter] dataType 'array' requires an elementType`,
+        path,
+      });
+      return;
+    }
+    const elementType = token(condition.elementType);
+    if (
+      !(MATCH_QUERY_ELEMENT_TYPES as readonly string[]).includes(elementType)
+    ) {
+      issues.push({
+        code: 'unsupportedElementType',
+        message: `[data-filter] unsupported elementType '${elementType}' for dataType 'array'`,
+        path,
+      });
+      return;
+    }
+    const allowed = supportedOperators(dataType, elementType);
+    if (!allowed?.includes(operator)) {
+      issues.push({
+        code: 'unsupportedOperator',
+        message: `[data-filter] unsupported operator '${operator}' for dataType 'array<${elementType}>'`,
+        path,
+      });
+      return;
+    }
+    // `elemmatch` nests a whole group whose leaves the evaluator dispatches the
+    // same way — a bad dataType down there throws just as loudly, so recurse.
+    if (elementType === 'object') {
+      collectQueryIssues(condition.filters, `${path ? `${path}.` : ''}filters`, issues);
+    }
+    return;
+  }
+
+  const allowed = supportedOperators(dataType);
+  if (!allowed?.includes(operator)) {
+    issues.push({
+      code: 'unsupportedOperator',
+      message: `[data-filter] unsupported operator '${operator}' for dataType '${dataType}'`,
+      path,
+    });
+  }
+}
+
+function collectQueryIssues(
+  query: unknown,
+  path: string,
+  issues: ConditionIssue[],
+): void {
+  if (!isRecord(query)) {
+    issues.push({
+      code: 'notAnObject',
+      message: `[data-filter] filter group must be an object`,
+      path,
+    });
+    return;
+  }
+  const logic = token(query.logic);
+  if (!(LOGICAL_OPERATORS as readonly string[]).includes(logic)) {
+    // The evaluator does not throw here — `logicMatchQuery` falls through its
+    // switch and returns `false`, i.e. an unknown logic silently matches
+    // nothing. Reject it at authoring time instead.
+    issues.push({
+      code: 'unsupportedLogic',
+      message: `[data-filter] unsupported logic '${logic}'`,
+      path,
+    });
+  }
+  if (!Array.isArray(query.filters)) {
+    issues.push({
+      code: 'invalidFilters',
+      message: `[data-filter] filter group requires a 'filters' array`,
+      path,
+    });
+    return;
+  }
+  query.filters.forEach((child, index) => {
+    const childPath = `${path ? `${path}.` : ''}filters[${index}]`;
+    if (isRecord(child) && isGroupNode(child)) {
+      collectQueryIssues(child, childPath, issues);
+    } else {
+      collectConditionIssues(child, childPath, issues);
+    }
+  });
+}
+
+/**
+ * Answer "can the engine evaluate this condition leaf?" against the same
+ * dataType/operator tables `createMatchQuery` and the matchers dispatch on.
+ *
+ * Vocabulary only — it does not check the tree's *shape* (that is
+ * `parseFilterGroup` in `@rfjs/filter-builder`) nor whether `value` suits the
+ * operator (e.g. `range` wanting exactly two values). An `elemmatch` leaf's
+ * nested group is walked, because those leaves reach the same dispatch.
+ *
+ * ```ts
+ * validateCondition({ field: 'x', dataType: 'wat', operator: 'eq', value: 1 });
+ * // { ok: false, issues: [{ code: 'unsupportedDataType', message: "[data-filter] unsupported dataType 'wat'", path: '' }] }
+ * ```
+ */
+export function validateCondition(condition: unknown): VocabularyResult {
+  const issues: ConditionIssue[] = [];
+  collectConditionIssues(condition, '', issues);
+  return issues.length === 0 ? { ok: true } : { ok: false, issues };
+}
+
+/**
+ * {@link validateCondition} over a whole `FilterMatchQuery`: walks nested
+ * groups and `elemmatch` sub-groups, and also checks each group's `logic`.
+ * Returns every issue found (not just the first) with a `path` naming the
+ * offending node.
+ */
+export function validateMatchQuery(query: unknown): VocabularyResult {
+  const issues: ConditionIssue[] = [];
+  collectQueryIssues(query, '', issues);
+  return issues.length === 0 ? { ok: true } : { ok: false, issues };
+}

--- a/packages/data-filter/src/match/ArrayMatch.ts
+++ b/packages/data-filter/src/match/ArrayMatch.ts
@@ -1,6 +1,6 @@
 import { resolvePath } from '../path/resolve';
 import { typeTransfer } from '../filter/matchQuery';
-import { assertOperator, ARRAY_OPERATORS_BY_ELEMENT } from './operators';
+import { assertOperator, operatorsForArrayElement } from './operators';
 import { TextMatch } from './TextMatch';
 import { NumericMatch } from './NumericMatch';
 import { DateMatch } from './DateMatch';
@@ -51,7 +51,15 @@ export class ArrayMatch {
     value: unknown,
     data: object,
   ) {
-    assertOperator(`array<${elementType}>`, operator, ARRAY_OPERATORS_BY_ELEMENT[elementType]);
+    const allowed = operatorsForArrayElement(elementType);
+    if (!allowed) {
+      // Only reachable from untyped input (JSON off the wire). Previously this
+      // indexed the table blind and died with a TypeError inside assertOperator.
+      throw new Error(
+        `[data-filter] unsupported elementType '${elementType}' for dataType 'array'`,
+      );
+    }
+    assertOperator(`array<${elementType}>`, operator, allowed);
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const raw = resolvePath(data, field);
     if (operator === 'isnull') {

--- a/packages/data-filter/src/match/index.ts
+++ b/packages/data-filter/src/match/index.ts
@@ -1,3 +1,4 @@
+export * from './operators';
 export * from './BooleanMatch';
 export * from './NumericMatch';
 export * from './TextMatch';

--- a/packages/data-filter/src/match/operators.ts
+++ b/packages/data-filter/src/match/operators.ts
@@ -1,3 +1,5 @@
+import type { MatchQueryDataType } from '../types';
+
 export const STRING_OPERATORS = [
   'eq',
   'neq',
@@ -54,12 +56,39 @@ export const NUMERIC_ARRAY_OPERATORS = [
 export const DATE_ARRAY_OPERATORS = NUMERIC_ARRAY_OPERATORS;
 export const BOOLEAN_ARRAY_OPERATORS = ['eq', 'isnull', 'isnotnull'] as const;
 
-export const ARRAY_OPERATORS_BY_ELEMENT: Record<string, readonly string[]> = {
+/**
+ * Operator allowlist per **scalar** array `elementType`. Keyed by
+ * `MatchQueryDataType`, so an element type added to that union has to be listed
+ * here to compile. `elementType: 'object'` is not here — it routes to
+ * `ElemMatch` and its only operator is `elemmatch`.
+ */
+export const ARRAY_OPERATORS_BY_ELEMENT: Record<
+  MatchQueryDataType,
+  readonly string[]
+> = {
   string: STRING_ARRAY_OPERATORS,
   numeric: NUMERIC_ARRAY_OPERATORS,
   date: DATE_ARRAY_OPERATORS,
   boolean: BOOLEAN_ARRAY_OPERATORS,
 };
+
+/**
+ * Own-property lookup into {@link ARRAY_OPERATORS_BY_ELEMENT}. Returns
+ * `undefined` for an unknown element type instead of an inherited
+ * `Object.prototype` member (`constructor`, `toString`, …), which would
+ * otherwise reach `assertOperator` as a non-array `allowed` and blow up with a
+ * `TypeError` rather than a domain error.
+ */
+export function operatorsForArrayElement(
+  elementType: string,
+): readonly string[] | undefined {
+  return Object.prototype.hasOwnProperty.call(
+    ARRAY_OPERATORS_BY_ELEMENT,
+    elementType,
+  )
+    ? ARRAY_OPERATORS_BY_ELEMENT[elementType as MatchQueryDataType]
+    : undefined;
+}
 
 /**
  * Throw if `operator` is not valid for `dataType`. Guards against typos,

--- a/packages/filter-builder/src/engines/data-filter.spec.ts
+++ b/packages/filter-builder/src/engines/data-filter.spec.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
 
+import {
+  MATCH_QUERY_DATA_TYPES,
+  MATCH_QUERY_ELEMENT_TYPES,
+  supportedOperators,
+} from "@rfjs/data-filter";
+
 import { treeToFilterGroup } from "../compile";
 import type { BuilderGroup } from "../types";
 import { dataFilterEngine, DATA_FILTER_OPS } from "./data-filter";
@@ -77,5 +83,46 @@ describe("DATA_FILTER_OPS coverage set", () => {
     }
     expect(DATA_FILTER_OPS.has("containsany")).toBe(false); // removed (use terms/containsall)
     expect(DATA_FILTER_OPS.has("haskey")).toBe(false);
+  });
+});
+
+describe("data-filter engine ↔ @rfjs/data-filter vocabulary", () => {
+  // The adapter's lists are an *editor* offer and may be a deliberate subset
+  // (e.g. `ieq`/`ineq` are withheld on string arrays). What is never allowed is
+  // offering something the engine rejects — that is the editor telling the user
+  // "this is fine" and the evaluator throwing on it later. `containsall` on a
+  // boolean array used to do exactly that.
+  const pairs: { dataType: string; elementType?: string }[] = MATCH_QUERY_DATA_TYPES.flatMap(
+    (dataType) =>
+      dataType === "array"
+        ? MATCH_QUERY_ELEMENT_TYPES.map((elementType) => ({ dataType, elementType }))
+        : [{ dataType }],
+  );
+
+  it("never offers an operator the evaluator would reject", () => {
+    const offered = pairs.flatMap(({ dataType, elementType }) =>
+      dataFilterEngine
+        .operators(dataType, elementType)
+        .map((o) => o.op)
+        .filter((op) => !(supportedOperators(dataType, elementType) ?? []).includes(op))
+        .map((op) => `${dataType}<${String(elementType)}>.${op}`),
+    );
+    expect(offered).toEqual([]);
+  });
+
+  it("covers every dataType the evaluator dispatches", () => {
+    for (const { dataType, elementType } of pairs) {
+      expect(
+        dataFilterEngine.operators(dataType, elementType).length,
+        `${dataType}<${String(elementType)}>`,
+      ).toBeGreaterThan(0);
+    }
+  });
+
+  it("DATA_FILTER_OPS is the evaluator's own operator union", () => {
+    const fromEngine = new Set(
+      pairs.flatMap(({ dataType, elementType }) => [...(supportedOperators(dataType, elementType) ?? [])]),
+    );
+    expect([...DATA_FILTER_OPS].sort()).toEqual([...fromEngine].sort());
   });
 });

--- a/packages/filter-builder/src/engines/data-filter.ts
+++ b/packages/filter-builder/src/engines/data-filter.ts
@@ -1,3 +1,9 @@
+import {
+  MATCH_QUERY_DATA_TYPES,
+  MATCH_QUERY_ELEMENT_TYPES,
+  supportedOperators,
+} from "@rfjs/data-filter";
+
 import type { FilterGroupLike } from "../compile";
 import { arityOf } from "./arity";
 import type { Engine, OperatorSpec } from "./types";
@@ -27,7 +33,10 @@ function arrayOps(elementType?: string): string[] {
   // For exact array membership use `terms` (any) / `containsall` (all); `contains`
   // is per-element substring by design, not membership (see issue #267 and the
   // data-filter README operator table).
-  if (elementType === "boolean") return ["eq", "containsall", ...NULL_OPS];
+  // `containsall` is string/numeric/date only — data-filter's
+  // BOOLEAN_ARRAY_OPERATORS does not carry it, and offering it here produced a
+  // condition the engine throws on (caught by the vocabulary-subset guard).
+  if (elementType === "boolean") return ["eq", ...NULL_OPS];
   if (elementType === "numeric" || elementType === "date") {
     return ["eq", "gt", "gte", "lt", "lte", "range", "terms", "containsall", ...NULL_OPS];
   }
@@ -45,11 +54,17 @@ function toSpecs(ops: string[]): OperatorSpec[] {
   return [...new Set(ops)].map((op) => ({ op, arity: arityOf(op) }));
 }
 
-// Coverage set for live match: every operator data-filter can evaluate.
+// Coverage set for live match: every operator data-filter can evaluate. Derived
+// from the engine's own exported vocabulary rather than re-listed here, so it
+// cannot drift from what `matchQuery` actually accepts.
 export const DATA_FILTER_OPS = new Set<string>([
-  ...STRING_OPS, ...COMPARABLE_OPS, ...BOOLEAN_OPS, ...OBJECT_OPS,
-  "contains", "icontains", "startswith", "istartswith", "endswith", "iendswith",
-  "ieq", "ineq", "containsall", "elemmatch",
+  ...MATCH_QUERY_DATA_TYPES.flatMap((dataType) =>
+    dataType === "array"
+      ? MATCH_QUERY_ELEMENT_TYPES.flatMap((elementType) => [
+          ...(supportedOperators(dataType, elementType) ?? []),
+        ])
+      : [...(supportedOperators(dataType) ?? [])],
+  ),
 ]);
 
 export const dataFilterEngine: Engine = {

--- a/packages/flow-core/README.md
+++ b/packages/flow-core/README.md
@@ -12,7 +12,9 @@ IO, no persistence.
 schema.ts       FlowDoc / FlowNode / FlowEdge — the zod contract, and (de)serialization
 projection.ts   projectFlow — node-type-filtering view, contracting edges through
 runtime.ts      FlowState / FlowEvent / startFlow / advance / FlowError — the engine
-condition.ts    resolveCondition / resolveHandle — optional bridge to @rfjs/data-filter
+condition.ts    resolveCondition / resolveHandle / validateFlowConditions — the
+                @rfjs/data-filter bridge (evaluate, and validate against the
+                same copy that evaluates)
 ```
 
 Originally the FlowDoc contract lived inside `apps/web`'s `flow-builder` tool;
@@ -118,6 +120,38 @@ tried in order; the first whose condition matches `context` wins; an edge
 with **no** `condition` is treated as always-true (a handy default/fallback
 branch). `resolveHandle` returns `null` if nothing matches or the node has no
 condition edges.
+
+### validateFlowConditions — reject a bad condition at save time
+
+An `edge.condition` is `unknown` in the schema, so a leaf naming a `dataType` or
+`operator` the evaluator doesn't know saves and publishes fine and then throws
+inside `resolveCondition` — at the moment a user submits, not at the moment an
+author saves. Check it before persisting:
+
+```ts
+import { validateFlowConditions } from "@rfjs/flow-core";
+
+const result = validateFlowConditions(doc);
+if (!result.ok) return badRequest(result.issues);
+// [{ edgeId: 'e2', code: 'unsupportedDataType',
+//    message: "[data-filter] unsupported dataType 'wat'", path: 'filters[0]' }]
+```
+
+flow-core also re-exports the underlying condition vocabulary —
+`validateCondition`, `validateMatchQuery`, `supportedOperators`,
+`MATCH_QUERY_DATA_TYPES`, `MATCH_QUERY_ELEMENT_TYPES`, `LOGICAL_OPERATORS`,
+`OPERATORS_BY_DATA_TYPE`, `ARRAY_OPERATORS_BY_ELEMENT`.
+
+**Import them from here, not from `@rfjs/data-filter` directly.**
+`resolveCondition` evaluates with the `@rfjs/data-filter` copy in *flow-core's*
+dependency tree. A consumer that depends on `@rfjs/data-filter` separately can
+end up resolving a different copy — pnpm will happily install both — and then
+the vocabulary it validates against is not the vocabulary that evaluates. Taking
+it from flow-core makes that physically impossible.
+
+Scope: vocabulary only. The tree's *shape* is
+[`@rfjs/filter-builder`](../filter-builder)'s `parseFilterGroup`; operator/value
+arity (`range` wanting two values) is still a runtime throw.
 
 ## Contract
 

--- a/packages/flow-core/README.zh-TW.md
+++ b/packages/flow-core/README.zh-TW.md
@@ -8,7 +8,8 @@ Framework-agnostic 的 **FlowDoc 契約** + 純投影 + 純**狀態機 runtime**
 schema.ts       FlowDoc / FlowNode / FlowEdge —— zod 契約 + (反)序列化
 projection.ts   projectFlow —— 節點型別過濾投影,自動「縮線」接起邊
 runtime.ts      FlowState / FlowEvent / startFlow / advance / FlowError —— 引擎本體
-condition.ts    resolveCondition / resolveHandle —— 選配,接 @rfjs/data-filter
+condition.ts    resolveCondition / resolveHandle / validateFlowConditions —— 接
+                @rfjs/data-filter:求值,以及用「同一份 copy」的詞彙表驗證
 ```
 
 FlowDoc 契約原本住在 `apps/web` 的 `flow-builder` 工具裡;現在搬進這個套件,讓
@@ -106,6 +107,34 @@ if (handle) state = advance(doc, state, { type: "decide", handle });
 第一個 condition 成立的邊獲勝;沒有 `condition` 的邊視為恆真(可當
 default／fallback 分支用)。若都不成立、或該節點沒有出邊,`resolveHandle` 回傳
 `null`。
+
+### validateFlowConditions——存檔當下就擋掉壞條件
+
+schema 裡 `edge.condition` 是 `unknown`,所以一片寫了引擎不認得的 `dataType` 或
+`operator` 的葉節點,存得進去也發佈得出去,等到 `resolveCondition` 求值時才丟例外——
+爆的時機是使用者送出的那一刻,不是作者存檔的那一刻。存檔前先驗:
+
+```ts
+import { validateFlowConditions } from "@rfjs/flow-core";
+
+const result = validateFlowConditions(doc);
+if (!result.ok) return badRequest(result.issues);
+// [{ edgeId: 'e2', code: 'unsupportedDataType',
+//    message: "[data-filter] unsupported dataType 'wat'", path: 'filters[0]' }]
+```
+
+flow-core 也轉出底層的 condition 詞彙:`validateCondition`、`validateMatchQuery`、
+`supportedOperators`、`MATCH_QUERY_DATA_TYPES`、`MATCH_QUERY_ELEMENT_TYPES`、
+`LOGICAL_OPERATORS`、`OPERATORS_BY_DATA_TYPE`、`ARRAY_OPERATORS_BY_ELEMENT`。
+
+**請從這裡 import,不要直接從 `@rfjs/data-filter` 拿。** `resolveCondition` 是用
+**flow-core 依賴樹裡**那份 `@rfjs/data-filter` 求值的。消費端若另外自己依賴
+`@rfjs/data-filter`,可能解析到另一份(pnpm 完全可以同時裝兩份),於是驗證用的詞彙表
+和求值用的引擎分家。從 flow-core 拿,物理上就不會發生。
+
+範圍:只驗詞彙。樹的**形狀**是
+[`@rfjs/filter-builder`](../filter-builder) 的 `parseFilterGroup`;運算子與值的搭配
+(`range` 需要兩個值)仍是執行期例外。
 
 ## 契約
 

--- a/packages/flow-core/src/condition.spec.ts
+++ b/packages/flow-core/src/condition.spec.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 import type { FlowDoc } from "./schema";
-import { resolveCondition, resolveHandle } from "./condition";
+import {
+  resolveCondition,
+  resolveHandle,
+  validateCondition,
+  validateFlowConditions,
+  MATCH_QUERY_DATA_TYPES,
+} from "./condition";
 
 // data-filter 的 FilterMatchQuery 形狀(以 packages/data-filter/src/types/filter.ts 為準):
 // { logic, filters:[{ field, dataType, operator, value }] } —— leaf 欄位是 `field`,不是 `path`。
@@ -36,5 +42,62 @@ describe("resolveHandle", () => {
   });
   it("查無此節點的出邊 → null", async () => {
     expect(await resolveHandle(doc, "missing", { days: 5 })).toBe(null);
+  });
+});
+
+describe("validateFlowConditions", () => {
+  // 就是這片葉子:形狀合法、詞彙不合法 —— 以前存得進去、發佈得出去,
+  // 等到申請人送出表單才在 resolveCondition 丟例外(500 而不是 400)。
+  const wat = { logic: "and", filters: [{ field: "x", dataType: "wat", operator: "eq", value: 1 }] };
+
+  const docWith = (condition: unknown): FlowDoc => ({
+    version: 1,
+    nodes: [{ id: "cond1", type: "condition", position: { x: 0, y: 0 } }],
+    edges: [{ id: "bad-edge", source: "cond1", target: "a", sourceHandle: "yes", condition }],
+  });
+
+  it("合法的 doc → ok", () => {
+    expect(validateFlowConditions(doc)).toEqual({ ok: true });
+  });
+
+  it("擋下 dataType 'wat',並指出是哪一條邊", () => {
+    const result = validateFlowConditions(docWith(wat));
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.issues).toEqual([
+      {
+        edgeId: "bad-edge",
+        code: "unsupportedDataType",
+        message: "[data-filter] unsupported dataType 'wat'",
+        path: "filters[0]",
+      },
+    ]);
+  });
+
+  it("擋下的正是 resolveCondition 會丟例外的那一片", async () => {
+    const edge = docWith(wat).edges[0]!;
+    expect(validateFlowConditions(docWith(wat)).ok).toBe(false);
+    await expect(resolveCondition(edge, { x: 1 })).rejects.toThrow(
+      "[data-filter] unsupported dataType 'wat'",
+    );
+  });
+
+  it("無 condition 的邊不算問題", () => {
+    expect(validateFlowConditions({ ...doc, edges: [{ id: "e", source: "a", target: "b" }] })).toEqual({
+      ok: true,
+    });
+  });
+
+  it("轉出的詞彙表就是求值那份引擎的(同一個 copy)", () => {
+    expect([...MATCH_QUERY_DATA_TYPES].sort()).toEqual([
+      "array",
+      "boolean",
+      "date",
+      "numeric",
+      "object",
+      "string",
+    ]);
+    expect(validateCondition({ field: "days", dataType: "numeric", operator: "gt", value: 3 })).toEqual({
+      ok: true,
+    });
   });
 });

--- a/packages/flow-core/src/condition.ts
+++ b/packages/flow-core/src/condition.ts
@@ -1,5 +1,63 @@
-import { matchQueryAsync, type FilterMatchQuery, type ObjectData } from "@rfjs/data-filter";
+import {
+  matchQueryAsync,
+  validateMatchQuery,
+  type ConditionIssue,
+  type FilterMatchQuery,
+  type ObjectData,
+} from "@rfjs/data-filter";
 import type { FlowDoc, FlowEdge } from "./schema";
+
+/**
+ * data-filter 的「這個 condition 引擎跑得動嗎」詞彙表 —— 由 flow-core **自己那份**
+ * `@rfjs/data-filter` 轉出。
+ *
+ * 為什麼要轉出:`resolveCondition` 是用 flow-core 依賴樹裡那份 data-filter 求值的。
+ * 消費端若自己 import `@rfjs/data-filter` 來驗證,pnpm 完全可能裝到另一份(版本不同
+ * 就是兩份 copy),於是「驗證用的詞彙表」和「求值用的引擎」分家 —— 驗證說 OK、引擎卻
+ * 丟例外,正是這組 API 存在的理由。從這裡拿,物理上不可能拿到另一份。
+ */
+export {
+  validateCondition,
+  validateMatchQuery,
+  supportedOperators,
+  LOGICAL_OPERATORS,
+  MATCH_QUERY_DATA_TYPES,
+  MATCH_QUERY_ELEMENT_TYPES,
+  OPERATORS_BY_DATA_TYPE,
+  ARRAY_OPERATORS_BY_ELEMENT,
+} from "@rfjs/data-filter";
+export type {
+  ConditionIssue,
+  ConditionIssueCode,
+  VocabularyResult,
+  MatchQueryConditionDataType,
+  MatchQueryElementType,
+} from "@rfjs/data-filter";
+
+/** 帶上出處 edge 的 condition 詞彙問題。 */
+export interface EdgeConditionIssue extends ConditionIssue {
+  edgeId: string;
+}
+
+export type FlowConditionResult = { ok: true } | { ok: false; issues: EdgeConditionIssue[] };
+
+/**
+ * 存檔/發佈前檢查:doc 裡每條邊的 `condition` 是否都用了引擎認得的
+ * dataType / operator / logic。回報每一條有問題的邊(不是只回第一條)。
+ *
+ * 只驗詞彙,不驗形狀(形狀交給 `@rfjs/filter-builder` 的 `parseFilterGroup`),
+ * 也不驗 value 與 operator 的搭配(例如 `range` 需要兩個值)。無 `condition` 的邊
+ * 恆真,直接略過 —— 與 `resolveCondition` 一致。
+ */
+export function validateFlowConditions(doc: FlowDoc): FlowConditionResult {
+  const issues: EdgeConditionIssue[] = [];
+  for (const edge of doc.edges) {
+    if (edge.condition == null) continue;
+    const result = validateMatchQuery(edge.condition);
+    if (!result.ok) issues.push(...result.issues.map((issue) => ({ ...issue, edgeId: edge.id })));
+  }
+  return issues.length === 0 ? { ok: true } : { ok: false, issues };
+}
 
 /** 用 @rfjs/data-filter 對 context 評估 edge.condition;無 condition 視為恆真。 */
 export async function resolveCondition(edge: FlowEdge, context: Record<string, unknown>): Promise<boolean> {


### PR DESCRIPTION
## Why

A filter condition can be perfectly well-shaped and still name a `dataType` the engine has never heard of:

```js
{ field: 'x', dataType: 'wat', operator: 'eq', value: 1 }
```

It passes shape validation, saves, publishes, and only throws `[data-filter] unsupported dataType 'wat'` at evaluation time. For a consumer that validates when the author saves and evaluates much later, that is a 500 after an end user hits submit, not a 400 when the author hits save.

The operator allowlists already existed as real `as const` arrays but were never on the public surface. The dataType vocabulary had no runtime counterpart at all — `MatchQueryDataType` is a type union, erased at build.

## The drift this prevents was already live

`filter-builder`'s `operators('array', 'boolean')` offered `containsall`, which `BOOLEAN_ARRAY_OPERATORS` does not carry. **The filter editor has been blessing a condition the evaluator throws on.** Removed here, and pinned by a subset guard that fails whenever the adapter offers anything `supportedOperators()` rejects. `DATA_FILTER_OPS` is now derived from the engine's vocabulary rather than re-listed beside it.

## What is exported

**`@rfjs/data-filter`** — `validateCondition` / `validateMatchQuery` (one yes/no per leaf or per tree, with a stable code, the evaluator's own message, and a path), `supportedOperators(dataType, elementType?)`, `MATCH_QUERY_DATA_TYPES`, `MATCH_QUERY_ELEMENT_TYPES`, `LOGICAL_OPERATORS`, `OPERATORS_BY_DATA_TYPE`, and the previously-internal `match/operators` module.

There is deliberately **no second copy of any of it**. The operator tables *are* the arrays the matchers pass to `assertOperator`. The dataType/elementType/logic lists are `Object.keys` of presence maps typed against `MatchQueryMetadata` / `LogicalOperator`, so a dataType added to the union — and therefore to the `never`-exhaustive `createMatchQuery` switch, which cannot gain an arm without it — fails to compile until it is listed.

`createMatchQuery` now gates on `MATCH_QUERY_DATA_TYPES` before dispatching, which makes the exported list **load-bearing rather than descriptive**: a dataType that reaches the switch but is missing from the list stops evaluating and takes every test for it down.

**`@rfjs/flow-core`** — `validateFlowConditions(doc)` (per-edge issues keyed by `edgeId`), plus a re-export of the vocabulary from the `@rfjs/data-filter` copy flow-core itself evaluates with.

## On versioning

In-repo the dependency is `workspace:*`; the exact `0.2.1` pin in the published artifact is pnpm's publish-time substitution, and changesets' `updateInternalDependencies: patch` republishes `flow-core` whenever `data-filter` versions — so the two normally resolve to one copy.

Re-exporting removes the "normally". A consumer taking the validator from `flow-core` physically cannot get a different copy from the one `resolveCondition` runs.

## Also

An `array` leaf with an unknown `elementType` now throws a domain error rather than falling through.

## Verification

| package | Test Files | Tests |
|---|---|---|
| `@rfjs/data-filter` | 20 passed | 267 passed |
| `@rfjs/flow-core` | 5 passed | 54 passed |
| `@rfjs/filter-builder` | 18 passed | 123 passed |

`pnpm run typecheck` → 21/24. The one failure, `@rfjs/form-builder#typecheck`, is **pre-existing** — verified by checking out the parent commit `c51f746` and reproducing it there (`config-schema.ts` zod assignability, `types.ts` missing `File`/`AbortSignal` lib types).

🤖 Generated with [Claude Code](https://claude.com/claude-code)